### PR TITLE
docs: add doc tests for public parser API

### DIFF
--- a/crates/vue_oxc_toolkit/src/lib.rs
+++ b/crates/vue_oxc_toolkit/src/lib.rs
@@ -19,11 +19,11 @@ pub struct VueOxcParser<'a> {
   options: ParseOptions,
 }
 
-/// The return value of [`VueOxcParser::parse`]
-/// Has the same struct as [`oxc_parser::ParserReturn`]
-/// A workaround to pass #[`non_exhaustive`] of [`oxc_parser::ParserReturn`]
+/// The return value of [`VueOxcParser::parse`].
 ///
-/// Do not provide `is_flow_language` field, it should be always false, as vue do not support it
+/// Mirrors [`oxc_parser::ParserReturn`] as a workaround for its
+/// `#[non_exhaustive]` attribute. The `is_flow_language` field is intentionally
+/// omitted because Vue does not support Flow.
 #[non_exhaustive]
 pub struct VueParserReturn<'a> {
   pub program: Program<'a>,
@@ -34,10 +34,46 @@ pub struct VueParserReturn<'a> {
 }
 
 impl<'a> VueOxcParser<'a> {
+  /// Creates a new [`VueOxcParser`] for the given Vue SFC `source_text`.
+  ///
+  /// The `allocator` must outlive the returned parser and the resulting
+  /// [`VueParserReturn`], because the produced AST nodes are arena-allocated.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use oxc_allocator::Allocator;
+  /// use vue_oxc_toolkit::VueOxcParser;
+  ///
+  /// let allocator = Allocator::default();
+  /// let source = r#"<template><div>{{ msg }}</div></template>
+  /// <script setup>
+  /// const msg = 'hello';
+  /// </script>"#;
+  ///
+  /// let ret = VueOxcParser::new(&allocator, source).parse();
+  /// assert!(!ret.panicked);
+  /// ```
   pub fn new(allocator: &'a Allocator, source_text: &'a str) -> Self {
     Self { allocator, source_text, options: ParseOptions::default() }
   }
 
+  /// Overrides the [`ParseOptions`] passed to the underlying `oxc_parser`.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use oxc_allocator::Allocator;
+  /// use oxc_parser::ParseOptions;
+  /// use vue_oxc_toolkit::VueOxcParser;
+  ///
+  /// let allocator = Allocator::default();
+  /// let source = "<script setup lang=\"ts\">const n: number = 1;</script>";
+  ///
+  /// let options = ParseOptions { parse_regular_expression: true, ..ParseOptions::default() };
+  /// let ret = VueOxcParser::new(&allocator, source).with_options(options).parse();
+  /// assert!(!ret.panicked);
+  /// ```
   #[must_use]
   pub const fn with_options(mut self, options: ParseOptions) -> Self {
     self.options = options;
@@ -46,6 +82,27 @@ impl<'a> VueOxcParser<'a> {
 }
 
 impl<'a> VueOxcParser<'a> {
+  /// Parses the Vue SFC and returns a [`VueParserReturn`] containing the
+  /// JS/TS [`Program`], the [`ModuleRecord`], collected diagnostics, and any
+  /// irregular whitespace spans found in the source.
+  ///
+  /// On a fatal parse failure, [`VueParserReturn::panicked`] is `true` and
+  /// [`VueParserReturn::program`] is a dummy program; callers should inspect
+  /// [`VueParserReturn::errors`] in that case.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use oxc_allocator::Allocator;
+  /// use vue_oxc_toolkit::VueOxcParser;
+  ///
+  /// let allocator = Allocator::default();
+  /// let source = r#"<script setup>const count = 1;</script>"#;
+  ///
+  /// let ret = VueOxcParser::new(&allocator, source).parse();
+  /// assert!(!ret.panicked);
+  /// assert!(ret.errors.is_empty());
+  /// ```
   #[must_use]
   pub fn parse(self) -> VueParserReturn<'a> {
     let ParserImplReturn { program, errors, fatal, module_record } =


### PR DESCRIPTION
## Summary
- Add runnable doc tests on `VueOxcParser::new`, `with_options`, and `parse` so `cargo shear` no longer warns about `doctest = true` without any doc tests.
- Fix the broken `[non_exhaustive]` intra-doc link on `VueParserReturn` and clean up its doc comment.

Per the request, doc tests are added only for the user-facing public API (`VueOxcParser` methods), not for infra interfaces such as the `is_void_tag!` macro or the `test_*` macros.

## Test plan
- [x] `cargo test --doc -p vue_oxc_toolkit` (3 doc tests pass)
- [x] `just lint` (cargo shear: no issues; clippy clean)
- [x] `just test` (all unit + doc tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)