### PR TITLE
feat: use JSX spread attribute for v-bind without argument

### DIFF
--- a/crates/vue_oxc_toolkit/fixtures/directive/basic.vue
+++ b/crates/vue_oxc_toolkit/fixtures/directive/basic.vue
@@ -6,4 +6,6 @@
   <Some v-bind:some.none="1" />
   <div :id />
   <div :msg-id />
+  <div v-bind="{ id: 'app', class: 'w-100' }" />
+  <div :="{ id: 'app' }" />
 </template>

--- a/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
@@ -295,6 +295,22 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
           error::v_if_else_without_expression(&mut self.errors, dir.location.span());
         }
 
+        // v-bind="expr" or :="expr" without an argument → JSX spread attribute {...expr}.
+        // Vue treats argument-less v-bind as an object spread onto the element, which maps
+        // directly to JSX spread: <div v-bind="obj" /> ↔ <div {...obj} />.
+        // https://play.vuejs.org/#eNqVkbtOwzAUhl/FOkuWNC2CKQqVAFWiDICA0UuID8HFsS1f0khR3h3bVS9DVamb/V/s7+iM8KB10XuEEiqHnRa1wyWVhFSM96SfffPJ7imMhLOSZLXWWU4aUVsbbtvZzWKRkYnCkjyvSTUPlWO3vLJWzU/+hxycbZT84W2xsUoGvDG+TKFRneYCzZt2XElLoSTJiV4thNq+JM0Zj/leb36x+Tujb+wQNQrvBi2aHikcPFebFt3OXn2+4hDOB7NTzIuQvmB+oFXCR8Zd7NFLFrBPcol23WllHJftl10NDqXdDxVBY3JKeQphR08XRj/i3hZ3qUflBNM/rC6XVg==
+        if dir.name == "bind"
+          && dir.argument.is_none()
+          && let Some(expr_node) = &dir.expression
+          && let Some(argument) = self.parse_pure_expression(Span::new(
+            (expr_node.location.start.offset + 1) as u32,
+            dir_end - 1,
+          ))
+        {
+          return ast
+            .jsx_attribute_item_spread_attribute(Span::new(dir_start, dir_end), argument);
+        }
+
         let value = if let Some(expr) = &dir.expression {
           // +1 to skip the opening quote
           let expr_start = expr.location.start.offset + 1;
@@ -333,8 +349,9 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
           && let Some(argument) = dir.argument
           && let DirectiveArg::Static(arg_name) = argument
         {
-          // :prop without value → synthesize :prop="prop" (identifier reference).
-          // Vue normalizes dashed prop names to camelCase (:msg-id → msgId).
+          // :prop without value -> synthesize :prop="prop" (identifier reference).
+          // Vue normalizes dashed prop names to camelCase (:msg-id -> msgId).
+          // https://play.vuejs.org/#eNp9kUFLxDAQhf/KmEsV1pZFT6UuqCy4HlRU8JJLaadt1jQJSboWSv+7k5Zde5C9ZeZ98/ImGdi9MfGhQ5ayzBVWGA8OfWc2XInWaOthAIsVjFBZ3UJEaMQVV4VWzkPr6l0Jd4G4jJ5QSg1f2sryIrriKktmQ7KiwmNrZO6RKoCsWUNKw9ei3MBiLkuaNQFZsqDZinlH11WijvdOK0o6BA/OCt0aIdG+Gi8oDmcpTErQcvL8eZ563na4OvaLBovvf/p714ceZ28WHdoDcnbSfG5r9LO8/XjBns4nsdVlJ4k+I76j07ILGWfsoVMlxV5wU9rd9N5C1Z9u23tU7rhUCBrIceI5oz94PLP6X9yb+Haa42pk4y+ZtaHr
           let ident_name = kebab_to_case(arg_name, false);
           let ident_str = ast.str(&ident_name);
           Some(ast.jsx_attribute_value_expression_container(

--- a/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
@@ -295,10 +295,8 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
           error::v_if_else_without_expression(&mut self.errors, dir.location.span());
         }
 
-        // v-bind="expr" or :="expr" without an argument → JSX spread attribute {...expr}.
-        // Vue treats argument-less v-bind as an object spread onto the element, which maps
-        // directly to JSX spread: <div v-bind="obj" /> ↔ <div {...obj} />.
-        // https://play.vuejs.org/#eNqVkbtOwzAUhl/FOkuWNC2CKQqVAFWiDICA0UuID8HFsS1f0khR3h3bVS9DVamb/V/s7+iM8KB10XuEEiqHnRa1wyWVhFSM96SfffPJ7imMhLOSZLXWWU4aUVsbbtvZzWKRkYnCkjyvSTUPlWO3vLJWzU/+hxycbZT84W2xsUoGvDG+TKFRneYCzZt2XElLoSTJiV4thNq+JM0Zj/leb36x+Tujb+wQNQrvBi2aHikcPFebFt3OXn2+4hDOB7NTzIuQvmB+oFXCR8Zd7NFLFrBPcol23WllHJftl10NDqXdDxVBY3JKeQphR08XRj/i3hZ3qUflBNM/rC6XVg==
+        // This branch won't return `a=b` attribute but a `...x` struct
+        // So we picked this logic into a separate block instead of a elseif branch in the under if-else chain
         if dir.name == "bind"
           && dir.argument.is_none()
           && let Some(expr_node) = &dir.expression
@@ -307,6 +305,10 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
             dir_end - 1,
           ))
         {
+          // v-bind="expr" or :="expr" without an argument → JSX spread attribute {...expr}.
+          // Vue treats argument-less v-bind as an object spread onto the element, which maps
+          // directly to JSX spread: <div v-bind="obj" /> ↔ <div {...obj} />.
+          // https://play.vuejs.org/#eNqVkbtOwzAUhl/FOkuWNC2CKQqVAFWiDICA0UuID8HFsS1f0khR3h3bVS9DVamb/V/s7+iM8KB10XuEEiqHnRa1wyWVhFSM96SfffPJ7imMhLOSZLXWWU4aUVsbbtvZzWKRkYnCkjyvSTUPlWO3vLJWzU/+hxycbZT84W2xsUoGvDG+TKFRneYCzZt2XElLoSTJiV4thNq+JM0Zj/leb36x+Tujb+wQNQrvBi2aHikcPFebFt3OXn2+4hDOB7NTzIuQvmB+oFXCR8Zd7NFLFrBPcol23WllHJftl10NDqXdDxVBY3JKeQphR08XRj/i3hZ3qUflBNM/rC6XVg==
           return ast.jsx_attribute_item_spread_attribute(Span::new(dir_start, dir_end), argument);
         }
 

--- a/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
@@ -307,8 +307,7 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
             dir_end - 1,
           ))
         {
-          return ast
-            .jsx_attribute_item_spread_attribute(Span::new(dir_start, dir_end), argument);
+          return ast.jsx_attribute_item_spread_attribute(Span::new(dir_start, dir_end), argument);
         }
 
         let value = if let Some(expr) = &dir.expression {

--- a/crates/vue_oxc_toolkit/src/parser/snapshots/ast/directive_basic_vue.snap
+++ b/crates/vue_oxc_toolkit/src/parser/snapshots/ast/directive_basic_vue.snap
@@ -6,7 +6,7 @@ expression: result
 Program {
     span: Span {
         start: 0,
-        end: 191,
+        end: 268,
     },
     node_id: Cell {
         value: NodeId(0),
@@ -14,7 +14,7 @@ Program {
     scope_id: Cell {
         value: None,
     },
-    source_text: "<template>\n  <div :class=\"'w-100'\" />\n  <div :[some]=\"2\" />\n  <Some #default=\"{ a }\" />\n  <input v-model=\"text\" />\n  <Some v-bind:some.none=\"1\" />\n  <div :id />\n  <div :msg-id />\n</template>\n",
+    source_text: "<template>\n  <div :class=\"'w-100'\" />\n  <div :[some]=\"2\" />\n  <Some #default=\"{ a }\" />\n  <input v-model=\"text\" />\n  <Some v-bind:some.none=\"1\" />\n  <div :id />\n  <div :msg-id />\n  <div v-bind=\"{ id: 'app', class: 'w-100' }\" />\n  <div :=\"{ id: 'app' }\" />\n</template>\n",
     comments: Vec(
         [],
     ),
@@ -107,7 +107,7 @@ Program {
                                                                     JSXElement {
                                                                         span: Span {
                                                                             start: 0,
-                                                                            end: 190,
+                                                                            end: 267,
                                                                         },
                                                                         node_id: Cell {
                                                                             value: NodeId(0),
@@ -1449,7 +1449,344 @@ Program {
                                                                                     JSXText {
                                                                                         span: Span {
                                                                                             start: 178,
-                                                                                            end: 179,
+                                                                                            end: 181,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        value: "\n  ",
+                                                                                        raw: Some(
+                                                                                            "\n  ",
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Element(
+                                                                                    JSXElement {
+                                                                                        span: Span {
+                                                                                            start: 181,
+                                                                                            end: 227,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        opening_element: JSXOpeningElement {
+                                                                                            span: Span {
+                                                                                                start: 181,
+                                                                                                end: 227,
+                                                                                            },
+                                                                                            node_id: Cell {
+                                                                                                value: NodeId(0),
+                                                                                            },
+                                                                                            name: Identifier(
+                                                                                                JSXIdentifier {
+                                                                                                    span: Span {
+                                                                                                        start: 182,
+                                                                                                        end: 185,
+                                                                                                    },
+                                                                                                    node_id: Cell {
+                                                                                                        value: NodeId(0),
+                                                                                                    },
+                                                                                                    name: "div",
+                                                                                                },
+                                                                                            ),
+                                                                                            type_arguments: None,
+                                                                                            attributes: Vec(
+                                                                                                [
+                                                                                                    SpreadAttribute(
+                                                                                                        JSXSpreadAttribute {
+                                                                                                            span: Span {
+                                                                                                                start: 186,
+                                                                                                                end: 224,
+                                                                                                            },
+                                                                                                            node_id: Cell {
+                                                                                                                value: NodeId(0),
+                                                                                                            },
+                                                                                                            argument: ObjectExpression(
+                                                                                                                ObjectExpression {
+                                                                                                                    span: Span {
+                                                                                                                        start: 194,
+                                                                                                                        end: 223,
+                                                                                                                    },
+                                                                                                                    node_id: Cell {
+                                                                                                                        value: NodeId(0),
+                                                                                                                    },
+                                                                                                                    properties: Vec(
+                                                                                                                        [
+                                                                                                                            ObjectProperty(
+                                                                                                                                ObjectProperty {
+                                                                                                                                    span: Span {
+                                                                                                                                        start: 196,
+                                                                                                                                        end: 205,
+                                                                                                                                    },
+                                                                                                                                    node_id: Cell {
+                                                                                                                                        value: NodeId(0),
+                                                                                                                                    },
+                                                                                                                                    kind: Init,
+                                                                                                                                    method: false,
+                                                                                                                                    shorthand: false,
+                                                                                                                                    computed: false,
+                                                                                                                                    key: StaticIdentifier(
+                                                                                                                                        IdentifierName {
+                                                                                                                                            span: Span {
+                                                                                                                                                start: 196,
+                                                                                                                                                end: 198,
+                                                                                                                                            },
+                                                                                                                                            node_id: Cell {
+                                                                                                                                                value: NodeId(0),
+                                                                                                                                            },
+                                                                                                                                            name: "id",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                    value: StringLiteral(
+                                                                                                                                        StringLiteral {
+                                                                                                                                            span: Span {
+                                                                                                                                                start: 200,
+                                                                                                                                                end: 205,
+                                                                                                                                            },
+                                                                                                                                            node_id: Cell {
+                                                                                                                                                value: NodeId(0),
+                                                                                                                                            },
+                                                                                                                                            lone_surrogates: false,
+                                                                                                                                            value: "app",
+                                                                                                                                            raw: Some(
+                                                                                                                                                "'app'",
+                                                                                                                                            ),
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                            ObjectProperty(
+                                                                                                                                ObjectProperty {
+                                                                                                                                    span: Span {
+                                                                                                                                        start: 207,
+                                                                                                                                        end: 221,
+                                                                                                                                    },
+                                                                                                                                    node_id: Cell {
+                                                                                                                                        value: NodeId(0),
+                                                                                                                                    },
+                                                                                                                                    kind: Init,
+                                                                                                                                    method: false,
+                                                                                                                                    shorthand: false,
+                                                                                                                                    computed: false,
+                                                                                                                                    key: StaticIdentifier(
+                                                                                                                                        IdentifierName {
+                                                                                                                                            span: Span {
+                                                                                                                                                start: 207,
+                                                                                                                                                end: 212,
+                                                                                                                                            },
+                                                                                                                                            node_id: Cell {
+                                                                                                                                                value: NodeId(0),
+                                                                                                                                            },
+                                                                                                                                            name: "class",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                    value: StringLiteral(
+                                                                                                                                        StringLiteral {
+                                                                                                                                            span: Span {
+                                                                                                                                                start: 214,
+                                                                                                                                                end: 221,
+                                                                                                                                            },
+                                                                                                                                            node_id: Cell {
+                                                                                                                                                value: NodeId(0),
+                                                                                                                                            },
+                                                                                                                                            lone_surrogates: false,
+                                                                                                                                            value: "w-100",
+                                                                                                                                            raw: Some(
+                                                                                                                                                "'w-100'",
+                                                                                                                                            ),
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                        ],
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                            ),
+                                                                                        },
+                                                                                        children: Vec(
+                                                                                            [],
+                                                                                        ),
+                                                                                        closing_element: Some(
+                                                                                            JSXClosingElement {
+                                                                                                span: Span {
+                                                                                                    start: 0,
+                                                                                                    end: 0,
+                                                                                                },
+                                                                                                node_id: Cell {
+                                                                                                    value: NodeId(0),
+                                                                                                },
+                                                                                                name: Identifier(
+                                                                                                    JSXIdentifier {
+                                                                                                        span: Span {
+                                                                                                            start: 0,
+                                                                                                            end: 0,
+                                                                                                        },
+                                                                                                        node_id: Cell {
+                                                                                                            value: NodeId(0),
+                                                                                                        },
+                                                                                                        name: "",
+                                                                                                    },
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Text(
+                                                                                    JSXText {
+                                                                                        span: Span {
+                                                                                            start: 227,
+                                                                                            end: 230,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        value: "\n  ",
+                                                                                        raw: Some(
+                                                                                            "\n  ",
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Element(
+                                                                                    JSXElement {
+                                                                                        span: Span {
+                                                                                            start: 230,
+                                                                                            end: 255,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        opening_element: JSXOpeningElement {
+                                                                                            span: Span {
+                                                                                                start: 230,
+                                                                                                end: 255,
+                                                                                            },
+                                                                                            node_id: Cell {
+                                                                                                value: NodeId(0),
+                                                                                            },
+                                                                                            name: Identifier(
+                                                                                                JSXIdentifier {
+                                                                                                    span: Span {
+                                                                                                        start: 231,
+                                                                                                        end: 234,
+                                                                                                    },
+                                                                                                    node_id: Cell {
+                                                                                                        value: NodeId(0),
+                                                                                                    },
+                                                                                                    name: "div",
+                                                                                                },
+                                                                                            ),
+                                                                                            type_arguments: None,
+                                                                                            attributes: Vec(
+                                                                                                [
+                                                                                                    SpreadAttribute(
+                                                                                                        JSXSpreadAttribute {
+                                                                                                            span: Span {
+                                                                                                                start: 235,
+                                                                                                                end: 252,
+                                                                                                            },
+                                                                                                            node_id: Cell {
+                                                                                                                value: NodeId(0),
+                                                                                                            },
+                                                                                                            argument: ObjectExpression(
+                                                                                                                ObjectExpression {
+                                                                                                                    span: Span {
+                                                                                                                        start: 238,
+                                                                                                                        end: 251,
+                                                                                                                    },
+                                                                                                                    node_id: Cell {
+                                                                                                                        value: NodeId(0),
+                                                                                                                    },
+                                                                                                                    properties: Vec(
+                                                                                                                        [
+                                                                                                                            ObjectProperty(
+                                                                                                                                ObjectProperty {
+                                                                                                                                    span: Span {
+                                                                                                                                        start: 240,
+                                                                                                                                        end: 249,
+                                                                                                                                    },
+                                                                                                                                    node_id: Cell {
+                                                                                                                                        value: NodeId(0),
+                                                                                                                                    },
+                                                                                                                                    kind: Init,
+                                                                                                                                    method: false,
+                                                                                                                                    shorthand: false,
+                                                                                                                                    computed: false,
+                                                                                                                                    key: StaticIdentifier(
+                                                                                                                                        IdentifierName {
+                                                                                                                                            span: Span {
+                                                                                                                                                start: 240,
+                                                                                                                                                end: 242,
+                                                                                                                                            },
+                                                                                                                                            node_id: Cell {
+                                                                                                                                                value: NodeId(0),
+                                                                                                                                            },
+                                                                                                                                            name: "id",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                    value: StringLiteral(
+                                                                                                                                        StringLiteral {
+                                                                                                                                            span: Span {
+                                                                                                                                                start: 244,
+                                                                                                                                                end: 249,
+                                                                                                                                            },
+                                                                                                                                            node_id: Cell {
+                                                                                                                                                value: NodeId(0),
+                                                                                                                                            },
+                                                                                                                                            lone_surrogates: false,
+                                                                                                                                            value: "app",
+                                                                                                                                            raw: Some(
+                                                                                                                                                "'app'",
+                                                                                                                                            ),
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                        ],
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                            ),
+                                                                                        },
+                                                                                        children: Vec(
+                                                                                            [],
+                                                                                        ),
+                                                                                        closing_element: Some(
+                                                                                            JSXClosingElement {
+                                                                                                span: Span {
+                                                                                                    start: 0,
+                                                                                                    end: 0,
+                                                                                                },
+                                                                                                node_id: Cell {
+                                                                                                    value: NodeId(0),
+                                                                                                },
+                                                                                                name: Identifier(
+                                                                                                    JSXIdentifier {
+                                                                                                        span: Span {
+                                                                                                            start: 0,
+                                                                                                            end: 0,
+                                                                                                        },
+                                                                                                        node_id: Cell {
+                                                                                                            value: NodeId(0),
+                                                                                                        },
+                                                                                                        name: "",
+                                                                                                    },
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Text(
+                                                                                    JSXText {
+                                                                                        span: Span {
+                                                                                            start: 255,
+                                                                                            end: 256,
                                                                                         },
                                                                                         node_id: Cell {
                                                                                             value: NodeId(0),
@@ -1465,8 +1802,8 @@ Program {
                                                                         closing_element: Some(
                                                                             JSXClosingElement {
                                                                                 span: Span {
-                                                                                    start: 179,
-                                                                                    end: 190,
+                                                                                    start: 256,
+                                                                                    end: 267,
                                                                                 },
                                                                                 node_id: Cell {
                                                                                     value: NodeId(0),
@@ -1474,8 +1811,8 @@ Program {
                                                                                 name: Identifier(
                                                                                     JSXIdentifier {
                                                                                         span: Span {
-                                                                                            start: 181,
-                                                                                            end: 189,
+                                                                                            start: 258,
+                                                                                            end: 266,
                                                                                         },
                                                                                         node_id: Cell {
                                                                                             value: NodeId(0),
@@ -1490,8 +1827,8 @@ Program {
                                                                 Text(
                                                                     JSXText {
                                                                         span: Span {
-                                                                            start: 190,
-                                                                            end: 191,
+                                                                            start: 267,
+                                                                            end: 268,
                                                                         },
                                                                         node_id: Cell {
                                                                             value: NodeId(0),
@@ -1551,18 +1888,23 @@ async () => {
   <Some v-bind:some.none={1}></>
   <div v-bind:id={id}></>
   <div v-bind:msg-id={msgId}></>
+  <div {...{
+		id: "app",
+		class: "w-100"
+	}}></>
+  <div {...{ id: "app" }}></>
 </template>
 </>;
 };
 
 
 ===============  Spans  ===============
-Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..iv :id />\n  <div :msg-id />\n</template>\n"; 
-Span: (0, 191); 
+Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..  <div :=\"{ id: 'app' }\" />\n</template>\n"; 
+Span: (0, 268); 
 Type: Program; 
 
-Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..div :id />\n  <div :msg-id />\n</template>"; 
-Span: (0, 190); 
+Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..\n  <div :=\"{ id: 'app' }\" />\n</template>"; 
+Span: (0, 267); 
 Type: JSXElement; 
 
 Slice: "<template>"; 
@@ -1861,18 +2203,102 @@ Slice: "msg-id";
 Span: (169, 175); 
 Type: JSXIdentifier; 
 
+Slice: "\n  "; 
+Span: (178, 181); 
+Type: JSXText; 
+
+Slice: "<div v-bind=\"{ id: 'app', class: 'w-100' }\" />"; 
+Span: (181, 227); 
+Type: JSXElement; 
+
+Slice: "<div v-bind=\"{ id: 'app', class: 'w-100' }\" />"; 
+Span: (181, 227); 
+Type: JSXOpeningElement; 
+
+Slice: "div"; 
+Span: (182, 185); 
+Type: JSXIdentifier; 
+
+Slice: "v-bind=\"{ id: 'app', class: 'w-100' }\""; 
+Span: (186, 224); 
+Type: JSXSpreadAttribute; 
+
+Slice: "{ id: 'app', class: 'w-100' }"; 
+Span: (194, 223); 
+Type: ObjectExpression; 
+
+Slice: "id: 'app'"; 
+Span: (196, 205); 
+Type: ObjectProperty; 
+
+Slice: "id"; 
+Span: (196, 198); 
+Type: IdentifierName; 
+
+Slice: "'app'"; 
+Span: (200, 205); 
+Type: StringLiteral; 
+
+Slice: "class: 'w-100'"; 
+Span: (207, 221); 
+Type: ObjectProperty; 
+
+Slice: "class"; 
+Span: (207, 212); 
+Type: IdentifierName; 
+
+Slice: "'w-100'"; 
+Span: (214, 221); 
+Type: StringLiteral; 
+
+Slice: "\n  "; 
+Span: (227, 230); 
+Type: JSXText; 
+
+Slice: "<div :=\"{ id: 'app' }\" />"; 
+Span: (230, 255); 
+Type: JSXElement; 
+
+Slice: "<div :=\"{ id: 'app' }\" />"; 
+Span: (230, 255); 
+Type: JSXOpeningElement; 
+
+Slice: "div"; 
+Span: (231, 234); 
+Type: JSXIdentifier; 
+
+Slice: ":=\"{ id: 'app' }\""; 
+Span: (235, 252); 
+Type: JSXSpreadAttribute; 
+
+Slice: "{ id: 'app' }"; 
+Span: (238, 251); 
+Type: ObjectExpression; 
+
+Slice: "id: 'app'"; 
+Span: (240, 249); 
+Type: ObjectProperty; 
+
+Slice: "id"; 
+Span: (240, 242); 
+Type: IdentifierName; 
+
+Slice: "'app'"; 
+Span: (244, 249); 
+Type: StringLiteral; 
+
 Slice: "\n"; 
-Span: (178, 179); 
+Span: (255, 256); 
 Type: JSXText; 
 
 Slice: "</template>"; 
-Span: (179, 190); 
+Span: (256, 267); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
-Span: (181, 189); 
+Span: (258, 266); 
 Type: JSXIdentifier; 
 
 Slice: "\n"; 
-Span: (190, 191); 
+Span: (267, 268); 
 Type: JSXText;


### PR DESCRIPTION
## Summary

- `v-bind="obj"` and `:="obj"` (argument-less v-bind) spread all properties onto the element, which maps to JSX spread `{...obj}` rather than a named attribute
- Added early-return in `parse_prop` that detects `dir.name == "bind"` with no argument and emits `JSXAttributeItem::SpreadAttribute`
- Updated fixture `directive/basic.vue` with two new test cases and regenerated the snapshot

## Test plan

- [ ] `just test` passes (all 12 tests green)
- [ ] `just lint` clean (no warnings)
- [ ] Snapshot codegen shows `{...{ id: "app", class: "w-100" }}` and `{...{ id: "app" }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)