### PR TITLE
refactor: move codegen into vue_oxlint_jsx with dedicated public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,9 +1715,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "oxc_allocator",
  "oxc_ast",
- "oxc_codegen",
  "vue_oxlint_jsx",
 ]
 

--- a/crates/vue_oxlint_jsx/Cargo.toml
+++ b/crates/vue_oxlint_jsx/Cargo.toml
@@ -13,6 +13,7 @@ description.workspace = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
+oxc_codegen = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
@@ -25,7 +26,6 @@ vue-compiler-core = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 oxc_ast_visit = { workspace = true }
-oxc_codegen = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/vue_oxlint_jsx/src/codegen.rs
+++ b/crates/vue_oxlint_jsx/src/codegen.rs
@@ -1,0 +1,115 @@
+use oxc_allocator::Allocator;
+use oxc_ast::Comment;
+use oxc_codegen::Codegen;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_parser::ParseOptions;
+use oxc_span::{SourceType, Span};
+
+use crate::irregular_whitespaces::collect_irregular_whitespaces;
+use crate::parser::{ParseConfig, ParserImpl};
+
+/// Configuration for [`VueOxcCodegen`].
+///
+/// The struct is `#[non_exhaustive]` so additional knobs (e.g. minification,
+/// source map output) can be added in the future without a breaking change.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct CodegenMode;
+
+impl CodegenMode {
+  #[must_use]
+  pub const fn new() -> Self {
+    Self
+  }
+}
+
+/// The return value of [`VueOxcCodegen::build`].
+#[non_exhaustive]
+pub struct VueOxcCodegenReturn {
+  /// The generated JS/TS source produced from the Vue SFC.
+  pub source_text: String,
+  /// The detected source type (JSX vs TSX, module vs script).
+  pub source_type: SourceType,
+  /// Comments collected from the parsed source. Spans refer to the original
+  /// Vue SFC source, not [`VueOxcCodegenReturn::source_text`].
+  pub comments: Vec<Comment>,
+  /// Irregular whitespace spans in the original Vue SFC source.
+  pub irregular_whitespaces: Box<[Span]>,
+  /// Diagnostics produced while parsing the Vue SFC.
+  pub errors: Vec<OxcDiagnostic>,
+  /// `true` if parsing fatally failed; [`VueOxcCodegenReturn::source_text`]
+  /// will be empty in that case.
+  pub panicked: bool,
+}
+
+/// Parses a Vue SFC and emits the resulting JS/TS source via `oxc_codegen`.
+///
+/// Unlike [`crate::VueOxcParser`] this entry point does not surface the AST
+/// — the parser allocator lives only for the duration of [`Self::build`] and
+/// is dropped before returning. Use this when you only need the generated
+/// code (e.g. for downstream tooling that lints or transforms the output).
+///
+/// # Examples
+///
+/// ```
+/// use vue_oxlint_jsx::{CodegenMode, VueOxcCodegen};
+///
+/// let source = r#"<template><div>{{ msg }}</div></template>
+/// <script setup>
+/// const msg = 'hello';
+/// </script>"#;
+///
+/// let ret = VueOxcCodegen::new(source).build(CodegenMode::new());
+/// assert!(!ret.panicked);
+/// ```
+pub struct VueOxcCodegen<'a> {
+  source_text: &'a str,
+  options: ParseOptions,
+}
+
+impl<'a> VueOxcCodegen<'a> {
+  #[must_use]
+  pub fn new(source_text: &'a str) -> Self {
+    Self { source_text, options: ParseOptions::default() }
+  }
+
+  /// Overrides the [`ParseOptions`] passed to the underlying `oxc_parser`.
+  #[must_use]
+  pub const fn with_options(mut self, options: ParseOptions) -> Self {
+    self.options = options;
+    self
+  }
+
+  /// Parses the Vue SFC and runs `oxc_codegen` to produce JS/TS source.
+  #[must_use]
+  pub fn build(self, _mode: CodegenMode) -> VueOxcCodegenReturn {
+    let allocator = Allocator::default();
+    let ret =
+      ParserImpl::new(&allocator, self.source_text, self.options, ParseConfig { codegen: true })
+        .parse();
+
+    if ret.fatal {
+      return VueOxcCodegenReturn {
+        source_text: String::new(),
+        source_type: ret.program.source_type,
+        comments: Vec::new(),
+        irregular_whitespaces: Box::new([]),
+        errors: ret.errors,
+        panicked: true,
+      };
+    }
+
+    let source_type = ret.program.source_type;
+    let comments = ret.program.comments.iter().copied().collect();
+    let source_text = Codegen::new().build(&ret.program).code;
+
+    VueOxcCodegenReturn {
+      source_text,
+      source_type,
+      comments,
+      irregular_whitespaces: collect_irregular_whitespaces(self.source_text),
+      errors: ret.errors,
+      panicked: false,
+    }
+  }
+}

--- a/crates/vue_oxlint_jsx/src/irregular_whitespaces.rs
+++ b/crates/vue_oxlint_jsx/src/irregular_whitespaces.rs
@@ -1,25 +1,21 @@
 use oxc_span::Span;
 
-use crate::VueOxcParser;
-
-impl VueOxcParser<'_> {
-  pub(super) fn get_irregular_whitespaces(&self) -> Box<[Span]> {
-    let mut irregular_whitespaces = Vec::new();
-    let mut offset = 0;
-    for c in self.source_text.chars() {
-      if oxc_syntax::identifier::is_irregular_whitespace(c) {
-        irregular_whitespaces.push(Span::sized(offset, c.len_utf8() as u32));
-      }
-      offset += c.len_utf8() as u32;
+pub fn collect_irregular_whitespaces(source_text: &str) -> Box<[Span]> {
+  let mut irregular_whitespaces = Vec::new();
+  let mut offset = 0;
+  for c in source_text.chars() {
+    if oxc_syntax::identifier::is_irregular_whitespace(c) {
+      irregular_whitespaces.push(Span::sized(offset, c.len_utf8() as u32));
     }
-
-    irregular_whitespaces.into_boxed_slice()
+    offset += c.len_utf8() as u32;
   }
+
+  irregular_whitespaces.into_boxed_slice()
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+  use crate::VueOxcParser;
   use oxc_allocator::Allocator;
 
   #[test]

--- a/crates/vue_oxlint_jsx/src/lib.rs
+++ b/crates/vue_oxlint_jsx/src/lib.rs
@@ -5,24 +5,21 @@ use oxc_parser::ParseOptions;
 use oxc_span::Span;
 use oxc_syntax::module_record::ModuleRecord;
 
-use crate::parser::{ParserImpl, ParserImplReturn};
+use crate::parser::{ParseConfig, ParserImpl, ParserImplReturn};
 
+mod codegen;
 mod irregular_whitespaces;
 mod parser;
 
 #[cfg(test)]
 mod test;
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ParseConfig {
-  pub codegen: bool,
-}
+pub use crate::codegen::{CodegenMode, VueOxcCodegen, VueOxcCodegenReturn};
 
 pub struct VueOxcParser<'a> {
   allocator: &'a Allocator,
   source_text: &'a str,
   options: ParseOptions,
-  config: ParseConfig,
 }
 
 /// The return value of [`VueOxcParser::parse`].
@@ -61,12 +58,7 @@ impl<'a> VueOxcParser<'a> {
   /// assert!(!ret.panicked);
   /// ```
   pub fn new(allocator: &'a Allocator, source_text: &'a str) -> Self {
-    Self {
-      allocator,
-      source_text,
-      options: ParseOptions::default(),
-      config: ParseConfig::default(),
-    }
+    Self { allocator, source_text, options: ParseOptions::default() }
   }
 
   /// Overrides the [`ParseOptions`] passed to the underlying `oxc_parser`.
@@ -88,13 +80,6 @@ impl<'a> VueOxcParser<'a> {
   #[must_use]
   pub const fn with_options(mut self, options: ParseOptions) -> Self {
     self.options = options;
-    self
-  }
-
-  /// Overrides the [`ParseConfig`]
-  #[must_use]
-  pub const fn with_config(mut self, config: ParseConfig) -> Self {
-    self.config = config;
     self
   }
 }
@@ -124,7 +109,8 @@ impl<'a> VueOxcParser<'a> {
   #[must_use]
   pub fn parse(self) -> VueParserReturn<'a> {
     let ParserImplReturn { program, errors, fatal, module_record } =
-      ParserImpl::new(self.allocator, self.source_text, self.options, self.config).parse();
+      ParserImpl::new(self.allocator, self.source_text, self.options, ParseConfig::default())
+        .parse();
 
     if fatal {
       VueParserReturn {
@@ -139,7 +125,9 @@ impl<'a> VueOxcParser<'a> {
         program,
         errors,
         panicked: false,
-        irregular_whitespaces: self.get_irregular_whitespaces(),
+        irregular_whitespaces: irregular_whitespaces::collect_irregular_whitespaces(
+          self.source_text,
+        ),
         module_record,
       }
     }

--- a/crates/vue_oxlint_jsx/src/parser/mod.rs
+++ b/crates/vue_oxlint_jsx/src/parser/mod.rs
@@ -10,14 +10,17 @@ use oxc_parser::ParseOptions;
 use oxc_span::{SourceType, Span};
 use oxc_syntax::module_record::ModuleRecord;
 
-use crate::ParseConfig;
-
 mod codegen;
 mod elements;
 mod error;
 mod modules;
 mod parse;
 mod script;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ParseConfig {
+  pub codegen: bool,
+}
 
 pub struct ScriptBlock<'a> {
   directives: ArenaVec<'a, Directive<'a>>,

--- a/crates/vue_oxlint_jsx/src/test/codegen.rs
+++ b/crates/vue_oxlint_jsx/src/test/codegen.rs
@@ -1,13 +1,12 @@
 use oxc_allocator::Allocator;
 use oxc_parser::ParseOptions;
 
-use crate::{ParseConfig, parser::ParserImpl};
+use crate::{CodegenMode, VueOxcCodegen};
 
 /// Tests for codegen
 /// For downstream use
 #[test]
 fn validate_all_codegen_syntax() {
-  use oxc_codegen::Codegen;
   use std::path::Path;
 
   fn visit_dir(path: &Path, results: &mut Vec<(String, Vec<String>)>) {
@@ -20,19 +19,11 @@ fn validate_all_codegen_syntax() {
         let file_path =
           path.strip_prefix("fixtures").unwrap().to_str().unwrap().trim_start_matches('/');
         let source_text = std::fs::read_to_string(&path).unwrap();
-        let allocator = Allocator::default();
-        let ret = ParserImpl::new(
-          &allocator,
-          &source_text,
-          ParseOptions::default(),
-          ParseConfig { codegen: true },
-        )
-        .parse();
-        if ret.fatal {
+        let ret = VueOxcCodegen::new(&source_text).build(CodegenMode::new());
+        if ret.panicked {
           continue;
         }
-        let js = Codegen::new().build(&ret.program);
-        let codegen = js.code;
+        let codegen = ret.source_text;
 
         // Store codegen as snapshot
         let snap_name = super::snapshot_name(file_path);
@@ -44,8 +35,7 @@ fn validate_all_codegen_syntax() {
         });
 
         let new_allocator = Allocator::default();
-        let source_type = ret.program.source_type;
-        let reparsed = oxc_parser::Parser::new(&new_allocator, &codegen, source_type)
+        let reparsed = oxc_parser::Parser::new(&new_allocator, &codegen, ret.source_type)
           .with_options(ParseOptions::default())
           .parse();
         if !reparsed.errors.is_empty() {

--- a/crates/vue_oxlint_jsx/src/test/mod.rs
+++ b/crates/vue_oxlint_jsx/src/test/mod.rs
@@ -1,6 +1,5 @@
-use crate::ParseConfig;
-use crate::parser::ParserImpl;
 pub use crate::parser::ParserImplReturn;
+use crate::parser::{ParseConfig, ParserImpl};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
 use oxc_ast_visit::Visit;

--- a/packages/vue-oxlint-toolkit/Cargo.toml
+++ b/packages/vue-oxlint-toolkit/Cargo.toml
@@ -18,9 +18,7 @@ crate-type = ["cdylib"]
 vue_oxlint_jsx = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
-oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
-oxc_codegen = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/packages/vue-oxlint-toolkit/src/lib.rs
+++ b/packages/vue-oxlint-toolkit/src/lib.rs
@@ -1,9 +1,7 @@
 #![deny(clippy::all)]
 
-use oxc_allocator::Allocator;
 use oxc_ast::ast::CommentKind;
-use oxc_codegen::Codegen;
-use vue_oxlint_jsx::{ParseConfig, VueOxcParser};
+use vue_oxlint_jsx::{CodegenMode, VueOxcCodegen};
 
 use napi_derive::napi;
 
@@ -43,18 +41,13 @@ pub struct NativeTransformResult {
 #[must_use]
 #[allow(clippy::needless_pass_by_value, reason = "N-API owns string arguments at the boundary.")]
 pub fn transform_jsx(source: String) -> NativeTransformResult {
-  let allocator = Allocator::default();
-  let ret =
-    VueOxcParser::new(&allocator, &source).with_config(ParseConfig { codegen: true }).parse();
-  let script_kind = if ret.program.source_type.is_typescript() { "tsx" } else { "jsx" }.to_string();
-  let source_text =
-    if ret.panicked { String::new() } else { Codegen::new().build(&ret.program).code };
+  let ret = VueOxcCodegen::new(&source).build(CodegenMode::new());
+  let script_kind = if ret.source_type.is_typescript() { "tsx" } else { "jsx" }.to_string();
 
   NativeTransformResult {
-    source_text,
+    source_text: ret.source_text,
     script_kind,
     comments: ret
-      .program
       .comments
       .iter()
       .map(|comment| {


### PR DESCRIPTION
## Summary

- Add a dedicated public codegen entry point in \`vue_oxlint_jsx\`: \`VueOxcCodegen\` (builder), \`CodegenMode\` (config), and \`VueOxcCodegenReturn\` (result with \`source_text\`, \`source_type\`, \`comments\`, \`irregular_whitespaces\`, \`errors\`, \`panicked\`). The codegen flow owns its allocator internally — callers no longer need to manage one when they only want generated JS/TS source.
- Make \`ParseConfig\` crate-private (mirroring \`ParserImpl\`); it is no longer part of the public API. \`VueOxcParser\` loses \`with_config\` since the codegen toggle now lives behind \`VueOxcCodegen\`.
- Move \`oxc_codegen\` from a dev-dependency to a regular dependency of \`vue_oxlint_jsx\`, and drop \`oxc_codegen\` / \`oxc_allocator\` from \`vue-oxlint-toolkit\` (the napi shim) since codegen is now performed in the parser crate.
- Refactor \`irregular_whitespaces\` into a free \`collect_irregular_whitespaces(&str)\` so both the parse and codegen flows can reuse it.
- Rewrite \`transform_jsx\` in the napi binding on top of the new \`VueOxcCodegen\` API and update the codegen snapshot test accordingly.

## Test plan

- [x] \`cargo build -p vue_oxlint_jsx -p vue_oxlint_toolkit\`
- [x] \`cargo clippy -p vue_oxlint_jsx -p vue_oxlint_toolkit --all-targets\` (clean)
- [x] \`cargo test -p vue_oxlint_jsx\` (all unit + doc tests + codegen snapshot test pass)
- [x] \`pnpm -F vue-oxlint-toolkit build\` (release napi build succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)