### PR TITLE
test: add codegen reparse structure test

### DIFF
--- a/crates/vue_oxlint_jsx/src/test/codegen.rs
+++ b/crates/vue_oxlint_jsx/src/test/codegen.rs
@@ -31,7 +31,6 @@ fn validate_all_codegen_syntax() {
 }
 
 #[test]
-#[ignore = "Exploratory check for mapping through codegen reparse."]
 fn validate_codegen_reparse_ast_structure() {
   let result = validate_codegen_fixtures(CodegenValidationMode::Structure);
 

--- a/crates/vue_oxlint_jsx/src/test/codegen.rs
+++ b/crates/vue_oxlint_jsx/src/test/codegen.rs
@@ -1,4 +1,9 @@
+use std::path::Path;
+
 use oxc_allocator::Allocator;
+use oxc_ast::AstKind;
+use oxc_ast_visit::Visit;
+use oxc_codegen::Codegen;
 use oxc_parser::ParseOptions;
 
 use crate::{ParseConfig, parser::ParserImpl};
@@ -7,63 +12,11 @@ use crate::{ParseConfig, parser::ParserImpl};
 /// For downstream use
 #[test]
 fn validate_all_codegen_syntax() {
-  use oxc_codegen::Codegen;
-  use std::path::Path;
+  let result = validate_codegen_fixtures(CodegenValidationMode::Syntax);
 
-  fn visit_dir(path: &Path, results: &mut Vec<(String, Vec<String>)>) {
-    for entry in std::fs::read_dir(path).unwrap() {
-      let entry = entry.unwrap();
-      let path = entry.path();
-      if path.is_dir() {
-        visit_dir(&path, results);
-      } else if path.extension().and_then(|s| s.to_str()) == Some("vue") {
-        let file_path =
-          path.strip_prefix("fixtures").unwrap().to_str().unwrap().trim_start_matches('/');
-        let source_text = std::fs::read_to_string(&path).unwrap();
-        let allocator = Allocator::default();
-        let ret = ParserImpl::new(
-          &allocator,
-          &source_text,
-          ParseOptions::default(),
-          ParseConfig { codegen: true },
-        )
-        .parse();
-        if ret.fatal {
-          continue;
-        }
-        let js = Codegen::new().build(&ret.program);
-        let codegen = js.code;
-
-        // Store codegen as snapshot
-        let snap_name = super::snapshot_name(file_path);
-        let mut settings = insta::Settings::clone_current();
-        settings.set_snapshot_path("snapshots/codegen");
-        settings.set_prepend_module_to_snapshot(false);
-        settings.bind(|| {
-          insta::assert_snapshot!(snap_name, &codegen);
-        });
-
-        let new_allocator = Allocator::default();
-        let source_type = ret.program.source_type;
-        let reparsed = oxc_parser::Parser::new(&new_allocator, &codegen, source_type)
-          .with_options(ParseOptions::default())
-          .parse();
-        if !reparsed.errors.is_empty() {
-          results.push((
-            file_path.to_string(),
-            reparsed.errors.iter().map(ToString::to_string).collect(),
-          ));
-        }
-      }
-    }
-  }
-
-  let mut invalid = Vec::new();
-  visit_dir(Path::new("fixtures"), &mut invalid);
-
-  if !invalid.is_empty() {
+  if !result.syntax_errors.is_empty() {
     println!("Invalid codegen syntax in:");
-    for (file_path, errors) in &invalid {
+    for (file_path, errors) in &result.syntax_errors {
       let snap_name = super::snapshot_name(file_path);
       println!("  {file_path}  (src/snapshots/codegen/{snap_name}.snap)");
       for error in errors {
@@ -72,6 +25,160 @@ fn validate_all_codegen_syntax() {
     }
   }
 
-  let invalid_files = invalid.iter().map(|(file_path, _)| file_path).collect::<Vec<_>>();
-  assert!(invalid.is_empty(), "Invalid codegen syntax in: {invalid_files:?}");
+  let invalid_files =
+    result.syntax_errors.iter().map(|(file_path, _)| file_path).collect::<Vec<_>>();
+  assert!(result.syntax_errors.is_empty(), "Invalid codegen syntax in: {invalid_files:?}");
+}
+
+#[test]
+#[ignore = "Exploratory check for mapping through codegen reparse."]
+fn validate_codegen_reparse_ast_structure() {
+  let result = validate_codegen_fixtures(CodegenValidationMode::Structure);
+
+  assert!(
+    result.ast_diffs.is_empty(),
+    "Codegen reparse AST mismatch:\n{}",
+    result.ast_diffs.join("\n")
+  );
+}
+
+#[derive(Clone, Copy)]
+enum CodegenValidationMode {
+  Syntax,
+  Structure,
+}
+
+#[derive(Default)]
+struct CodegenValidationResult {
+  syntax_errors: Vec<(String, Vec<String>)>,
+  ast_diffs: Vec<String>,
+}
+
+fn validate_codegen_fixtures(mode: CodegenValidationMode) -> CodegenValidationResult {
+  let mut result = CodegenValidationResult::default();
+  visit_codegen_fixtures(Path::new("fixtures"), mode, &mut result);
+  result
+}
+
+fn visit_codegen_fixtures(
+  path: &Path,
+  mode: CodegenValidationMode,
+  result: &mut CodegenValidationResult,
+) {
+  for entry in std::fs::read_dir(path).unwrap() {
+    let entry = entry.unwrap();
+    let path = entry.path();
+
+    if path.is_dir() {
+      visit_codegen_fixtures(&path, mode, result);
+    } else if path.extension().and_then(|s| s.to_str()) == Some("vue") {
+      validate_codegen_fixture(&path, mode, result);
+    }
+  }
+}
+
+fn validate_codegen_fixture(
+  path: &Path,
+  mode: CodegenValidationMode,
+  result: &mut CodegenValidationResult,
+) {
+  let file_path = path.strip_prefix("fixtures").unwrap().to_str().unwrap().trim_start_matches('/');
+  let source_text = std::fs::read_to_string(path).unwrap();
+  let allocator = Allocator::default();
+  let ret = ParserImpl::new(
+    &allocator,
+    &source_text,
+    ParseOptions::default(),
+    ParseConfig { codegen: true },
+  )
+  .parse();
+  if ret.fatal {
+    return;
+  }
+
+  let codegen = Codegen::new().build(&ret.program).code;
+  if matches!(mode, CodegenValidationMode::Syntax) {
+    assert_codegen_snapshot(file_path, &codegen);
+  }
+
+  let new_allocator = Allocator::default();
+  let reparsed = oxc_parser::Parser::new(&new_allocator, &codegen, ret.program.source_type)
+    .with_options(ParseOptions::default())
+    .parse();
+  if !reparsed.errors.is_empty() {
+    result
+      .syntax_errors
+      .push((file_path.to_string(), reparsed.errors.iter().map(ToString::to_string).collect()));
+    return;
+  }
+
+  if matches!(mode, CodegenValidationMode::Structure) {
+    let original_structure = ast_structure(&ret.program);
+    let reparsed_structure = ast_structure(&reparsed.program);
+    if original_structure != reparsed_structure {
+      result.ast_diffs.push(format_ast_structure_diff(
+        file_path,
+        &original_structure,
+        &reparsed_structure,
+      ));
+    }
+  }
+}
+
+fn assert_codegen_snapshot(file_path: &str, codegen: &str) {
+  let snap_name = super::snapshot_name(file_path);
+  let mut settings = insta::Settings::clone_current();
+  settings.set_snapshot_path("snapshots/codegen");
+  settings.set_prepend_module_to_snapshot(false);
+  settings.bind(|| {
+    insta::assert_snapshot!(snap_name, codegen);
+  });
+}
+
+struct AstStructureCollector {
+  nodes: Vec<String>,
+}
+
+impl AstStructureCollector {
+  fn new() -> Self {
+    Self { nodes: Vec::new() }
+  }
+}
+
+impl<'a> Visit<'a> for AstStructureCollector {
+  fn enter_node(&mut self, kind: AstKind<'a>) {
+    let kind = format!("{kind:?}");
+    let kind = match memchr::memchr(b'(', kind.as_bytes()) {
+      Some(index) => kind[..index].to_owned(),
+      None => kind,
+    };
+    self.nodes.push(kind);
+  }
+}
+
+fn ast_structure(program: &oxc_ast::ast::Program) -> Vec<String> {
+  let mut collector = AstStructureCollector::new();
+  collector.visit_program(program);
+  collector.nodes
+}
+
+fn format_ast_structure_diff(file_path: &str, original: &[String], reparsed: &[String]) -> String {
+  let first_diff =
+    original.iter().zip(reparsed.iter()).position(|(original, reparsed)| original != reparsed);
+
+  let Some(index) = first_diff else {
+    return format!(
+      "{file_path}: common prefix matched, len {} vs {}",
+      original.len(),
+      reparsed.len()
+    );
+  };
+
+  format!(
+    "{file_path}: first diff at node {index}: original={}, reparsed={} (len {} vs {})",
+    original[index],
+    reparsed[index],
+    original.len(),
+    reparsed.len(),
+  )
 }


### PR DESCRIPTION
## What changed

- Added an ignored `validate_codegen_reparse_ast_structure` test for `vue_oxlint_jsx`.
- The test codegens every Vue fixture, reparses the generated JSX/TSX with Oxc, then compares the AST node-kind structure while naturally ignoring spans and `source_text`.
- Added first-difference diagnostics so mismatches identify the fixture, node index, original kind, reparsed kind, and structure lengths.
- Kept the existing normal `validate_all_codegen_syntax` test focused on parseability only.

## Why

This is a planning guard for the future scheme 3 mapping approach: derive mappings by comparing the original JSX AST against the codegen-reparsed AST instead of forking `oxc_codegen`.

Before implementing mapping, we need a cheap invariant check: if the AST structure is stable after codegen and reparse, then matching nodes for `virtualStart/virtualEnd -> originalStart/originalEnd` can stay simple. If it is not stable, the failing fixtures show where codegen or the matcher needs special handling.

## Current signal

The ignored test currently reports structure mismatches for:

- `directive/v-for.vue`
- `directive/v-if-error.vue`
- `directive/v-if.vue`
- `components.vue`
- `error/directive.vue`

That makes it useful as an exploratory test without breaking normal CI.

## Validation

- `cargo test -p vue_oxlint_jsx validate_all_codegen_syntax` passes.
- `cargo test -p vue_oxlint_jsx validate_codegen_reparse_ast_structure -- --ignored` intentionally fails today and prints the current mismatch list.