### PR TITLE
refactor: move directive codegen helpers

### DIFF
--- a/crates/vue_oxlint_jsx/src/parser/codegen.rs
+++ b/crates/vue_oxlint_jsx/src/parser/codegen.rs
@@ -1,4 +1,4 @@
-use oxc_ast::ast::JSXChild;
+use oxc_ast::ast::{JSXChild, Str};
 use oxc_span::Span;
 
 use crate::parser::ParserImpl;
@@ -27,4 +27,31 @@ impl<'a> ParserImpl<'a> {
 
     self.ast.jsx_child_text(span, ast_str, Some(ast_str))
   }
+
+  pub(super) fn codegen_directive_identifier(&self, name: &'a str) -> Str<'a> {
+    if !self.config.codegen || is_codegen_safe_jsx_identifier(name) {
+      return name.into();
+    }
+
+    let mut result = String::from("__v_");
+    for ch in name.chars() {
+      if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$' | '-') {
+        result.push(ch);
+      } else if !result.ends_with('_') {
+        result.push('_');
+      }
+    }
+
+    result.push_str("__");
+    self.ast.str(&result)
+  }
+}
+
+fn is_codegen_safe_jsx_identifier(name: &str) -> bool {
+  let Some((&first, rest)) = name.as_bytes().split_first() else {
+    return false;
+  };
+
+  matches!(first, b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$')
+    && rest.iter().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'$' | b'-'))
 }

--- a/crates/vue_oxlint_jsx/src/parser/elements/directive.rs
+++ b/crates/vue_oxlint_jsx/src/parser/elements/directive.rs
@@ -1,5 +1,5 @@
 use memchr::memchr;
-use oxc_ast::ast::{JSXAttributeName, Str};
+use oxc_ast::ast::JSXAttributeName;
 use oxc_span::{SPAN, Span};
 use vue_compiler_core::parser::Directive;
 
@@ -67,41 +67,6 @@ impl<'a> ParserImpl<'a> {
       ),
     )
   }
-
-  fn codegen_directive_identifier(&self, name: &'a str) -> Str<'a> {
-    if !self.config.codegen || is_codegen_safe_jsx_identifier(name) {
-      return name.into();
-    }
-
-    let mut result = String::from("__v_");
-    for ch in name.chars() {
-      if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$' | '-') {
-        result.push(ch);
-      } else if !result.ends_with('_') {
-        result.push('_');
-      }
-    }
-
-    if result == "__v_" {
-      return self.ast.str("__v__");
-    }
-
-    if result.ends_with('_') {
-      result.push('_');
-    } else {
-      result.push_str("__");
-    }
-    self.ast.str(&result)
-  }
-}
-
-fn is_codegen_safe_jsx_identifier(name: &str) -> bool {
-  let Some((&first, rest)) = name.as_bytes().split_first() else {
-    return false;
-  };
-
-  matches!(first, b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$')
-    && rest.iter().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'$' | b'-'))
 }
 
 #[cfg(test)]

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_basic_vue.snap
@@ -5,9 +5,9 @@ expression: "&codegen"
 async () => {
 	<><template>
   <div v-bind:class={"w-100"} />
-  <div v-bind:__v_some__={{ [some]: 2 }} />
+  <div v-bind:__v_some___={{ [some]: 2 }} />
   <Some v-slot:default={undefined} />{{ default: ({ a }) => <></> }}
-  <input v-model:__v__={text} />
+  <input v-model:__v___={text} />
   <Some v-bind:__v_some_none__={1} />
   <div v-bind:id={id} />
   <div v-bind:msg-id={msgId} />

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for-error_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for-error_vue.snap
@@ -4,11 +4,11 @@ expression: "&codegen"
 ---
 async () => {
 	<><template>
-  <div v-for:__v__={undefined} />
-  <div v-for:__v__={undefined} />
-  <div v-for:__v__={undefined} />
-  <div v-for:__v__={undefined} />
-  <div v-for:__v__={undefined} />
+  <div v-for:__v___={undefined} />
+  <div v-for:__v___={undefined} />
+  <div v-for:__v___={undefined} />
+  <div v-for:__v___={undefined} />
+  <div v-for:__v___={undefined} />
 </template>
 </>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for_vue.snap
@@ -4,16 +4,16 @@ expression: "&codegen"
 ---
 async () => {
 	<><template>
-  {source((item) => <div v-for:__v__={undefined} />)}
-  {source1((item1) => <div v-for:__v__={undefined} />)}
-  {source2((item2, index2) => <div v-for:__v__={undefined} />)}
-  {source3((item3 = "1", index3 = 99) => <div v-for:__v__={undefined} />)}
-  {users4(({ id4, name4 }) => <div v-for:__v__={undefined} />)}
-  {users5(({ id5, name5 }, index) => <div v-for:__v__={undefined} />)}
-  {users6(({ id6 = 1, name6 = "Liang" }, index) => <div v-for:__v__={undefined} />)}
-  {someObj7((key7, value7, index7) => <div v-for:__v__={undefined} />)}
-  {someIter8(([item8, index8]) => <div v-for:__v__={undefined} />)}
-  {someIter9(([item9 = "hi", index9]) => <div v-for:__v__={undefined} />)}
+  {source((item) => <div v-for:__v___={undefined} />)}
+  {source1((item1) => <div v-for:__v___={undefined} />)}
+  {source2((item2, index2) => <div v-for:__v___={undefined} />)}
+  {source3((item3 = "1", index3 = 99) => <div v-for:__v___={undefined} />)}
+  {users4(({ id4, name4 }) => <div v-for:__v___={undefined} />)}
+  {users5(({ id5, name5 }, index) => <div v-for:__v___={undefined} />)}
+  {users6(({ id6 = 1, name6 = "Liang" }, index) => <div v-for:__v___={undefined} />)}
+  {someObj7((key7, value7, index7) => <div v-for:__v___={undefined} />)}
+  {someIter8(([item8, index8]) => <div v-for:__v___={undefined} />)}
+  {someIter9(([item9 = "hi", index9]) => <div v-for:__v___={undefined} />)}
 </template>
 </>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-if-error_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-if-error_vue.snap
@@ -4,14 +4,14 @@ expression: "&codegen"
 ---
 async () => {
 	<><template>
-  <div v-else-if:__v__={undefined} />
-  <div v-else:__v__ />
+  <div v-else-if:__v___={undefined} />
+  <div v-else:__v___ />
 
   
-  {1 ? <><div v-if:__v__={undefined} /></> : undefined}<div v-if:__v__={undefined} />
-  <div v-if:__v__ />
-  <div v-else-if:__v__={undefined} />
-  <div v-else-if:__v__ />
+  {1 ? <><div v-if:__v___={undefined} /></> : undefined}<div v-if:__v___={undefined} />
+  <div v-if:__v___ />
+  <div v-else-if:__v___={undefined} />
+  <div v-else-if:__v___ />
 </template>
 
 </>;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-if_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-if_vue.snap
@@ -8,14 +8,14 @@ async () => {
   
   
   
-  {a ? <><div v-if:__v__={undefined}>A</div></> : b ? <><div v-else-if:__v__={undefined}>B</div></> : c ? <><div v-else-if:__v__={undefined}>C</div></> : d ? <><div v-else-if:__v__={undefined}>D</div></> : <><div v-else:__v__>E</div></>}
+  {a ? <><div v-if:__v___={undefined}>A</div></> : b ? <><div v-else-if:__v___={undefined}>B</div></> : c ? <><div v-else-if:__v___={undefined}>C</div></> : d ? <><div v-else-if:__v___={undefined}>D</div></> : <><div v-else:__v___>E</div></>}
   
   
-  {x ? <><div v-if:__v__={undefined}>X</div></> : <><div v-else:__v__>Y</div></>}
+  {x ? <><div v-if:__v___={undefined}>X</div></> : <><div v-else:__v___>Y</div></>}
   
   
-  {z ? <><div v-if:__v__={undefined}>Z</div></> : undefined}
-  {w ? <><div v-if:__v__={undefined}>W</div></> : undefined}<div>K</div>
+  {z ? <><div v-if:__v___={undefined}>Z</div></> : undefined}
+  {w ? <><div v-if:__v___={undefined}>W</div></> : undefined}<div>K</div>
 </template>
 </>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-slot_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-slot_vue.snap
@@ -4,19 +4,19 @@ expression: "&codegen"
 ---
 async () => {
 	<><template>
-  <Comp v-slot:__v__={undefined}>{{ default: ({ message }) => <></> }}</Comp>
+  <Comp v-slot:__v___={undefined}>{{ default: ({ message }) => <></> }}</Comp>
   <Comp v-slot:header={undefined}>{{ header: ({ message }) => <>
     {message}
   </> }}</Comp>
   <Comp v-slot:abc>{{ abc: () => <> abc </> }}</Comp>
-  <Comp v-slot:__v__ />{{ default: () => <></> }}
+  <Comp v-slot:__v___ />{{ default: () => <></> }}
   <Comp v-slot:header={undefined}>{{ header: ({ message }) => <>
     {message}
   </> }}</Comp>
-  <Comp v-slot:__v__={undefined}>{{ default: ({ message }) => <>
+  <Comp v-slot:__v___={undefined}>{{ default: ({ message }) => <>
     {message}
   </> }}</Comp>
-  <Comp v-slot:__v_key__={undefined}>{{ [key]: ({ message }) => <>
+  <Comp v-slot:__v_key___={undefined}>{{ [key]: ({ message }) => <>
     {message}
   </> }}</Comp>
   <Comp v-slot:header={undefined}>{{ header: (user) => <>


### PR DESCRIPTION
## Summary

- Move `codegen_directive_identifier` and `is_codegen_safe_jsx_identifier` from the directive parser module into `parser/codegen.rs`.
- Simplify generated directive identifier suffixing so sanitized names always append `__` directly.
- Update codegen snapshots for the new directive identifier output.

## Validation

- `cargo fmt --all -- --emit=files`
- `cargo test -p vue_oxlint_jsx --all-features`
- `just test`
