### PR TITLE
fix: handle v-pre interpolations as plain text

### DIFF
--- a/crates/vue_oxc_toolkit/fixtures/directive/basic.vue
+++ b/crates/vue_oxc_toolkit/fixtures/directive/basic.vue
@@ -8,4 +8,5 @@
   <div :msg-id />
   <div v-bind="{ id: 'app', class: 'w-100' }" />
   <div :="{ id: 'app' }" />
+  <div v-pre>{{ Hello World }}</div>
 </template>

--- a/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/elements/mod.rs
@@ -103,7 +103,15 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
         }
         AstNode::Text(text) => result.push(self.parse_text(&text)),
         AstNode::Comment(comment) => result.push(self.parse_comment(&comment)),
-        AstNode::Interpolation(interp) => result.push(self.parse_interpolation(&interp)),
+        AstNode::Interpolation(interp) => {
+          if self.in_v_pre {
+            let span = interp.location.span();
+            let raw = self.ast.str(span.source_text(self.source_text));
+            result.push(self.ast.jsx_child_text(span, raw, Some(raw)));
+          } else {
+            result.push(self.parse_interpolation(&interp));
+          }
+        }
       }
     }
 
@@ -196,6 +204,7 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
     let mut v_for_wrapper = VForWrapper::new(&ast);
     let mut v_slot_wrapper = VSlotWrapper::new(&ast);
     let mut v_if_state: Option<VIf<'a>> = None;
+    let has_v_pre = node.properties.iter().any(|p| matches!(p, ElemProp::Dir(d) if d.name == "pre"));
     let mut attributes = ast.vec();
     for prop in node.properties {
       attributes.push(self.parse_prop(
@@ -206,6 +215,9 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
       ));
     }
 
+    if has_v_pre {
+      self.in_v_pre = true;
+    }
     let children = match children {
       Some(children) => children,
       None => v_slot_wrapper.wrap(self.parse_children(
@@ -214,6 +226,9 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
         node.children,
       )),
     };
+    if has_v_pre {
+      self.in_v_pre = false;
+    }
 
     // Clone element_name for opening element (needed because we may consume it in closing element)
     let opening_element_name = element_name.clone_in(self.allocator);

--- a/crates/vue_oxc_toolkit/src/parser/mod.rs
+++ b/crates/vue_oxc_toolkit/src/parser/mod.rs
@@ -36,6 +36,7 @@ pub struct ParserImpl<'a> {
   ast: AstBuilder<'a>,
   script_set: bool,
   setup_set: bool,
+  in_v_pre: bool,
 
   global: ScriptBlock<'a>,
   setup: ScriptBlock<'a>,
@@ -64,6 +65,7 @@ impl<'a> ParserImpl<'a> {
       ast,
       script_set: false,
       setup_set: false,
+      in_v_pre: false,
 
       global: ScriptBlock { directives: ast.vec(), statements: ast.vec() },
       setup: ScriptBlock { directives: ast.vec(), statements: ast.vec() },

--- a/crates/vue_oxc_toolkit/src/parser/snapshots/ast/directive_basic_vue.snap
+++ b/crates/vue_oxc_toolkit/src/parser/snapshots/ast/directive_basic_vue.snap
@@ -6,7 +6,7 @@ expression: result
 Program {
     span: Span {
         start: 0,
-        end: 268,
+        end: 305,
     },
     node_id: Cell {
         value: NodeId(0),
@@ -14,7 +14,7 @@ Program {
     scope_id: Cell {
         value: None,
     },
-    source_text: "<template>\n  <div :class=\"'w-100'\" />\n  <div :[some]=\"2\" />\n  <Some #default=\"{ a }\" />\n  <input v-model=\"text\" />\n  <Some v-bind:some.none=\"1\" />\n  <div :id />\n  <div :msg-id />\n  <div v-bind=\"{ id: 'app', class: 'w-100' }\" />\n  <div :=\"{ id: 'app' }\" />\n</template>\n",
+    source_text: "<template>\n  <div :class=\"'w-100'\" />\n  <div :[some]=\"2\" />\n  <Some #default=\"{ a }\" />\n  <input v-model=\"text\" />\n  <Some v-bind:some.none=\"1\" />\n  <div :id />\n  <div :msg-id />\n  <div v-bind=\"{ id: 'app', class: 'w-100' }\" />\n  <div :=\"{ id: 'app' }\" />\n  <div v-pre>{{ Hello World }}</div>\n</template>\n",
     comments: Vec(
         [],
     ),
@@ -107,7 +107,7 @@ Program {
                                                                     JSXElement {
                                                                         span: Span {
                                                                             start: 0,
-                                                                            end: 267,
+                                                                            end: 304,
                                                                         },
                                                                         node_id: Cell {
                                                                             value: NodeId(0),
@@ -1786,7 +1786,144 @@ Program {
                                                                                     JSXText {
                                                                                         span: Span {
                                                                                             start: 255,
-                                                                                            end: 256,
+                                                                                            end: 258,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        value: "\n  ",
+                                                                                        raw: Some(
+                                                                                            "\n  ",
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Element(
+                                                                                    JSXElement {
+                                                                                        span: Span {
+                                                                                            start: 258,
+                                                                                            end: 292,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        opening_element: JSXOpeningElement {
+                                                                                            span: Span {
+                                                                                                start: 258,
+                                                                                                end: 269,
+                                                                                            },
+                                                                                            node_id: Cell {
+                                                                                                value: NodeId(0),
+                                                                                            },
+                                                                                            name: Identifier(
+                                                                                                JSXIdentifier {
+                                                                                                    span: Span {
+                                                                                                        start: 259,
+                                                                                                        end: 262,
+                                                                                                    },
+                                                                                                    node_id: Cell {
+                                                                                                        value: NodeId(0),
+                                                                                                    },
+                                                                                                    name: "div",
+                                                                                                },
+                                                                                            ),
+                                                                                            type_arguments: None,
+                                                                                            attributes: Vec(
+                                                                                                [
+                                                                                                    Attribute(
+                                                                                                        JSXAttribute {
+                                                                                                            span: Span {
+                                                                                                                start: 263,
+                                                                                                                end: 268,
+                                                                                                            },
+                                                                                                            node_id: Cell {
+                                                                                                                value: NodeId(0),
+                                                                                                            },
+                                                                                                            name: NamespacedName(
+                                                                                                                JSXNamespacedName {
+                                                                                                                    span: Span {
+                                                                                                                        start: 263,
+                                                                                                                        end: 268,
+                                                                                                                    },
+                                                                                                                    node_id: Cell {
+                                                                                                                        value: NodeId(0),
+                                                                                                                    },
+                                                                                                                    namespace: JSXIdentifier {
+                                                                                                                        span: Span {
+                                                                                                                            start: 263,
+                                                                                                                            end: 268,
+                                                                                                                        },
+                                                                                                                        node_id: Cell {
+                                                                                                                            value: NodeId(0),
+                                                                                                                        },
+                                                                                                                        name: "v-pre",
+                                                                                                                    },
+                                                                                                                    name: JSXIdentifier {
+                                                                                                                        span: Span {
+                                                                                                                            start: 0,
+                                                                                                                            end: 0,
+                                                                                                                        },
+                                                                                                                        node_id: Cell {
+                                                                                                                            value: NodeId(0),
+                                                                                                                        },
+                                                                                                                        name: "",
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            value: None,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                            ),
+                                                                                        },
+                                                                                        children: Vec(
+                                                                                            [
+                                                                                                Text(
+                                                                                                    JSXText {
+                                                                                                        span: Span {
+                                                                                                            start: 269,
+                                                                                                            end: 286,
+                                                                                                        },
+                                                                                                        node_id: Cell {
+                                                                                                            value: NodeId(0),
+                                                                                                        },
+                                                                                                        value: "{{ Hello World }}",
+                                                                                                        raw: Some(
+                                                                                                            "{{ Hello World }}",
+                                                                                                        ),
+                                                                                                    },
+                                                                                                ),
+                                                                                            ],
+                                                                                        ),
+                                                                                        closing_element: Some(
+                                                                                            JSXClosingElement {
+                                                                                                span: Span {
+                                                                                                    start: 286,
+                                                                                                    end: 292,
+                                                                                                },
+                                                                                                node_id: Cell {
+                                                                                                    value: NodeId(0),
+                                                                                                },
+                                                                                                name: Identifier(
+                                                                                                    JSXIdentifier {
+                                                                                                        span: Span {
+                                                                                                            start: 288,
+                                                                                                            end: 291,
+                                                                                                        },
+                                                                                                        node_id: Cell {
+                                                                                                            value: NodeId(0),
+                                                                                                        },
+                                                                                                        name: "div",
+                                                                                                    },
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Text(
+                                                                                    JSXText {
+                                                                                        span: Span {
+                                                                                            start: 292,
+                                                                                            end: 293,
                                                                                         },
                                                                                         node_id: Cell {
                                                                                             value: NodeId(0),
@@ -1802,8 +1939,8 @@ Program {
                                                                         closing_element: Some(
                                                                             JSXClosingElement {
                                                                                 span: Span {
-                                                                                    start: 256,
-                                                                                    end: 267,
+                                                                                    start: 293,
+                                                                                    end: 304,
                                                                                 },
                                                                                 node_id: Cell {
                                                                                     value: NodeId(0),
@@ -1811,8 +1948,8 @@ Program {
                                                                                 name: Identifier(
                                                                                     JSXIdentifier {
                                                                                         span: Span {
-                                                                                            start: 258,
-                                                                                            end: 266,
+                                                                                            start: 295,
+                                                                                            end: 303,
                                                                                         },
                                                                                         node_id: Cell {
                                                                                             value: NodeId(0),
@@ -1827,8 +1964,8 @@ Program {
                                                                 Text(
                                                                     JSXText {
                                                                         span: Span {
-                                                                            start: 267,
-                                                                            end: 268,
+                                                                            start: 304,
+                                                                            end: 305,
                                                                         },
                                                                         node_id: Cell {
                                                                             value: NodeId(0),
@@ -1893,18 +2030,19 @@ async () => {
 		class: "w-100"
 	}}></>
   <div {...{ id: "app" }}></>
+  <div v-pre:>{{ Hello World }}</div>
 </template>
 </>;
 };
 
 
 ===============  Spans  ===============
-Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..  <div :=\"{ id: 'app' }\" />\n</template>\n"; 
-Span: (0, 268); 
+Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..pre>{{ Hello World }}</div>\n</template>\n"; 
+Span: (0, 305); 
 Type: Program; 
 
-Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..\n  <div :=\"{ id: 'app' }\" />\n</template>"; 
-Span: (0, 267); 
+Slice: "<template>\n  <div :class=\"'w-100'\" />\n  ..[OMIT]..-pre>{{ Hello World }}</div>\n</template>"; 
+Span: (0, 304); 
 Type: JSXElement; 
 
 Slice: "<template>"; 
@@ -2287,18 +2425,58 @@ Slice: "'app'";
 Span: (244, 249); 
 Type: StringLiteral; 
 
-Slice: "\n"; 
-Span: (255, 256); 
+Slice: "\n  "; 
+Span: (255, 258); 
 Type: JSXText; 
 
-Slice: "</template>"; 
-Span: (256, 267); 
+Slice: "<div v-pre>{{ Hello World }}</div>"; 
+Span: (258, 292); 
+Type: JSXElement; 
+
+Slice: "<div v-pre>"; 
+Span: (258, 269); 
+Type: JSXOpeningElement; 
+
+Slice: "div"; 
+Span: (259, 262); 
+Type: JSXIdentifier; 
+
+Slice: "v-pre"; 
+Span: (263, 268); 
+Type: JSXAttribute; 
+
+Slice: "v-pre"; 
+Span: (263, 268); 
+Type: JSXNamespacedName; 
+
+Slice: "v-pre"; 
+Span: (263, 268); 
+Type: JSXIdentifier; 
+
+Slice: "{{ Hello World }}"; 
+Span: (269, 286); 
+Type: JSXText; 
+
+Slice: "</div>"; 
+Span: (286, 292); 
 Type: JSXClosingElement; 
 
-Slice: "template"; 
-Span: (258, 266); 
+Slice: "div"; 
+Span: (288, 291); 
 Type: JSXIdentifier; 
 
 Slice: "\n"; 
-Span: (267, 268); 
+Span: (292, 293); 
+Type: JSXText; 
+
+Slice: "</template>"; 
+Span: (293, 304); 
+Type: JSXClosingElement; 
+
+Slice: "template"; 
+Span: (295, 303); 
+Type: JSXIdentifier; 
+
+Slice: "\n"; 
+Span: (304, 305); 
 Type: JSXText;


### PR DESCRIPTION
## Summary

- `vue-compiler-core` always emits `AstNode::Interpolation` for `{{ }}` tokens, even inside `v-pre` elements — it leaves suppression to consumers
- When the toolkit processed those nodes, it tried to parse the raw content (e.g. `Hello World`) as a JS expression, producing a spurious parse error
- Fix: add `in_v_pre: bool` to `ParserImpl`; set it when entering an element with a `v-pre` directive and clear it on exit; in `parse_children`, emit `JSXText` instead of `JSXExpressionContainer` while the flag is active (works recursively for nested elements)

## Test plan

- [ ] `just test` passes (all 12 unit tests + 3 doc tests)
- [ ] `just lint` passes
- [ ] `directive/basic.vue` fixture now includes `<div v-pre>{{ Hello World }}</div>` with no parse errors
- [ ] Snapshot `directive_basic_vue.snap` updated: `{{ Hello World }}` appears as a `JSXText` value, not a parsed expression

🤖 Generated with [Claude Code](https://claude.com/claude-code)