### PR TITLE
refactor(jsx)!: slim public API to VueJsxParser/VueJsxCodegen + return pairs

### DIFF
--- a/benchmark/benches/jsx.rs
+++ b/benchmark/benches/jsx.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use oxc_allocator::Allocator;
-use vue_oxlint_jsx::VueOxcParser;
+use vue_oxlint_jsx::Parser as VueParser;
 
 fn bench(c: &mut Criterion) {
   let mut group = c.benchmark_group("vue_parse_by_size");
@@ -18,7 +18,7 @@ fn bench(c: &mut Criterion) {
     #[allow(clippy::cast_precision_loss)]
     {
       let allocator = Allocator::default();
-      let _ = black_box(VueOxcParser::new(&allocator, html).parse());
+      let _ = black_box(VueParser::new(&allocator, html).parse());
       let used = allocator.used_bytes();
 
       println!(
@@ -32,7 +32,7 @@ fn bench(c: &mut Criterion) {
     group.bench_function(name, |b| {
       b.iter(|| {
         let allocator = Allocator::new();
-        black_box(VueOxcParser::new(&allocator, html).parse());
+        black_box(VueParser::new(&allocator, html).parse());
       });
     });
   }

--- a/benchmark/benches/jsx.rs
+++ b/benchmark/benches/jsx.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use oxc_allocator::Allocator;
-use vue_oxlint_jsx::Parser as VueParser;
+use vue_oxlint_jsx::VueJsxParser;
 
 fn bench(c: &mut Criterion) {
   let mut group = c.benchmark_group("vue_parse_by_size");
@@ -18,7 +18,7 @@ fn bench(c: &mut Criterion) {
     #[allow(clippy::cast_precision_loss)]
     {
       let allocator = Allocator::default();
-      let _ = black_box(VueParser::new(&allocator, html).parse());
+      let _ = black_box(VueJsxParser::new(&allocator, html).parse());
       let used = allocator.used_bytes();
 
       println!(
@@ -32,7 +32,7 @@ fn bench(c: &mut Criterion) {
     group.bench_function(name, |b| {
       b.iter(|| {
         let allocator = Allocator::new();
-        black_box(VueParser::new(&allocator, html).parse());
+        black_box(VueJsxParser::new(&allocator, html).parse());
       });
     });
   }

--- a/crates/vue_oxlint_jsx/src/codegen/mod.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/mod.rs
@@ -1,49 +1,34 @@
 use oxc_allocator::Allocator;
 use oxc_ast::Comment;
-use oxc_codegen::Codegen;
+use oxc_codegen::Codegen as OxcCodegen;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::ParseOptions;
 use oxc_span::{SourceType, Span};
 
 use crate::parser::{ParseConfig, ParserImpl};
 
-/// Configuration for [`VueOxcCodegen`].
-///
-/// The struct is `#[non_exhaustive]` so additional knobs (e.g. minification,
-/// source map output) can be added in the future without a breaking change.
-#[derive(Debug, Clone, Copy, Default)]
+/// The return value of [`Codegen::build`].
 #[non_exhaustive]
-pub struct CodegenMode;
-
-impl CodegenMode {
-  #[must_use]
-  pub const fn new() -> Self {
-    Self
-  }
-}
-
-/// The return value of [`VueOxcCodegen::build`].
-#[non_exhaustive]
-pub struct VueOxcCodegenReturn {
+pub struct CodegenReturn {
   /// The generated JS/TS source produced from the Vue SFC.
   pub source_text: String,
   /// The detected source type (JSX vs TSX, module vs script).
   pub source_type: SourceType,
   /// Comments collected from the parsed source. Spans refer to the original
-  /// Vue SFC source, not [`VueOxcCodegenReturn::source_text`].
+  /// Vue SFC source, not [`CodegenReturn::source_text`].
   pub comments: Vec<Comment>,
   /// Irregular whitespace spans in the original Vue SFC source.
   pub irregular_whitespaces: Box<[Span]>,
   /// Diagnostics produced while parsing the Vue SFC.
   pub errors: Vec<OxcDiagnostic>,
-  /// `true` if parsing fatally failed; [`VueOxcCodegenReturn::source_text`]
+  /// `true` if parsing fatally failed; [`CodegenReturn::source_text`]
   /// will be empty in that case.
   pub panicked: bool,
 }
 
 /// Parses a Vue SFC and emits the resulting JS/TS source via `oxc_codegen`.
 ///
-/// Unlike [`crate::VueOxcParser`] this entry point does not surface the AST
+/// Unlike [`crate::Parser`] this entry point does not surface the AST
 /// — the parser allocator lives only for the duration of [`Self::build`] and
 /// is dropped before returning. Use this when you only need the generated
 /// code (e.g. for downstream tooling that lints or transforms the output).
@@ -51,22 +36,22 @@ pub struct VueOxcCodegenReturn {
 /// # Examples
 ///
 /// ```
-/// use vue_oxlint_jsx::{CodegenMode, VueOxcCodegen};
+/// use vue_oxlint_jsx::Codegen;
 ///
 /// let source = r#"<template><div>{{ msg }}</div></template>
 /// <script setup>
 /// const msg = 'hello';
 /// </script>"#;
 ///
-/// let ret = VueOxcCodegen::new(source).build(CodegenMode::new());
+/// let ret = Codegen::new(source).build();
 /// assert!(!ret.panicked);
 /// ```
-pub struct VueOxcCodegen<'a> {
+pub struct Codegen<'a> {
   source_text: &'a str,
   options: ParseOptions,
 }
 
-impl<'a> VueOxcCodegen<'a> {
+impl<'a> Codegen<'a> {
   #[must_use]
   pub fn new(source_text: &'a str) -> Self {
     Self { source_text, options: ParseOptions::default() }
@@ -81,14 +66,14 @@ impl<'a> VueOxcCodegen<'a> {
 
   /// Parses the Vue SFC and runs `oxc_codegen` to produce JS/TS source.
   #[must_use]
-  pub fn build(self, _mode: CodegenMode) -> VueOxcCodegenReturn {
+  pub fn build(self) -> CodegenReturn {
     let allocator = Allocator::default();
     let ret =
       ParserImpl::new(&allocator, self.source_text, self.options, ParseConfig { codegen: true })
         .parse();
 
     if ret.fatal {
-      return VueOxcCodegenReturn {
+      return CodegenReturn {
         source_text: String::new(),
         source_type: ret.program.source_type,
         comments: Vec::new(),
@@ -98,11 +83,11 @@ impl<'a> VueOxcCodegen<'a> {
       };
     }
 
-    let source_text = Codegen::new().build(&ret.program).code;
+    let source_text = OxcCodegen::new().build(&ret.program).code;
     let source_type = ret.program.source_type;
     let comments = ret.program.comments.iter().copied().collect();
 
-    VueOxcCodegenReturn {
+    CodegenReturn {
       source_text,
       source_type,
       comments,

--- a/crates/vue_oxlint_jsx/src/codegen/mod.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/mod.rs
@@ -1,34 +1,34 @@
 use oxc_allocator::Allocator;
 use oxc_ast::Comment;
-use oxc_codegen::Codegen as OxcCodegen;
+use oxc_codegen::Codegen;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::ParseOptions;
 use oxc_span::{SourceType, Span};
 
 use crate::parser::{ParseConfig, ParserImpl};
 
-/// The return value of [`Codegen::build`].
+/// The return value of [`VueJsxCodegen::build`].
 #[non_exhaustive]
-pub struct CodegenReturn {
+pub struct VueJsxCodegenReturn {
   /// The generated JS/TS source produced from the Vue SFC.
   pub source_text: String,
   /// The detected source type (JSX vs TSX, module vs script).
   pub source_type: SourceType,
   /// Comments collected from the parsed source. Spans refer to the original
-  /// Vue SFC source, not [`CodegenReturn::source_text`].
+  /// Vue SFC source, not [`VueJsxCodegenReturn::source_text`].
   pub comments: Vec<Comment>,
   /// Irregular whitespace spans in the original Vue SFC source.
   pub irregular_whitespaces: Box<[Span]>,
   /// Diagnostics produced while parsing the Vue SFC.
   pub errors: Vec<OxcDiagnostic>,
-  /// `true` if parsing fatally failed; [`CodegenReturn::source_text`]
+  /// `true` if parsing fatally failed; [`VueJsxCodegenReturn::source_text`]
   /// will be empty in that case.
   pub panicked: bool,
 }
 
 /// Parses a Vue SFC and emits the resulting JS/TS source via `oxc_codegen`.
 ///
-/// Unlike [`crate::Parser`] this entry point does not surface the AST
+/// Unlike [`crate::VueJsxParser`] this entry point does not surface the AST
 /// — the parser allocator lives only for the duration of [`Self::build`] and
 /// is dropped before returning. Use this when you only need the generated
 /// code (e.g. for downstream tooling that lints or transforms the output).
@@ -36,22 +36,22 @@ pub struct CodegenReturn {
 /// # Examples
 ///
 /// ```
-/// use vue_oxlint_jsx::Codegen;
+/// use vue_oxlint_jsx::VueJsxCodegen;
 ///
 /// let source = r#"<template><div>{{ msg }}</div></template>
 /// <script setup>
 /// const msg = 'hello';
 /// </script>"#;
 ///
-/// let ret = Codegen::new(source).build();
+/// let ret = VueJsxCodegen::new(source).build();
 /// assert!(!ret.panicked);
 /// ```
-pub struct Codegen<'a> {
+pub struct VueJsxCodegen<'a> {
   source_text: &'a str,
   options: ParseOptions,
 }
 
-impl<'a> Codegen<'a> {
+impl<'a> VueJsxCodegen<'a> {
   #[must_use]
   pub fn new(source_text: &'a str) -> Self {
     Self { source_text, options: ParseOptions::default() }
@@ -66,14 +66,14 @@ impl<'a> Codegen<'a> {
 
   /// Parses the Vue SFC and runs `oxc_codegen` to produce JS/TS source.
   #[must_use]
-  pub fn build(self) -> CodegenReturn {
+  pub fn build(self) -> VueJsxCodegenReturn {
     let allocator = Allocator::default();
     let ret =
       ParserImpl::new(&allocator, self.source_text, self.options, ParseConfig { codegen: true })
         .parse();
 
     if ret.fatal {
-      return CodegenReturn {
+      return VueJsxCodegenReturn {
         source_text: String::new(),
         source_type: ret.program.source_type,
         comments: Vec::new(),
@@ -83,11 +83,11 @@ impl<'a> Codegen<'a> {
       };
     }
 
-    let source_text = OxcCodegen::new().build(&ret.program).code;
+    let source_text = Codegen::new().build(&ret.program).code;
     let source_type = ret.program.source_type;
     let comments = ret.program.comments.iter().copied().collect();
 
-    CodegenReturn {
+    VueJsxCodegenReturn {
       source_text,
       source_type,
       comments,

--- a/crates/vue_oxlint_jsx/src/lib.rs
+++ b/crates/vue_oxlint_jsx/src/lib.rs
@@ -4,5 +4,5 @@ mod parser;
 #[cfg(test)]
 mod test;
 
-pub use crate::codegen::{Codegen, CodegenReturn};
-pub use crate::parser::{Parser, ParserReturn};
+pub use crate::codegen::{VueJsxCodegen, VueJsxCodegenReturn};
+pub use crate::parser::{VueJsxParser, VueJsxParserReturn};

--- a/crates/vue_oxlint_jsx/src/lib.rs
+++ b/crates/vue_oxlint_jsx/src/lib.rs
@@ -4,5 +4,5 @@ mod parser;
 #[cfg(test)]
 mod test;
 
-pub use crate::codegen::{CodegenMode, VueOxcCodegen, VueOxcCodegenReturn};
-pub use crate::parser::{VueOxcParser, VueParserReturn};
+pub use crate::codegen::{Codegen, CodegenReturn};
+pub use crate::parser::{Parser, ParserReturn};

--- a/crates/vue_oxlint_jsx/src/parser/interface.rs
+++ b/crates/vue_oxlint_jsx/src/parser/interface.rs
@@ -7,19 +7,19 @@ use oxc_syntax::module_record::ModuleRecord;
 
 use crate::parser::{ParseConfig, ParserImpl, ParserImplReturn};
 
-pub struct VueOxcParser<'a> {
+pub struct Parser<'a> {
   allocator: &'a Allocator,
   source_text: &'a str,
   options: ParseOptions,
 }
 
-/// The return value of [`VueOxcParser::parse`].
+/// The return value of [`Parser::parse`].
 ///
 /// Mirrors [`oxc_parser::ParserReturn`] as a workaround for its
 /// `#[non_exhaustive]` attribute. The `is_flow_language` field is intentionally
 /// omitted because Vue does not support Flow.
 #[non_exhaustive]
-pub struct VueParserReturn<'a> {
+pub struct ParserReturn<'a> {
   pub program: Program<'a>,
   pub module_record: ModuleRecord<'a>,
   pub errors: Vec<OxcDiagnostic>,
@@ -27,17 +27,17 @@ pub struct VueParserReturn<'a> {
   pub panicked: bool,
 }
 
-impl<'a> VueOxcParser<'a> {
-  /// Creates a new [`VueOxcParser`] for the given Vue SFC `source_text`.
+impl<'a> Parser<'a> {
+  /// Creates a new [`Parser`] for the given Vue SFC `source_text`.
   ///
   /// The `allocator` must outlive the returned parser and the resulting
-  /// [`VueParserReturn`], because the produced AST nodes are arena-allocated.
+  /// [`ParserReturn`], because the produced AST nodes are arena-allocated.
   ///
   /// # Examples
   ///
   /// ```
   /// use oxc_allocator::Allocator;
-  /// use vue_oxlint_jsx::VueOxcParser;
+  /// use vue_oxlint_jsx::Parser;
   ///
   /// let allocator = Allocator::default();
   /// let source = r#"<template><div>{{ msg }}</div></template>
@@ -45,7 +45,7 @@ impl<'a> VueOxcParser<'a> {
   /// const msg = 'hello';
   /// </script>"#;
   ///
-  /// let ret = VueOxcParser::new(&allocator, source).parse();
+  /// let ret = Parser::new(&allocator, source).parse();
   /// assert!(!ret.panicked);
   /// ```
   pub fn new(allocator: &'a Allocator, source_text: &'a str) -> Self {
@@ -59,13 +59,13 @@ impl<'a> VueOxcParser<'a> {
   /// ```
   /// use oxc_allocator::Allocator;
   /// use oxc_parser::ParseOptions;
-  /// use vue_oxlint_jsx::VueOxcParser;
+  /// use vue_oxlint_jsx::Parser;
   ///
   /// let allocator = Allocator::default();
   /// let source = "<script setup lang=\"ts\">const n: number = 1;</script>";
   ///
   /// let options = ParseOptions { parse_regular_expression: true, ..ParseOptions::default() };
-  /// let ret = VueOxcParser::new(&allocator, source).with_options(options).parse();
+  /// let ret = Parser::new(&allocator, source).with_options(options).parse();
   /// assert!(!ret.panicked);
   /// ```
   #[must_use]
@@ -75,36 +75,36 @@ impl<'a> VueOxcParser<'a> {
   }
 }
 
-impl<'a> VueOxcParser<'a> {
-  /// Parses the Vue SFC and returns a [`VueParserReturn`] containing the
+impl<'a> Parser<'a> {
+  /// Parses the Vue SFC and returns a [`ParserReturn`] containing the
   /// JS/TS [`Program`], the [`ModuleRecord`], collected diagnostics, and any
   /// irregular whitespace spans found in the source.
   ///
-  /// On a fatal parse failure, [`VueParserReturn::panicked`] is `true` and
-  /// [`VueParserReturn::program`] is a dummy program; callers should inspect
-  /// [`VueParserReturn::errors`] in that case.
+  /// On a fatal parse failure, [`ParserReturn::panicked`] is `true` and
+  /// [`ParserReturn::program`] is a dummy program; callers should inspect
+  /// [`ParserReturn::errors`] in that case.
   ///
   /// # Examples
   ///
   /// ```
   /// use oxc_allocator::Allocator;
-  /// use vue_oxlint_jsx::VueOxcParser;
+  /// use vue_oxlint_jsx::Parser;
   ///
   /// let allocator = Allocator::default();
   /// let source = r#"<script setup>const count = 1;</script>"#;
   ///
-  /// let ret = VueOxcParser::new(&allocator, source).parse();
+  /// let ret = Parser::new(&allocator, source).parse();
   /// assert!(!ret.panicked);
   /// assert!(ret.errors.is_empty());
   /// ```
   #[must_use]
-  pub fn parse(self) -> VueParserReturn<'a> {
+  pub fn parse(self) -> ParserReturn<'a> {
     let ParserImplReturn { program, errors, fatal, module_record, irregular_whitespaces } =
       ParserImpl::new(self.allocator, self.source_text, self.options, ParseConfig::default())
         .parse();
 
     if fatal {
-      VueParserReturn {
+      ParserReturn {
         program: Program::dummy(self.allocator),
         module_record, // Dummy one if fatal, can be directly passed there without recreate a new one
         errors,
@@ -112,7 +112,7 @@ impl<'a> VueOxcParser<'a> {
         panicked: true,
       }
     } else {
-      VueParserReturn { program, errors, panicked: false, irregular_whitespaces, module_record }
+      ParserReturn { program, errors, panicked: false, irregular_whitespaces, module_record }
     }
   }
 }

--- a/crates/vue_oxlint_jsx/src/parser/interface.rs
+++ b/crates/vue_oxlint_jsx/src/parser/interface.rs
@@ -7,19 +7,19 @@ use oxc_syntax::module_record::ModuleRecord;
 
 use crate::parser::{ParseConfig, ParserImpl, ParserImplReturn};
 
-pub struct Parser<'a> {
+pub struct VueJsxParser<'a> {
   allocator: &'a Allocator,
   source_text: &'a str,
   options: ParseOptions,
 }
 
-/// The return value of [`Parser::parse`].
+/// The return value of [`VueJsxParser::parse`].
 ///
 /// Mirrors [`oxc_parser::ParserReturn`] as a workaround for its
 /// `#[non_exhaustive]` attribute. The `is_flow_language` field is intentionally
 /// omitted because Vue does not support Flow.
 #[non_exhaustive]
-pub struct ParserReturn<'a> {
+pub struct VueJsxParserReturn<'a> {
   pub program: Program<'a>,
   pub module_record: ModuleRecord<'a>,
   pub errors: Vec<OxcDiagnostic>,
@@ -27,17 +27,17 @@ pub struct ParserReturn<'a> {
   pub panicked: bool,
 }
 
-impl<'a> Parser<'a> {
-  /// Creates a new [`Parser`] for the given Vue SFC `source_text`.
+impl<'a> VueJsxParser<'a> {
+  /// Creates a new [`VueJsxParser`] for the given Vue SFC `source_text`.
   ///
   /// The `allocator` must outlive the returned parser and the resulting
-  /// [`ParserReturn`], because the produced AST nodes are arena-allocated.
+  /// [`VueJsxParserReturn`], because the produced AST nodes are arena-allocated.
   ///
   /// # Examples
   ///
   /// ```
   /// use oxc_allocator::Allocator;
-  /// use vue_oxlint_jsx::Parser;
+  /// use vue_oxlint_jsx::VueJsxParser;
   ///
   /// let allocator = Allocator::default();
   /// let source = r#"<template><div>{{ msg }}</div></template>
@@ -45,7 +45,7 @@ impl<'a> Parser<'a> {
   /// const msg = 'hello';
   /// </script>"#;
   ///
-  /// let ret = Parser::new(&allocator, source).parse();
+  /// let ret = VueJsxParser::new(&allocator, source).parse();
   /// assert!(!ret.panicked);
   /// ```
   pub fn new(allocator: &'a Allocator, source_text: &'a str) -> Self {
@@ -59,13 +59,13 @@ impl<'a> Parser<'a> {
   /// ```
   /// use oxc_allocator::Allocator;
   /// use oxc_parser::ParseOptions;
-  /// use vue_oxlint_jsx::Parser;
+  /// use vue_oxlint_jsx::VueJsxParser;
   ///
   /// let allocator = Allocator::default();
   /// let source = "<script setup lang=\"ts\">const n: number = 1;</script>";
   ///
   /// let options = ParseOptions { parse_regular_expression: true, ..ParseOptions::default() };
-  /// let ret = Parser::new(&allocator, source).with_options(options).parse();
+  /// let ret = VueJsxParser::new(&allocator, source).with_options(options).parse();
   /// assert!(!ret.panicked);
   /// ```
   #[must_use]
@@ -75,36 +75,36 @@ impl<'a> Parser<'a> {
   }
 }
 
-impl<'a> Parser<'a> {
-  /// Parses the Vue SFC and returns a [`ParserReturn`] containing the
+impl<'a> VueJsxParser<'a> {
+  /// Parses the Vue SFC and returns a [`VueJsxParserReturn`] containing the
   /// JS/TS [`Program`], the [`ModuleRecord`], collected diagnostics, and any
   /// irregular whitespace spans found in the source.
   ///
-  /// On a fatal parse failure, [`ParserReturn::panicked`] is `true` and
-  /// [`ParserReturn::program`] is a dummy program; callers should inspect
-  /// [`ParserReturn::errors`] in that case.
+  /// On a fatal parse failure, [`VueJsxParserReturn::panicked`] is `true` and
+  /// [`VueJsxParserReturn::program`] is a dummy program; callers should inspect
+  /// [`VueJsxParserReturn::errors`] in that case.
   ///
   /// # Examples
   ///
   /// ```
   /// use oxc_allocator::Allocator;
-  /// use vue_oxlint_jsx::Parser;
+  /// use vue_oxlint_jsx::VueJsxParser;
   ///
   /// let allocator = Allocator::default();
   /// let source = r#"<script setup>const count = 1;</script>"#;
   ///
-  /// let ret = Parser::new(&allocator, source).parse();
+  /// let ret = VueJsxParser::new(&allocator, source).parse();
   /// assert!(!ret.panicked);
   /// assert!(ret.errors.is_empty());
   /// ```
   #[must_use]
-  pub fn parse(self) -> ParserReturn<'a> {
+  pub fn parse(self) -> VueJsxParserReturn<'a> {
     let ParserImplReturn { program, errors, fatal, module_record, irregular_whitespaces } =
       ParserImpl::new(self.allocator, self.source_text, self.options, ParseConfig::default())
         .parse();
 
     if fatal {
-      ParserReturn {
+      VueJsxParserReturn {
         program: Program::dummy(self.allocator),
         module_record, // Dummy one if fatal, can be directly passed there without recreate a new one
         errors,
@@ -112,7 +112,7 @@ impl<'a> Parser<'a> {
         panicked: true,
       }
     } else {
-      ParserReturn { program, errors, panicked: false, irregular_whitespaces, module_record }
+      VueJsxParserReturn { program, errors, panicked: false, irregular_whitespaces, module_record }
     }
   }
 }

--- a/crates/vue_oxlint_jsx/src/parser/irregular_whitespaces.rs
+++ b/crates/vue_oxlint_jsx/src/parser/irregular_whitespaces.rs
@@ -15,7 +15,7 @@ pub fn collect_irregular_whitespaces(source_text: &str) -> Box<[Span]> {
 
 #[cfg(test)]
 mod tests {
-  use crate::Parser;
+  use crate::VueJsxParser;
   use oxc_allocator::Allocator;
 
   #[test]
@@ -23,7 +23,7 @@ mod tests {
     let allocator = Allocator::default();
     // \u{000B} is vertical tab, an irregular whitespace
     let source_text = "<div>\u{000B}</div>";
-    let parser = Parser::new(&allocator, source_text);
+    let parser = VueJsxParser::new(&allocator, source_text);
     let ret = parser.parse();
     assert_eq!(ret.irregular_whitespaces.len(), 1);
     assert_eq!(ret.irregular_whitespaces[0].start, 5);

--- a/crates/vue_oxlint_jsx/src/parser/irregular_whitespaces.rs
+++ b/crates/vue_oxlint_jsx/src/parser/irregular_whitespaces.rs
@@ -15,7 +15,7 @@ pub fn collect_irregular_whitespaces(source_text: &str) -> Box<[Span]> {
 
 #[cfg(test)]
 mod tests {
-  use crate::VueOxcParser;
+  use crate::Parser;
   use oxc_allocator::Allocator;
 
   #[test]
@@ -23,7 +23,7 @@ mod tests {
     let allocator = Allocator::default();
     // \u{000B} is vertical tab, an irregular whitespace
     let source_text = "<div>\u{000B}</div>";
-    let parser = VueOxcParser::new(&allocator, source_text);
+    let parser = Parser::new(&allocator, source_text);
     let ret = parser.parse();
     assert_eq!(ret.irregular_whitespaces.len(), 1);
     assert_eq!(ret.irregular_whitespaces[0].start, 5);

--- a/crates/vue_oxlint_jsx/src/parser/mod.rs
+++ b/crates/vue_oxlint_jsx/src/parser/mod.rs
@@ -19,7 +19,7 @@ mod modules;
 mod parse;
 mod script;
 
-pub use interface::{Parser, ParserReturn};
+pub use interface::{VueJsxParser, VueJsxParserReturn};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ParseConfig {

--- a/crates/vue_oxlint_jsx/src/parser/mod.rs
+++ b/crates/vue_oxlint_jsx/src/parser/mod.rs
@@ -19,7 +19,7 @@ mod modules;
 mod parse;
 mod script;
 
-pub use interface::{VueOxcParser, VueParserReturn};
+pub use interface::{Parser, ParserReturn};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ParseConfig {

--- a/crates/vue_oxlint_jsx/src/test/mod.rs
+++ b/crates/vue_oxlint_jsx/src/test/mod.rs
@@ -102,10 +102,10 @@ pub fn read_file(file_path: &str) -> String {
 }
 
 pub fn run_codegen_test(file_path: &str) {
-  use crate::Codegen;
+  use crate::VueJsxCodegen;
 
   let source_text = read_file(file_path);
-  let ret = Codegen::new(&source_text).build();
+  let ret = VueJsxCodegen::new(&source_text).build();
   assert!(!ret.panicked, "Codegen unexpectedly panicked for {file_path}");
   let codegen = ret.source_text;
 

--- a/crates/vue_oxlint_jsx/src/test/mod.rs
+++ b/crates/vue_oxlint_jsx/src/test/mod.rs
@@ -102,10 +102,10 @@ pub fn read_file(file_path: &str) -> String {
 }
 
 pub fn run_codegen_test(file_path: &str) {
-  use crate::{CodegenMode, VueOxcCodegen};
+  use crate::Codegen;
 
   let source_text = read_file(file_path);
-  let ret = VueOxcCodegen::new(&source_text).build(CodegenMode::new());
+  let ret = Codegen::new(&source_text).build();
   assert!(!ret.panicked, "Codegen unexpectedly panicked for {file_path}");
   let codegen = ret.source_text;
 

--- a/packages/vue-oxlint-toolkit/src/lib.rs
+++ b/packages/vue-oxlint-toolkit/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all)]
 
 use oxc_ast::ast::CommentKind;
-use vue_oxlint_jsx::Codegen;
+use vue_oxlint_jsx::VueJsxCodegen;
 
 use napi_derive::napi;
 
@@ -41,7 +41,7 @@ pub struct NativeTransformResult {
 #[must_use]
 #[allow(clippy::needless_pass_by_value, reason = "N-API owns string arguments at the boundary.")]
 pub fn transform_jsx(source: String) -> NativeTransformResult {
-  let ret = Codegen::new(&source).build();
+  let ret = VueJsxCodegen::new(&source).build();
   let script_kind = if ret.source_type.is_typescript() { "tsx" } else { "jsx" }.to_string();
 
   NativeTransformResult {

--- a/packages/vue-oxlint-toolkit/src/lib.rs
+++ b/packages/vue-oxlint-toolkit/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all)]
 
 use oxc_ast::ast::CommentKind;
-use vue_oxlint_jsx::{CodegenMode, VueOxcCodegen};
+use vue_oxlint_jsx::Codegen;
 
 use napi_derive::napi;
 
@@ -41,7 +41,7 @@ pub struct NativeTransformResult {
 #[must_use]
 #[allow(clippy::needless_pass_by_value, reason = "N-API owns string arguments at the boundary.")]
 pub fn transform_jsx(source: String) -> NativeTransformResult {
-  let ret = VueOxcCodegen::new(&source).build(CodegenMode::new());
+  let ret = Codegen::new(&source).build();
   let script_kind = if ret.source_type.is_typescript() { "tsx" } else { "jsx" }.to_string();
 
   NativeTransformResult {


### PR DESCRIPTION
## Summary
- Renames the public surface of `vue_oxlint_jsx` so the crate exposes exactly **two generator structs** (`VueJsxParser`, `VueJsxCodegen`) and their two **return pairs** (`VueJsxParserReturn`, `VueJsxCodegenReturn`).
- Drops the unit-marker `CodegenMode`; `VueJsxCodegen::build` now takes no argument.
- The `VueJsx` prefix avoids shadowing common names (`Parser`/`Codegen`) in consumers, and means we don't have to alias `oxc_codegen::Codegen` internally.

### Renames
| Before | After |
| --- | --- |
| `VueOxcParser` | `VueJsxParser` |
| `VueParserReturn` | `VueJsxParserReturn` |
| `VueOxcCodegen` | `VueJsxCodegen` |
| `VueOxcCodegenReturn` | `VueJsxCodegenReturn` |
| `CodegenMode` | _removed_ |

All in-tree consumers are updated: the `benchmark` crate, the `vue-oxlint-toolkit` napi crate, the test harness, and doctests.

This is a **breaking change** for downstream consumers of `vue_oxlint_jsx`.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (incl. doctests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)