### PR TITLE
feat: synthesize identifier for v-bind shorthand without value

### DIFF
--- a/crates/vue_oxc_toolkit/fixtures/directive/basic.vue
+++ b/crates/vue_oxc_toolkit/fixtures/directive/basic.vue
@@ -5,4 +5,5 @@
   <input v-model="text" />
   <Some v-bind:some.none="1" />
   <div :id />
+  <div :msg-id />
 </template>

--- a/crates/vue_oxc_toolkit/fixtures/directive/basic.vue
+++ b/crates/vue_oxc_toolkit/fixtures/directive/basic.vue
@@ -4,4 +4,5 @@
   <Some #default="{ a }" />
   <input v-model="text" />
   <Some v-bind:some.none="1" />
+  <div :id />
 </template>

--- a/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
@@ -27,22 +27,28 @@ mod v_for;
 mod v_if;
 mod v_slot;
 
-/// Convert a kebab-case string to camelCase, matching Vue's prop-name normalization.
+/// Convert kebab-case to `PascalCase`. e.g. `keep-alive` → `KeepAlive`
+fn kebab_to_pascal(s: &str) -> String {
+  s.split('-')
+    .map(|seg| {
+      let mut bytes = seg.as_bytes().to_vec();
+      bytes[0] = bytes[0].to_ascii_uppercase();
+      String::from_utf8(bytes).unwrap()
+    })
+    .collect()
+}
+
+/// Convert kebab-case to camelCase, matching Vue's prop-name normalization.
 /// e.g. `msg-id` → `msgId`, `foo` → `foo`
 fn kebab_to_camel(s: &str) -> String {
-  let mut result = String::with_capacity(s.len());
-  let mut capitalize_next = false;
-  for ch in s.chars() {
-    if ch == '-' {
-      capitalize_next = true;
-    } else if capitalize_next {
-      result.extend(ch.to_uppercase());
-      capitalize_next = false;
-    } else {
-      result.push(ch);
-    }
+  if !s.contains('-') {
+    return s.to_string();
   }
-  result
+  let pascal = kebab_to_pascal(s);
+  let mut chars = pascal.chars();
+  chars
+    .next()
+    .map_or_else(String::new, |first| first.to_lowercase().collect::<String>() + chars.as_str())
 }
 
 impl<'a: 'b, 'b> ParserImpl<'a> {
@@ -177,16 +183,7 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
         jsx_element.opening_element.name.take_in(self.allocator)
       } else if tag_name.contains('-') {
         // For <keep-alive />
-        let name = tag_name
-          .split('-')
-          .map(|s| {
-            // SAFETY to use ascii and not check bytes length
-            let mut bytes = s.as_bytes().to_vec();
-            bytes[0] = bytes[0].to_ascii_uppercase();
-            String::from_utf8(bytes).unwrap()
-          })
-          .collect::<String>();
-
+        let name = kebab_to_pascal(tag_name);
         ast.jsx_element_name_identifier_reference(name_span, ast.str(&name))
       } else {
         let name = ast.str(node.tag_name);

--- a/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
@@ -27,6 +27,24 @@ mod v_for;
 mod v_if;
 mod v_slot;
 
+/// Convert a kebab-case string to camelCase, matching Vue's prop-name normalization.
+/// e.g. `msg-id` → `msgId`, `foo` → `foo`
+fn kebab_to_camel(s: &str) -> String {
+  let mut result = String::with_capacity(s.len());
+  let mut capitalize_next = false;
+  for ch in s.chars() {
+    if ch == '-' {
+      capitalize_next = true;
+    } else if capitalize_next {
+      result.extend(ch.to_uppercase());
+      capitalize_next = false;
+    } else {
+      result.push(ch);
+    }
+  }
+  result
+}
+
 impl<'a: 'b, 'b> ParserImpl<'a> {
   fn parse_children(
     &mut self,
@@ -323,10 +341,13 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
           && let Some(argument) = dir.argument
           && let DirectiveArg::Static(arg_name) = argument
         {
-          // :prop without value → synthesize :prop="prop" (identifier reference)
+          // :prop without value → synthesize :prop="prop" (identifier reference).
+          // Vue normalizes dashed prop names to camelCase (:msg-id → msgId).
+          let ident_name = kebab_to_camel(arg_name);
+          let ident_str = ast.str(&ident_name);
           Some(ast.jsx_attribute_value_expression_container(
             SPAN,
-            JSXExpression::from(ast.expression_identifier(SPAN, arg_name)),
+            JSXExpression::from(ast.expression_identifier(SPAN, ident_str)),
           ))
         } else {
           None

--- a/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
@@ -320,13 +320,13 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
           // v-slot:[name]
           Some(ast.jsx_attribute_value_expression_container(SPAN, argument.into()))
         } else if dir.name == "bind"
-          && let Some(DirectiveArg::Static(arg_name)) = &dir.argument
-          && dir.expression.is_none()
+          && let Some(argument) = dir.argument
+          && let DirectiveArg::Static(arg_name) = argument
         {
           // :prop without value → synthesize :prop="prop" (identifier reference)
           Some(ast.jsx_attribute_value_expression_container(
             SPAN,
-            JSXExpression::from(ast.expression_identifier(SPAN, *arg_name)),
+            JSXExpression::from(ast.expression_identifier(SPAN, arg_name)),
           ))
         } else {
           None

--- a/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
@@ -27,28 +27,23 @@ mod v_for;
 mod v_if;
 mod v_slot;
 
-/// Convert kebab-case to `PascalCase`. e.g. `keep-alive` → `KeepAlive`
-fn kebab_to_pascal(s: &str) -> String {
-  s.split('-')
-    .map(|seg| {
-      let mut bytes = seg.as_bytes().to_vec();
-      bytes[0] = bytes[0].to_ascii_uppercase();
-      String::from_utf8(bytes).unwrap()
-    })
-    .collect()
-}
-
-/// Convert kebab-case to camelCase, matching Vue's prop-name normalization.
-/// e.g. `msg-id` → `msgId`, `foo` → `foo`
-fn kebab_to_camel(s: &str) -> String {
-  if !s.contains('-') {
-    return s.to_string();
+/// Convert kebab-case to camel-like case.
+/// `pascal: true` → `PascalCase` (e.g. `keep-alive` → `KeepAlive`)
+/// `pascal: false` → `camelCase`  (e.g. `msg-id` → `msgId`)
+fn kebab_to_case(s: &str, pascal: bool) -> String {
+  let mut result = String::with_capacity(s.len());
+  let mut capitalize_next = pascal;
+  for ch in s.chars() {
+    if ch == '-' {
+      capitalize_next = true;
+    } else if capitalize_next {
+      result.extend(ch.to_uppercase());
+      capitalize_next = false;
+    } else {
+      result.push(ch);
+    }
   }
-  let pascal = kebab_to_pascal(s);
-  let mut chars = pascal.chars();
-  chars
-    .next()
-    .map_or_else(String::new, |first| first.to_lowercase().collect::<String>() + chars.as_str())
+  result
 }
 
 impl<'a: 'b, 'b> ParserImpl<'a> {
@@ -183,7 +178,7 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
         jsx_element.opening_element.name.take_in(self.allocator)
       } else if tag_name.contains('-') {
         // For <keep-alive />
-        let name = kebab_to_pascal(tag_name);
+        let name = kebab_to_case(tag_name, true);
         ast.jsx_element_name_identifier_reference(name_span, ast.str(&name))
       } else {
         let name = ast.str(node.tag_name);
@@ -340,7 +335,7 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
         {
           // :prop without value → synthesize :prop="prop" (identifier reference).
           // Vue normalizes dashed prop names to camelCase (:msg-id → msgId).
-          let ident_name = kebab_to_camel(arg_name);
+          let ident_name = kebab_to_case(arg_name, false);
           let ident_str = ast.str(&ident_name);
           Some(ast.jsx_attribute_value_expression_container(
             SPAN,

--- a/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
@@ -319,6 +319,15 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
         {
           // v-slot:[name]
           Some(ast.jsx_attribute_value_expression_container(SPAN, argument.into()))
+        } else if dir.name == "bind"
+          && let Some(DirectiveArg::Static(arg_name)) = &dir.argument
+          && dir.expression.is_none()
+        {
+          // :prop without value → synthesize :prop="prop" (identifier reference)
+          Some(ast.jsx_attribute_value_expression_container(
+            SPAN,
+            JSXExpression::from(ast.expression_identifier(SPAN, *arg_name)),
+          ))
         } else {
           None
         };

--- a/crates/vue_oxc_toolkit/src/parser/snapshots/ast/directive_basic_vue.snap
+++ b/crates/vue_oxc_toolkit/src/parser/snapshots/ast/directive_basic_vue.snap
@@ -6,7 +6,7 @@ expression: result
 Program {
     span: Span {
         start: 0,
-        end: 173,
+        end: 191,
     },
     node_id: Cell {
         value: NodeId(0),
@@ -14,7 +14,7 @@ Program {
     scope_id: Cell {
         value: None,
     },
-    source_text: "<template>\n  <div :class=\"'w-100'\" />\n  <div :[some]=\"2\" />\n  <Some #default=\"{ a }\" />\n  <input v-model=\"text\" />\n  <Some v-bind:some.none=\"1\" />\n  <div :id />\n</template>\n",
+    source_text: "<template>\n  <div :class=\"'w-100'\" />\n  <div :[some]=\"2\" />\n  <Some #default=\"{ a }\" />\n  <input v-model=\"text\" />\n  <Some v-bind:some.none=\"1\" />\n  <div :id />\n  <div :msg-id />\n</template>\n",
     comments: Vec(
         [],
     ),
@@ -107,7 +107,7 @@ Program {
                                                                     JSXElement {
                                                                         span: Span {
                                                                             start: 0,
-                                                                            end: 172,
+                                                                            end: 190,
                                                                         },
                                                                         node_id: Cell {
                                                                             value: NodeId(0),
@@ -1301,7 +1301,155 @@ Program {
                                                                                     JSXText {
                                                                                         span: Span {
                                                                                             start: 160,
-                                                                                            end: 161,
+                                                                                            end: 163,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        value: "\n  ",
+                                                                                        raw: Some(
+                                                                                            "\n  ",
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Element(
+                                                                                    JSXElement {
+                                                                                        span: Span {
+                                                                                            start: 163,
+                                                                                            end: 178,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        opening_element: JSXOpeningElement {
+                                                                                            span: Span {
+                                                                                                start: 163,
+                                                                                                end: 178,
+                                                                                            },
+                                                                                            node_id: Cell {
+                                                                                                value: NodeId(0),
+                                                                                            },
+                                                                                            name: Identifier(
+                                                                                                JSXIdentifier {
+                                                                                                    span: Span {
+                                                                                                        start: 164,
+                                                                                                        end: 167,
+                                                                                                    },
+                                                                                                    node_id: Cell {
+                                                                                                        value: NodeId(0),
+                                                                                                    },
+                                                                                                    name: "div",
+                                                                                                },
+                                                                                            ),
+                                                                                            type_arguments: None,
+                                                                                            attributes: Vec(
+                                                                                                [
+                                                                                                    Attribute(
+                                                                                                        JSXAttribute {
+                                                                                                            span: Span {
+                                                                                                                start: 168,
+                                                                                                                end: 175,
+                                                                                                            },
+                                                                                                            node_id: Cell {
+                                                                                                                value: NodeId(0),
+                                                                                                            },
+                                                                                                            name: NamespacedName(
+                                                                                                                JSXNamespacedName {
+                                                                                                                    span: Span {
+                                                                                                                        start: 168,
+                                                                                                                        end: 175,
+                                                                                                                    },
+                                                                                                                    node_id: Cell {
+                                                                                                                        value: NodeId(0),
+                                                                                                                    },
+                                                                                                                    namespace: JSXIdentifier {
+                                                                                                                        span: Span {
+                                                                                                                            start: 168,
+                                                                                                                            end: 169,
+                                                                                                                        },
+                                                                                                                        node_id: Cell {
+                                                                                                                            value: NodeId(0),
+                                                                                                                        },
+                                                                                                                        name: "v-bind",
+                                                                                                                    },
+                                                                                                                    name: JSXIdentifier {
+                                                                                                                        span: Span {
+                                                                                                                            start: 169,
+                                                                                                                            end: 175,
+                                                                                                                        },
+                                                                                                                        node_id: Cell {
+                                                                                                                            value: NodeId(0),
+                                                                                                                        },
+                                                                                                                        name: "msg-id",
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            value: Some(
+                                                                                                                ExpressionContainer(
+                                                                                                                    JSXExpressionContainer {
+                                                                                                                        span: Span {
+                                                                                                                            start: 0,
+                                                                                                                            end: 0,
+                                                                                                                        },
+                                                                                                                        node_id: Cell {
+                                                                                                                            value: NodeId(0),
+                                                                                                                        },
+                                                                                                                        expression: Identifier(
+                                                                                                                            IdentifierReference {
+                                                                                                                                span: Span {
+                                                                                                                                    start: 0,
+                                                                                                                                    end: 0,
+                                                                                                                                },
+                                                                                                                                node_id: Cell {
+                                                                                                                                    value: NodeId(0),
+                                                                                                                                },
+                                                                                                                                reference_id: Cell {
+                                                                                                                                    value: None,
+                                                                                                                                },
+                                                                                                                                name: "msgId",
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                            ),
+                                                                                        },
+                                                                                        children: Vec(
+                                                                                            [],
+                                                                                        ),
+                                                                                        closing_element: Some(
+                                                                                            JSXClosingElement {
+                                                                                                span: Span {
+                                                                                                    start: 0,
+                                                                                                    end: 0,
+                                                                                                },
+                                                                                                node_id: Cell {
+                                                                                                    value: NodeId(0),
+                                                                                                },
+                                                                                                name: Identifier(
+                                                                                                    JSXIdentifier {
+                                                                                                        span: Span {
+                                                                                                            start: 0,
+                                                                                                            end: 0,
+                                                                                                        },
+                                                                                                        node_id: Cell {
+                                                                                                            value: NodeId(0),
+                                                                                                        },
+                                                                                                        name: "",
+                                                                                                    },
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Text(
+                                                                                    JSXText {
+                                                                                        span: Span {
+                                                                                            start: 178,
+                                                                                            end: 179,
                                                                                         },
                                                                                         node_id: Cell {
                                                                                             value: NodeId(0),
@@ -1317,8 +1465,8 @@ Program {
                                                                         closing_element: Some(
                                                                             JSXClosingElement {
                                                                                 span: Span {
-                                                                                    start: 161,
-                                                                                    end: 172,
+                                                                                    start: 179,
+                                                                                    end: 190,
                                                                                 },
                                                                                 node_id: Cell {
                                                                                     value: NodeId(0),
@@ -1326,8 +1474,8 @@ Program {
                                                                                 name: Identifier(
                                                                                     JSXIdentifier {
                                                                                         span: Span {
-                                                                                            start: 163,
-                                                                                            end: 171,
+                                                                                            start: 181,
+                                                                                            end: 189,
                                                                                         },
                                                                                         node_id: Cell {
                                                                                             value: NodeId(0),
@@ -1342,8 +1490,8 @@ Program {
                                                                 Text(
                                                                     JSXText {
                                                                         span: Span {
-                                                                            start: 172,
-                                                                            end: 173,
+                                                                            start: 190,
+                                                                            end: 191,
                                                                         },
                                                                         node_id: Cell {
                                                                             value: NodeId(0),
@@ -1402,18 +1550,19 @@ async () => {
   <input v-model:={text}></>
   <Some v-bind:some.none={1}></>
   <div v-bind:id={id}></>
+  <div v-bind:msg-id={msgId}></>
 </template>
 </>;
 };
 
 
 ===============  Spans  ===============
-Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..e.none=\"1\" />\n  <div :id />\n</template>\n"; 
-Span: (0, 173); 
+Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..iv :id />\n  <div :msg-id />\n</template>\n"; 
+Span: (0, 191); 
 Type: Program; 
 
-Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..me.none=\"1\" />\n  <div :id />\n</template>"; 
-Span: (0, 172); 
+Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..div :id />\n  <div :msg-id />\n</template>"; 
+Span: (0, 190); 
 Type: JSXElement; 
 
 Slice: "<template>"; 
@@ -1680,18 +1829,50 @@ Slice: "id";
 Span: (155, 157); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (160, 161); 
+Slice: "\n  "; 
+Span: (160, 163); 
 Type: JSXText; 
 
-Slice: "</template>"; 
-Span: (161, 172); 
-Type: JSXClosingElement; 
+Slice: "<div :msg-id />"; 
+Span: (163, 178); 
+Type: JSXElement; 
 
-Slice: "template"; 
-Span: (163, 171); 
+Slice: "<div :msg-id />"; 
+Span: (163, 178); 
+Type: JSXOpeningElement; 
+
+Slice: "div"; 
+Span: (164, 167); 
+Type: JSXIdentifier; 
+
+Slice: ":msg-id"; 
+Span: (168, 175); 
+Type: JSXAttribute; 
+
+Slice: ":msg-id"; 
+Span: (168, 175); 
+Type: JSXNamespacedName; 
+
+Slice: ":"; 
+Span: (168, 169); 
+Type: JSXIdentifier; 
+
+Slice: "msg-id"; 
+Span: (169, 175); 
 Type: JSXIdentifier; 
 
 Slice: "\n"; 
-Span: (172, 173); 
+Span: (178, 179); 
+Type: JSXText; 
+
+Slice: "</template>"; 
+Span: (179, 190); 
+Type: JSXClosingElement; 
+
+Slice: "template"; 
+Span: (181, 189); 
+Type: JSXIdentifier; 
+
+Slice: "\n"; 
+Span: (190, 191); 
 Type: JSXText;

--- a/crates/vue_oxc_toolkit/src/parser/snapshots/ast/directive_basic_vue.snap
+++ b/crates/vue_oxc_toolkit/src/parser/snapshots/ast/directive_basic_vue.snap
@@ -6,7 +6,7 @@ expression: result
 Program {
     span: Span {
         start: 0,
-        end: 159,
+        end: 173,
     },
     node_id: Cell {
         value: NodeId(0),
@@ -14,7 +14,7 @@ Program {
     scope_id: Cell {
         value: None,
     },
-    source_text: "<template>\n  <div :class=\"'w-100'\" />\n  <div :[some]=\"2\" />\n  <Some #default=\"{ a }\" />\n  <input v-model=\"text\" />\n  <Some v-bind:some.none=\"1\" />\n</template>\n",
+    source_text: "<template>\n  <div :class=\"'w-100'\" />\n  <div :[some]=\"2\" />\n  <Some #default=\"{ a }\" />\n  <input v-model=\"text\" />\n  <Some v-bind:some.none=\"1\" />\n  <div :id />\n</template>\n",
     comments: Vec(
         [],
     ),
@@ -107,7 +107,7 @@ Program {
                                                                     JSXElement {
                                                                         span: Span {
                                                                             start: 0,
-                                                                            end: 158,
+                                                                            end: 172,
                                                                         },
                                                                         node_id: Cell {
                                                                             value: NodeId(0),
@@ -1153,7 +1153,155 @@ Program {
                                                                                     JSXText {
                                                                                         span: Span {
                                                                                             start: 146,
-                                                                                            end: 147,
+                                                                                            end: 149,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        value: "\n  ",
+                                                                                        raw: Some(
+                                                                                            "\n  ",
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Element(
+                                                                                    JSXElement {
+                                                                                        span: Span {
+                                                                                            start: 149,
+                                                                                            end: 160,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        opening_element: JSXOpeningElement {
+                                                                                            span: Span {
+                                                                                                start: 149,
+                                                                                                end: 160,
+                                                                                            },
+                                                                                            node_id: Cell {
+                                                                                                value: NodeId(0),
+                                                                                            },
+                                                                                            name: Identifier(
+                                                                                                JSXIdentifier {
+                                                                                                    span: Span {
+                                                                                                        start: 150,
+                                                                                                        end: 153,
+                                                                                                    },
+                                                                                                    node_id: Cell {
+                                                                                                        value: NodeId(0),
+                                                                                                    },
+                                                                                                    name: "div",
+                                                                                                },
+                                                                                            ),
+                                                                                            type_arguments: None,
+                                                                                            attributes: Vec(
+                                                                                                [
+                                                                                                    Attribute(
+                                                                                                        JSXAttribute {
+                                                                                                            span: Span {
+                                                                                                                start: 154,
+                                                                                                                end: 157,
+                                                                                                            },
+                                                                                                            node_id: Cell {
+                                                                                                                value: NodeId(0),
+                                                                                                            },
+                                                                                                            name: NamespacedName(
+                                                                                                                JSXNamespacedName {
+                                                                                                                    span: Span {
+                                                                                                                        start: 154,
+                                                                                                                        end: 157,
+                                                                                                                    },
+                                                                                                                    node_id: Cell {
+                                                                                                                        value: NodeId(0),
+                                                                                                                    },
+                                                                                                                    namespace: JSXIdentifier {
+                                                                                                                        span: Span {
+                                                                                                                            start: 154,
+                                                                                                                            end: 155,
+                                                                                                                        },
+                                                                                                                        node_id: Cell {
+                                                                                                                            value: NodeId(0),
+                                                                                                                        },
+                                                                                                                        name: "v-bind",
+                                                                                                                    },
+                                                                                                                    name: JSXIdentifier {
+                                                                                                                        span: Span {
+                                                                                                                            start: 155,
+                                                                                                                            end: 157,
+                                                                                                                        },
+                                                                                                                        node_id: Cell {
+                                                                                                                            value: NodeId(0),
+                                                                                                                        },
+                                                                                                                        name: "id",
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            value: Some(
+                                                                                                                ExpressionContainer(
+                                                                                                                    JSXExpressionContainer {
+                                                                                                                        span: Span {
+                                                                                                                            start: 0,
+                                                                                                                            end: 0,
+                                                                                                                        },
+                                                                                                                        node_id: Cell {
+                                                                                                                            value: NodeId(0),
+                                                                                                                        },
+                                                                                                                        expression: Identifier(
+                                                                                                                            IdentifierReference {
+                                                                                                                                span: Span {
+                                                                                                                                    start: 0,
+                                                                                                                                    end: 0,
+                                                                                                                                },
+                                                                                                                                node_id: Cell {
+                                                                                                                                    value: NodeId(0),
+                                                                                                                                },
+                                                                                                                                reference_id: Cell {
+                                                                                                                                    value: None,
+                                                                                                                                },
+                                                                                                                                name: "id",
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                            ),
+                                                                                        },
+                                                                                        children: Vec(
+                                                                                            [],
+                                                                                        ),
+                                                                                        closing_element: Some(
+                                                                                            JSXClosingElement {
+                                                                                                span: Span {
+                                                                                                    start: 0,
+                                                                                                    end: 0,
+                                                                                                },
+                                                                                                node_id: Cell {
+                                                                                                    value: NodeId(0),
+                                                                                                },
+                                                                                                name: Identifier(
+                                                                                                    JSXIdentifier {
+                                                                                                        span: Span {
+                                                                                                            start: 0,
+                                                                                                            end: 0,
+                                                                                                        },
+                                                                                                        node_id: Cell {
+                                                                                                            value: NodeId(0),
+                                                                                                        },
+                                                                                                        name: "",
+                                                                                                    },
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Text(
+                                                                                    JSXText {
+                                                                                        span: Span {
+                                                                                            start: 160,
+                                                                                            end: 161,
                                                                                         },
                                                                                         node_id: Cell {
                                                                                             value: NodeId(0),
@@ -1169,8 +1317,8 @@ Program {
                                                                         closing_element: Some(
                                                                             JSXClosingElement {
                                                                                 span: Span {
-                                                                                    start: 147,
-                                                                                    end: 158,
+                                                                                    start: 161,
+                                                                                    end: 172,
                                                                                 },
                                                                                 node_id: Cell {
                                                                                     value: NodeId(0),
@@ -1178,8 +1326,8 @@ Program {
                                                                                 name: Identifier(
                                                                                     JSXIdentifier {
                                                                                         span: Span {
-                                                                                            start: 149,
-                                                                                            end: 157,
+                                                                                            start: 163,
+                                                                                            end: 171,
                                                                                         },
                                                                                         node_id: Cell {
                                                                                             value: NodeId(0),
@@ -1194,8 +1342,8 @@ Program {
                                                                 Text(
                                                                     JSXText {
                                                                         span: Span {
-                                                                            start: 158,
-                                                                            end: 159,
+                                                                            start: 172,
+                                                                            end: 173,
                                                                         },
                                                                         node_id: Cell {
                                                                             value: NodeId(0),
@@ -1253,18 +1401,19 @@ async () => {
   <Some v-slot:default={}>{{ default: ({ a }) => <></> }}</>
   <input v-model:={text}></>
   <Some v-bind:some.none={1}></>
+  <div v-bind:id={id}></>
 </template>
 </>;
 };
 
 
 ===============  Spans  ===============
-Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..ome v-bind:some.none=\"1\" />\n</template>\n"; 
-Span: (0, 159); 
+Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..e.none=\"1\" />\n  <div :id />\n</template>\n"; 
+Span: (0, 173); 
 Type: Program; 
 
-Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..Some v-bind:some.none=\"1\" />\n</template>"; 
-Span: (0, 158); 
+Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..me.none=\"1\" />\n  <div :id />\n</template>"; 
+Span: (0, 172); 
 Type: JSXElement; 
 
 Slice: "<template>"; 
@@ -1499,18 +1648,50 @@ Slice: "1";
 Span: (141, 142); 
 Type: NumericLiteral; 
 
-Slice: "\n"; 
-Span: (146, 147); 
+Slice: "\n  "; 
+Span: (146, 149); 
 Type: JSXText; 
 
-Slice: "</template>"; 
-Span: (147, 158); 
-Type: JSXClosingElement; 
+Slice: "<div :id />"; 
+Span: (149, 160); 
+Type: JSXElement; 
 
-Slice: "template"; 
-Span: (149, 157); 
+Slice: "<div :id />"; 
+Span: (149, 160); 
+Type: JSXOpeningElement; 
+
+Slice: "div"; 
+Span: (150, 153); 
+Type: JSXIdentifier; 
+
+Slice: ":id"; 
+Span: (154, 157); 
+Type: JSXAttribute; 
+
+Slice: ":id"; 
+Span: (154, 157); 
+Type: JSXNamespacedName; 
+
+Slice: ":"; 
+Span: (154, 155); 
+Type: JSXIdentifier; 
+
+Slice: "id"; 
+Span: (155, 157); 
 Type: JSXIdentifier; 
 
 Slice: "\n"; 
-Span: (158, 159); 
+Span: (160, 161); 
+Type: JSXText; 
+
+Slice: "</template>"; 
+Span: (161, 172); 
+Type: JSXClosingElement; 
+
+Slice: "template"; 
+Span: (163, 171); 
+Type: JSXIdentifier; 
+
+Slice: "\n"; 
+Span: (172, 173); 
 Type: JSXText;


### PR DESCRIPTION
## Summary

- `<div :id />` (v-bind shorthand with no value) is now expanded to `:id="id"` in the AST — an `IdentifierReference` with the prop name, consistent with Vue 3 shorthand semantics.
- Dashed prop names are normalized to camelCase before synthesis, matching Vue's own normalization: `:msg-id` → `msgId` (not `msg-id`, which is an invalid identifier).
- A `kebab_to_camel` helper drives the conversion.
- Fixture extended with `:msg-id` to cover and document the dashed-name case.

## Test plan

- [x] `just test` passes (all 12 tests green)
- [x] `just fmt` and `just lint` pass (pre-existing `doctest` warning unrelated to this change)
- [x] Snapshot updated and accepted — both `:id` → `id` and `:msg-id` → `msgId` visible in AST dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)