### PR TITLE
refactor!: remove JSXText support

### DIFF
--- a/crates/vue_oxlint_jsx/MAPPING.md
+++ b/crates/vue_oxlint_jsx/MAPPING.md
@@ -205,6 +205,8 @@ The `Comp` element's children contain a `JSXExpressionContainer` holding an `Obj
 - **Plain Text**: Dropped. The parser does not emit JSX nodes for template text.
 - **Interpolation** (`{{ msg }}`): Mapped to `JSXExpressionContainer` containing the JavaScript expression.
 
+This behavior changed in [PR #44](https://github.com/liangmiQwQ/vue-oxlint-toolkit/pull/44), which removed `JSXText` support from both parser and codegen outputs.
+
 ## Comments
 
 Template comments are captured as AST comments. They are represented by empty `JSXExpressionContainer` nodes to maintain their relative position in the tree.

--- a/crates/vue_oxlint_jsx/MAPPING.md
+++ b/crates/vue_oxlint_jsx/MAPPING.md
@@ -202,10 +202,8 @@ The `Comp` element's children contain a `JSXExpressionContainer` holding an `Obj
 
 ## Text and Interpolation
 
-- **Plain Text**: Dropped. The parser does not emit JSX nodes for template text.
+- **Plain Text**: Dropped. The parser does not emit JSX nodes for template text. Learn more in [PR #44](https://github.com/liangmiQwQ/vue-oxlint-toolkit/pull/44).
 - **Interpolation** (`{{ msg }}`): Mapped to `JSXExpressionContainer` containing the JavaScript expression.
-
-This behavior changed in [PR #44](https://github.com/liangmiQwQ/vue-oxlint-toolkit/pull/44), which removed `JSXText` support from both parser and codegen outputs.
 
 ## Comments
 

--- a/crates/vue_oxlint_jsx/MAPPING.md
+++ b/crates/vue_oxlint_jsx/MAPPING.md
@@ -202,7 +202,7 @@ The `Comp` element's children contain a `JSXExpressionContainer` holding an `Obj
 
 ## Text and Interpolation
 
-- **Plain Text**: Mapped to `JSXText`.
+- **Plain Text**: Dropped. The parser does not emit JSX nodes for template text.
 - **Interpolation** (`{{ msg }}`): Mapped to `JSXExpressionContainer` containing the JavaScript expression.
 
 ## Comments

--- a/crates/vue_oxlint_jsx/src/parser/codegen.rs
+++ b/crates/vue_oxlint_jsx/src/parser/codegen.rs
@@ -1,33 +1,8 @@
-use oxc_ast::ast::{JSXChild, Str};
-use oxc_span::Span;
+use oxc_ast::ast::Str;
 
 use crate::parser::ParserImpl;
 
 impl<'a> ParserImpl<'a> {
-  #[inline]
-  pub fn jsx_child_text(&self, span: Span, str: &str) -> JSXChild<'a> {
-    let ast_str = if self.config.codegen {
-      let bytes = str.as_bytes();
-      let mut vec: Vec<u8> = Vec::with_capacity(bytes.len());
-      for &b in bytes {
-        match b {
-          b'&' => vec.extend_from_slice(b"&amp;"),
-          b'<' => vec.extend_from_slice(b"&lt;"),
-          b'>' => vec.extend_from_slice(b"&gt;"),
-          b'{' => vec.extend_from_slice(b"&#123;"),
-          b'}' => vec.extend_from_slice(b"&#125;"),
-          _ => vec.push(b),
-        }
-      }
-      let escaped = unsafe { str::from_utf8_unchecked(&vec) };
-      self.ast.str(escaped)
-    } else {
-      self.ast.str(str)
-    };
-
-    self.ast.jsx_child_text(span, ast_str, Some(ast_str))
-  }
-
   pub(super) fn codegen_directive_identifier(&self, name: &'a str) -> Str<'a> {
     if !self.config.codegen || is_codegen_safe_jsx_identifier(name) {
       return name.into();

--- a/crates/vue_oxlint_jsx/src/parser/elements/mod.rs
+++ b/crates/vue_oxlint_jsx/src/parser/elements/mod.rs
@@ -65,7 +65,9 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
       && start != first.get_location().start.offset as u32
     {
       let span = Span::new(start, first.get_location().start.offset as u32);
-      result.push(self.jsx_child_text(span, span.source_text(self.source_text)));
+      if let Some(text) = self.parse_text_span(span) {
+        result.push(text);
+      }
     }
 
     let last = if let Some(last) = children.last()
@@ -73,7 +75,7 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
       && end != last.get_location().end.offset as u32
     {
       let span = Span::new(last.get_location().end.offset as u32, end);
-      Some(self.jsx_child_text(span, span.source_text(self.source_text)))
+      self.parse_text_span(span)
     } else {
       None
     };
@@ -99,7 +101,11 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
             result.push(child);
           }
         }
-        AstNode::Text(text) => result.push(self.parse_text(&text)),
+        AstNode::Text(text) => {
+          if let Some(text) = self.parse_text(&text) {
+            result.push(text);
+          }
+        }
         AstNode::Comment(comment) => result.push(self.parse_comment(&comment)),
         AstNode::Interpolation(interp) => result.push(self.parse_interpolation(&interp)),
       }
@@ -422,8 +428,24 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
     }
   }
 
-  fn parse_text(&self, text: &TextNode<'a>) -> JSXChild<'a> {
-    self.jsx_child_text(text.location.span(), &text.text.iter().map(|t| t.raw).collect::<String>())
+  fn parse_text(&self, text: &TextNode<'a>) -> Option<JSXChild<'a>> {
+    if self.config.codegen {
+      None
+    } else {
+      let content = text.text.iter().map(|t| t.raw).collect::<String>();
+      let ast_str = self.ast.str(&content);
+      Some(self.ast.jsx_child_text(text.location.span(), ast_str, Some(ast_str)))
+    }
+  }
+
+  pub(super) fn parse_text_span(&self, span: Span) -> Option<JSXChild<'a>> {
+    if self.config.codegen {
+      None
+    } else {
+      let text = span.source_text(self.source_text);
+      let ast_str = self.ast.str(text);
+      Some(self.ast.jsx_child_text(span, ast_str, Some(ast_str)))
+    }
   }
 
   fn parse_comment(&mut self, comment: &SourceNode<'a>) -> JSXChild<'a> {

--- a/crates/vue_oxlint_jsx/src/parser/elements/mod.rs
+++ b/crates/vue_oxlint_jsx/src/parser/elements/mod.rs
@@ -4,9 +4,7 @@ use oxc_ast::{
   ast::{Expression, JSXAttributeItem, JSXChild, JSXExpression, PropertyKind, Statement},
 };
 use oxc_span::{GetSpanMut, SPAN, Span};
-use vue_compiler_core::parser::{
-  AstNode, Directive, DirectiveArg, ElemProp, Element, SourceNode, TextNode,
-};
+use vue_compiler_core::parser::{AstNode, Directive, DirectiveArg, ElemProp, Element, SourceNode};
 
 use crate::{
   is_void_tag,
@@ -49,8 +47,8 @@ fn kebab_to_case(s: &str, pascal: bool) -> String {
 impl<'a: 'b, 'b> ParserImpl<'a> {
   fn parse_children(
     &mut self,
-    start: u32,
-    end: u32,
+    _start: u32,
+    _end: u32,
     children: Vec<AstNode<'a>>,
   ) -> ArenaVec<'a, JSXChild<'a>> {
     let ast = self.ast;
@@ -58,27 +56,6 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
       return ast.vec();
     }
     let mut result = self.ast.vec_with_capacity(children.len() + 2);
-
-    // Process the whitespaces text there <div>____<br>_____</div>
-    if let Some(first) = children.first()
-      && matches!(first, AstNode::Element(_) | AstNode::Interpolation(_))
-      && start != first.get_location().start.offset as u32
-    {
-      let span = Span::new(start, first.get_location().start.offset as u32);
-      if let Some(text) = self.parse_text_span(span) {
-        result.push(text);
-      }
-    }
-
-    let last = if let Some(last) = children.last()
-      && matches!(last, AstNode::Element(_) | AstNode::Interpolation(_))
-      && end != last.get_location().end.offset as u32
-    {
-      let span = Span::new(last.get_location().end.offset as u32, end);
-      self.parse_text_span(span)
-    } else {
-      None
-    };
 
     let mut v_if_manager = VIfManager::new(&ast);
     for child in children {
@@ -101,11 +78,7 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
             result.push(child);
           }
         }
-        AstNode::Text(text) => {
-          if let Some(text) = self.parse_text(&text) {
-            result.push(text);
-          }
-        }
+        AstNode::Text(_) => {}
         AstNode::Comment(comment) => result.push(self.parse_comment(&comment)),
         AstNode::Interpolation(interp) => result.push(self.parse_interpolation(&interp)),
       }
@@ -115,10 +88,6 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
       // If the last element is v-if / v-else-if / v-else, push all the children
       result.push(chain);
     }
-    if let Some(last) = last {
-      result.push(last);
-    }
-
     result
   }
 
@@ -425,26 +394,6 @@ impl<'a: 'b, 'b> ParserImpl<'a> {
       JSXExpression::from(self.ast.expression_identifier(SPAN, "undefined"))
     } else {
       self.ast.jsx_expression_empty_expression(SPAN)
-    }
-  }
-
-  fn parse_text(&self, text: &TextNode<'a>) -> Option<JSXChild<'a>> {
-    if self.config.codegen {
-      None
-    } else {
-      let content = text.text.iter().map(|t| t.raw).collect::<String>();
-      let ast_str = self.ast.str(&content);
-      Some(self.ast.jsx_child_text(text.location.span(), ast_str, Some(ast_str)))
-    }
-  }
-
-  pub(super) fn parse_text_span(&self, span: Span) -> Option<JSXChild<'a>> {
-    if self.config.codegen {
-      None
-    } else {
-      let text = span.source_text(self.source_text);
-      let ast_str = self.ast.str(text);
-      Some(self.ast.jsx_child_text(span, ast_str, Some(ast_str)))
     }
   }
 

--- a/crates/vue_oxlint_jsx/src/parser/parse.rs
+++ b/crates/vue_oxlint_jsx/src/parser/parse.rs
@@ -184,7 +184,7 @@ impl<'a> ParserImpl<'a> {
                 last.get_location().end.offset as u32,
               );
 
-              self.ast.vec1(self.jsx_child_text(span, span.source_text(self.source_text)))
+              self.parse_text_span(span).map_or_else(|| self.ast.vec(), |text| self.ast.vec1(text))
             } else {
               self.ast.vec()
             };
@@ -224,9 +224,8 @@ impl<'a> ParserImpl<'a> {
   }
 
   fn push_text_child(&self, children: &mut Vec<ParsingChild<'a>>, span: Span) {
-    if !span.is_empty() {
-      children
-        .push(ParsingChild::Finish(self.jsx_child_text(span, span.source_text(self.source_text))));
+    if let Some(text) = (!span.is_empty()).then(|| self.parse_text_span(span)).flatten() {
+      children.push(ParsingChild::Finish(text));
     }
   }
 }

--- a/crates/vue_oxlint_jsx/src/parser/parse.rs
+++ b/crates/vue_oxlint_jsx/src/parser/parse.rs
@@ -147,11 +147,7 @@ impl<'a> ParserImpl<'a> {
     let mut source_types: HashSet<&str> = HashSet::new();
     for child in result.children {
       if let AstNode::Element(node) = child {
-        // Process the texts between last element and current element
-        self.push_text_child(
-          &mut raw_children,
-          Span::new(text_start, node.location.start.offset as u32),
-        );
+        // Template text nodes are intentionally ignored.
         text_start = node.location.end.offset as u32;
 
         raw_children.push(if node.tag_name == "script" {
@@ -163,8 +159,7 @@ impl<'a> ParserImpl<'a> {
         });
       }
     }
-    // Process the texts after last element
-    self.push_text_child(&mut raw_children, Span::new(text_start, self.source_text.len() as u32));
+    let _ = text_start;
 
     // Parse the skip ones
     let mut children: ArenaVec<'a, JSXChild<'a>> = self.ast.vec();
@@ -176,20 +171,7 @@ impl<'a> ParserImpl<'a> {
           if node.tag_name == "template" {
             self.parse_element(node, None).0
           } else {
-            // Process other tags like <style>
-            let text = if let Some(first) = node.children.first() {
-              let last = node.children.last().unwrap(); // SAFETY: if first exists, last must exist
-              let span = Span::new(
-                first.get_location().start.offset as u32,
-                last.get_location().end.offset as u32,
-              );
-
-              self.parse_text_span(span).map_or_else(|| self.ast.vec(), |text| self.ast.vec1(text))
-            } else {
-              self.ast.vec()
-            };
-
-            self.parse_element(node, Some(text)).0
+            self.parse_element(node, Some(self.ast.vec())).0
           }
         }
       });
@@ -221,12 +203,6 @@ impl<'a> ParserImpl<'a> {
 
       a_first.offset().cmp(&b_first.offset())
     });
-  }
-
-  fn push_text_child(&self, children: &mut Vec<ParsingChild<'a>>, span: Span) {
-    if let Some(text) = (!span.is_empty()).then(|| self.parse_text_span(span)).flatten() {
-      children.push(ParsingChild::Finish(text));
-    }
   }
 }
 

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/basic_vue.snap
@@ -201,21 +201,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -252,21 +237,6 @@ Program {
                                                                                         },
                                                                                         children: Vec(
                                                                                             [
-                                                                                                Text(
-                                                                                                    JSXText {
-                                                                                                        span: Span {
-                                                                                                            start: 18,
-                                                                                                            end: 23,
-                                                                                                        },
-                                                                                                        node_id: Cell {
-                                                                                                            value: NodeId(0),
-                                                                                                        },
-                                                                                                        value: "\n    ",
-                                                                                                        raw: Some(
-                                                                                                            "\n    ",
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
                                                                                                 ExpressionContainer(
                                                                                                     JSXExpressionContainer {
                                                                                                         span: Span {
@@ -290,21 +260,6 @@ Program {
                                                                                                                 },
                                                                                                                 name: "count",
                                                                                                             },
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
-                                                                                                Text(
-                                                                                                    JSXText {
-                                                                                                        span: Span {
-                                                                                                            start: 34,
-                                                                                                            end: 37,
-                                                                                                        },
-                                                                                                        node_id: Cell {
-                                                                                                            value: NodeId(0),
-                                                                                                        },
-                                                                                                        value: "\n  ",
-                                                                                                        raw: Some(
-                                                                                                            "\n  ",
                                                                                                         ),
                                                                                                     },
                                                                                                 ),
@@ -335,21 +290,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 43,
-                                                                                            end: 44,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -374,21 +314,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 55,
-                                                                            end: 57,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -518,21 +443,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 108,
-                                                                            end: 110,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -568,23 +478,7 @@ Program {
                                                                             ),
                                                                         },
                                                                         children: Vec(
-                                                                            [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 117,
-                                                                                            end: 140,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\ndiv {\n  color: red;\n}\n",
-                                                                                        raw: Some(
-                                                                                            "\ndiv {\n  color: red;\n}\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                            ],
+                                                                            [],
                                                                         ),
                                                                         closing_element: Some(
                                                                             JSXClosingElement {
@@ -608,21 +502,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 148,
-                                                                            end: 149,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -670,20 +549,7 @@ Program {
 =============== Codegen ===============
 async () => {
 	const count = 1;
-	<><template>
-  <div>
-    {count}
-  </div>
-</template>
-
-<script lang="js" setup></script>
-
-<style>
-div {
-  color: red;
-}
-</style>
-</>;
+	<><template><div>{count}</div></template><script lang="js" setup></script><style></style></>;
 };
 
 
@@ -720,10 +586,6 @@ Slice: "template";
 Span: (1, 9); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
-
 Slice: "<div>\n    {{ count }}\n  </div>"; 
 Span: (13, 43); 
 Type: JSXElement; 
@@ -736,10 +598,6 @@ Slice: "div";
 Span: (14, 17); 
 Type: JSXIdentifier; 
 
-Slice: "\n    "; 
-Span: (18, 23); 
-Type: JSXText; 
-
 Slice: "{{ count }}"; 
 Span: (23, 34); 
 Type: JSXExpressionContainer; 
@@ -747,10 +605,6 @@ Type: JSXExpressionContainer;
 Slice: "count"; 
 Span: (26, 31); 
 Type: IdentifierReference; 
-
-Slice: "\n  "; 
-Span: (34, 37); 
-Type: JSXText; 
 
 Slice: "</div>"; 
 Span: (37, 43); 
@@ -760,10 +614,6 @@ Slice: "div";
 Span: (39, 42); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (43, 44); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (44, 55); 
 Type: JSXClosingElement; 
@@ -771,10 +621,6 @@ Type: JSXClosingElement;
 Slice: "template"; 
 Span: (46, 54); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (55, 57); 
-Type: JSXText; 
 
 Slice: "<script lang=\"js\" setup>\nconst count = 1;\n</script>"; 
 Span: (57, 108); 
@@ -816,10 +662,6 @@ Slice: "script";
 Span: (101, 107); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n"; 
-Span: (108, 110); 
-Type: JSXText; 
-
 Slice: "<style>\ndiv {\n  color: red;\n}\n</style>"; 
 Span: (110, 148); 
 Type: JSXElement; 
@@ -832,18 +674,10 @@ Slice: "style";
 Span: (111, 116); 
 Type: JSXIdentifier; 
 
-Slice: "\ndiv {\n  color: red;\n}\n"; 
-Span: (117, 140); 
-Type: JSXText; 
-
 Slice: "</style>"; 
 Span: (140, 148); 
 Type: JSXClosingElement; 
 
 Slice: "style"; 
 Span: (142, 147); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (148, 149); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/comments_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/comments_vue.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/mod.rs
-assertion_line: 98
 expression: result
 ---
 =============== Program ===============
@@ -219,21 +218,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -391,21 +375,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 89,
-                                                                                            end: 90,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -430,21 +399,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 101,
-                                                                            end: 103,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -547,21 +501,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 222,
-                                                                            end: 224,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -691,21 +630,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 281,
-                                                                            end: 282,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                             ],
                                                         ),
                                                         closing_fragment: JSXClosingFragment {
@@ -749,14 +673,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  <div v-bind:key={1}>{}</div>
-</template>
-
-<script lang="ts"></script>
-
-<script lang="ts" setup></script>
-</>;
+	<><template><div v-bind:key={1}>{}</div></template><script lang="ts"></script><script lang="ts" setup></script></>;
 };
 
 
@@ -776,10 +693,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
 
 Slice: "<div :key=\"1 /* vue is full of magic */\">\n    <!-- Good Morning -->\n  </div>"; 
 Span: (13, 89); 
@@ -829,10 +742,6 @@ Slice: "div";
 Span: (85, 88); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (89, 90); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (90, 101); 
 Type: JSXClosingElement; 
@@ -840,10 +749,6 @@ Type: JSXClosingElement;
 Slice: "template"; 
 Span: (92, 100); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (101, 103); 
-Type: JSXText; 
 
 Slice: "<script lang=\"ts\">\n// Hello, everyone\n/*..[OMIT]..nd Rust!\n  What about you?\n */\n</script>"; 
 Span: (103, 222); 
@@ -876,10 +781,6 @@ Type: JSXClosingElement;
 Slice: "script"; 
 Span: (215, 221); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (222, 224); 
-Type: JSXText; 
 
 Slice: "<script lang=\"ts\" setup>\n// Hello\n/* Me too! */\n</script>"; 
 Span: (224, 281); 
@@ -919,8 +820,4 @@ Type: JSXClosingElement;
 
 Slice: "script"; 
 Span: (274, 280); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (281, 282); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/components_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/components_vue.snap
@@ -268,21 +268,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -348,21 +333,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 30,
-                                                                                            end: 33,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -425,21 +395,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 51,
-                                                                                            end: 54,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -511,21 +466,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 79,
-                                                                                            end: 82,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -591,21 +531,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 105,
-                                                                                            end: 108,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -719,21 +644,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 133,
-                                                                                            end: 134,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -758,21 +668,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 145,
-                                                                            end: 147,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -902,21 +797,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 264,
-                                                                            end: 265,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                             ],
                                                         ),
                                                         closing_fragment: JSXClosingFragment {
@@ -962,16 +842,7 @@ Program {
 import SomeComponent from "./SomeComponent.vue";
 import { motion } from "motion-v";
 async () => {
-	<><template>
-  <SomeComponent></>
-  <SomeComponent></>
-  <Transition></Transition>
-  <component></component>
-  <motion.div></motion.div>
-</template>
-
-<script lang="ts" setup></script>
-</>;
+	<><template><SomeComponent></><SomeComponent></><Transition></Transition><component></component><motion.div></motion.div></template><script lang="ts" setup></script></>;
 };
 
 
@@ -1028,10 +899,6 @@ Slice: "template";
 Span: (1, 9); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
-
 Slice: "<SomeComponent />"; 
 Span: (13, 30); 
 Type: JSXElement; 
@@ -1044,10 +911,6 @@ Slice: "SomeComponent";
 Span: (14, 27); 
 Type: IdentifierReference; 
 
-Slice: "\n  "; 
-Span: (30, 33); 
-Type: JSXText; 
-
 Slice: "<some-component />"; 
 Span: (33, 51); 
 Type: JSXElement; 
@@ -1059,10 +922,6 @@ Type: JSXOpeningElement;
 Slice: "some-component"; 
 Span: (34, 48); 
 Type: IdentifierReference; 
-
-Slice: "\n  "; 
-Span: (51, 54); 
-Type: JSXText; 
 
 Slice: "<Transition></Transition>"; 
 Span: (54, 79); 
@@ -1084,10 +943,6 @@ Slice: "Transition";
 Span: (68, 78); 
 Type: IdentifierReference; 
 
-Slice: "\n  "; 
-Span: (79, 82); 
-Type: JSXText; 
-
 Slice: "<component></component>"; 
 Span: (82, 105); 
 Type: JSXElement; 
@@ -1107,10 +962,6 @@ Type: JSXClosingElement;
 Slice: "component"; 
 Span: (95, 104); 
 Type: IdentifierReference; 
-
-Slice: "\n  "; 
-Span: (105, 108); 
-Type: JSXText; 
 
 Slice: "<motion.div></motion.div>"; 
 Span: (108, 133); 
@@ -1148,10 +999,6 @@ Slice: "div";
 Span: (116, 119); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (133, 134); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (134, 145); 
 Type: JSXClosingElement; 
@@ -1159,10 +1006,6 @@ Type: JSXClosingElement;
 Slice: "template"; 
 Span: (136, 144); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (145, 147); 
-Type: JSXText; 
 
 Slice: "<script lang=\"ts\" setup>\nimport SomeComp..[OMIT]..ort { motion } from 'motion-v'\n</script>"; 
 Span: (147, 264); 
@@ -1202,8 +1045,4 @@ Type: JSXClosingElement;
 
 Slice: "script"; 
 Span: (257, 263); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (264, 265); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_basic_vue.snap
@@ -139,21 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -285,21 +270,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 37,
-                                                                                            end: 40,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -479,21 +449,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 59,
-                                                                                            end: 62,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -849,21 +804,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 87,
-                                                                                            end: 90,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -994,21 +934,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 114,
-                                                                                            end: 117,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1149,21 +1074,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 146,
-                                                                                            end: 149,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -1297,21 +1207,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 160,
-                                                                                            end: 163,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -1442,21 +1337,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 178,
-                                                                                            end: 181,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1635,21 +1515,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 227,
-                                                                                            end: 230,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -1779,21 +1644,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 255,
-                                                                                            end: 258,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1930,21 +1780,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 277,
-                                                                                            end: 278,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -1969,21 +1804,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 289,
-                                                                            end: 290,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -2028,22 +1848,10 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  <div v-bind:class={"w-100"}></>
-  <div v-bind:[some]={{ [some]: 2 }}></>
-  <Some v-slot:default={}>{{ default: ({ a }) => <></> }}</>
-  <input v-model:={text}></>
-  <Some v-bind:some.none={1}></>
-  <div v-bind:id={id}></>
-  <div v-bind:msg-id={msgId}></>
-  <div {...{
+	<><template><div v-bind:class={"w-100"}></><div v-bind:[some]={{ [some]: 2 }}></><Some v-slot:default={}>{{ default: ({ a }) => <></> }}</><input v-model:={text}></><Some v-bind:some.none={1}></><div v-bind:id={id}></><div v-bind:msg-id={msgId}></><div {...{
 		id: "app",
 		class: "w-100"
-	}}></>
-  <div {...{ id: "app" }}></>
-  <div v-bind:1foo={bar}></>
-</template>
-</>;
+	}}></><div {...{ id: "app" }}></><div v-bind:1foo={bar}></></template></>;
 };
 
 
@@ -2063,10 +1871,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
 
 Slice: "<div :class=\"'w-100'\" />"; 
 Span: (13, 37); 
@@ -2103,10 +1907,6 @@ Type: JSXExpressionContainer;
 Slice: "'w-100'"; 
 Span: (26, 33); 
 Type: StringLiteral; 
-
-Slice: "\n  "; 
-Span: (37, 40); 
-Type: JSXText; 
 
 Slice: "<div :[some]=\"2\" />"; 
 Span: (40, 59); 
@@ -2147,10 +1947,6 @@ Type: IdentifierReference;
 Slice: "2"; 
 Span: (54, 55); 
 Type: NumericLiteral; 
-
-Slice: "\n  "; 
-Span: (59, 62); 
-Type: JSXText; 
 
 Slice: "<Some #default=\"{ a }\" />"; 
 Span: (62, 87); 
@@ -2212,10 +2008,6 @@ Slice: "a";
 Span: (80, 81); 
 Type: BindingIdentifier; 
 
-Slice: "\n  "; 
-Span: (87, 90); 
-Type: JSXText; 
-
 Slice: "<input v-model=\"text\" />"; 
 Span: (90, 114); 
 Type: JSXElement; 
@@ -2247,10 +2039,6 @@ Type: JSXExpressionContainer;
 Slice: "text"; 
 Span: (106, 110); 
 Type: IdentifierReference; 
-
-Slice: "\n  "; 
-Span: (114, 117); 
-Type: JSXText; 
 
 Slice: "<Some v-bind:some.none=\"1\" />"; 
 Span: (117, 146); 
@@ -2288,10 +2076,6 @@ Slice: "1";
 Span: (141, 142); 
 Type: NumericLiteral; 
 
-Slice: "\n  "; 
-Span: (146, 149); 
-Type: JSXText; 
-
 Slice: "<div :id />"; 
 Span: (149, 160); 
 Type: JSXElement; 
@@ -2320,10 +2104,6 @@ Slice: "id";
 Span: (155, 157); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (160, 163); 
-Type: JSXText; 
-
 Slice: "<div :msg-id />"; 
 Span: (163, 178); 
 Type: JSXElement; 
@@ -2351,10 +2131,6 @@ Type: JSXIdentifier;
 Slice: "msg-id"; 
 Span: (169, 175); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (178, 181); 
-Type: JSXText; 
 
 Slice: "<div v-bind=\"{ id: 'app', class: 'w-100' }\" />"; 
 Span: (181, 227); 
@@ -2400,10 +2176,6 @@ Slice: "'w-100'";
 Span: (214, 221); 
 Type: StringLiteral; 
 
-Slice: "\n  "; 
-Span: (227, 230); 
-Type: JSXText; 
-
 Slice: "<div :=\"{ id: 'app' }\" />"; 
 Span: (230, 255); 
 Type: JSXElement; 
@@ -2435,10 +2207,6 @@ Type: IdentifierName;
 Slice: "'app'"; 
 Span: (244, 249); 
 Type: StringLiteral; 
-
-Slice: "\n  "; 
-Span: (255, 258); 
-Type: JSXText; 
 
 Slice: "<div :1foo=\"bar\" />"; 
 Span: (258, 277); 
@@ -2476,18 +2244,10 @@ Slice: "bar";
 Span: (270, 273); 
 Type: IdentifierReference; 
 
-Slice: "\n"; 
-Span: (277, 278); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (278, 289); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
 Span: (280, 288); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (289, 290); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-for-error_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-for-error_vue.snap
@@ -139,21 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -280,21 +265,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 29,
-                                                                                            end: 32,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -427,21 +397,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 72,
-                                                                                            end: 75,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -568,21 +523,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 105,
-                                                                                            end: 108,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -715,21 +655,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 144,
-                                                                                            end: 147,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -859,21 +784,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 195,
-                                                                                            end: 196,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -898,21 +808,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 207,
-                                                                            end: 208,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -1093,14 +988,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  <div v-for:={}></>
-  <div v-for:={}></>
-  <div v-for:={}></>
-  <div v-for:={}></>
-  <div v-for:={}></>
-</template>
-</>;
+	<><template><div v-for:={}></><div v-for:={}></><div v-for:={}></><div v-for:={}></><div v-for:={}></></template></>;
 };
 
 
@@ -1120,10 +1008,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
 
 Slice: "<div v-for=\"\" />"; 
 Span: (13, 29); 
@@ -1153,10 +1037,6 @@ Slice: "\"\"";
 Span: (24, 26); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n  "; 
-Span: (29, 32); 
-Type: JSXText; 
-
 Slice: "<div v-for=\"item /* some */in source\" />"; 
 Span: (32, 72); 
 Type: JSXElement; 
@@ -1184,10 +1064,6 @@ Type: JSXIdentifier;
 Slice: "\"item /* some */in source\""; 
 Span: (43, 69); 
 Type: JSXExpressionContainer; 
-
-Slice: "\n  "; 
-Span: (72, 75); 
-Type: JSXText; 
 
 Slice: "<div v-for=\"ehsgrjbegklhuk\" />"; 
 Span: (75, 105); 
@@ -1217,10 +1093,6 @@ Slice: "\"ehsgrjbegklhuk\"";
 Span: (86, 102); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n  "; 
-Span: (105, 108); 
-Type: JSXText; 
-
 Slice: "<div v-for=\"(item, index) source\" />"; 
 Span: (108, 144); 
 Type: JSXElement; 
@@ -1248,10 +1120,6 @@ Type: JSXIdentifier;
 Slice: "\"(item, index) source\""; 
 Span: (119, 141); 
 Type: JSXExpressionContainer; 
-
-Slice: "\n  "; 
-Span: (144, 147); 
-Type: JSXText; 
 
 Slice: "<div v-for=\"(item, index) /* in */ in source\" />"; 
 Span: (147, 195); 
@@ -1281,18 +1149,10 @@ Slice: "\"(item, index) /* in */ in source\"";
 Span: (158, 192); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n"; 
-Span: (195, 196); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (196, 207); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
 Span: (198, 206); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (207, 208); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-for_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-for_vue.snap
@@ -139,21 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 ExpressionContainer(
                                                                                     JSXExpressionContainer {
                                                                                         span: Span {
@@ -444,21 +429,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 43,
-                                                                                            end: 46,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 ExpressionContainer(
                                                                                     JSXExpressionContainer {
                                                                                         span: Span {
@@ -746,21 +716,6 @@ Program {
                                                                                                     ],
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 78,
-                                                                                            end: 81,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1084,21 +1039,6 @@ Program {
                                                                                                     ],
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 123,
-                                                                                            end: 126,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1456,21 +1396,6 @@ Program {
                                                                                                     ],
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 179,
-                                                                                            end: 182,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1838,21 +1763,6 @@ Program {
                                                                                                     ],
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 222,
-                                                                                            end: 225,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -2253,21 +2163,6 @@ Program {
                                                                                                     ],
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 274,
-                                                                                            end: 277,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -2725,21 +2620,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 340,
-                                                                                            end: 343,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 ExpressionContainer(
                                                                                     JSXExpressionContainer {
                                                                                         span: Span {
@@ -3096,21 +2976,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 393,
-                                                                                            end: 396,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 ExpressionContainer(
                                                                                     JSXExpressionContainer {
                                                                                         span: Span {
@@ -3433,21 +3298,6 @@ Program {
                                                                                                     ],
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 440,
-                                                                                            end: 443,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -3803,21 +3653,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 494,
-                                                                                            end: 495,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -3842,21 +3677,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 506,
-                                                                            end: 507,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -3901,19 +3721,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  {source((item) => <div v-for:={}></>)}
-  {source1((item1) => <div v-for:={}></>)}
-  {source2((item2, index2) => <div v-for:={}></>)}
-  {source3((item3 = "1", index3 = 99) => <div v-for:={}></>)}
-  {users4(({ id4, name4 }) => <div v-for:={}></>)}
-  {users5(({ id5, name5 }, index) => <div v-for:={}></>)}
-  {users6(({ id6 = 1, name6 = "Liang" }, index) => <div v-for:={}></>)}
-  {someObj7((key7, value7, index7) => <div v-for:={}></>)}
-  {someIter8(([item8, index8]) => <div v-for:={}></>)}
-  {someIter9(([item9 = "hi", index9]) => <div v-for:={}></>)}
-</template>
-</>;
+	<><template>{source((item) => <div v-for:={}></>)}{source1((item1) => <div v-for:={}></>)}{source2((item2, index2) => <div v-for:={}></>)}{source3((item3 = "1", index3 = 99) => <div v-for:={}></>)}{users4(({ id4, name4 }) => <div v-for:={}></>)}{users5(({ id5, name5 }, index) => <div v-for:={}></>)}{users6(({ id6 = 1, name6 = "Liang" }, index) => <div v-for:={}></>)}{someObj7((key7, value7, index7) => <div v-for:={}></>)}{someIter8(([item8, index8]) => <div v-for:={}></>)}{someIter9(([item9 = "hi", index9]) => <div v-for:={}></>)}</template></>;
 };
 
 
@@ -3933,10 +3741,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
 
 Slice: "source"; 
 Span: (33, 39); 
@@ -3978,10 +3782,6 @@ Slice: "\"item in source\"";
 Span: (24, 40); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n  "; 
-Span: (43, 46); 
-Type: JSXText; 
-
 Slice: "source1"; 
 Span: (67, 74); 
 Type: IdentifierReference; 
@@ -4021,10 +3821,6 @@ Type: JSXIdentifier;
 Slice: "\"item1 of source1\""; 
 Span: (57, 75); 
 Type: JSXExpressionContainer; 
-
-Slice: "\n  "; 
-Span: (78, 81); 
-Type: JSXText; 
 
 Slice: "source2"; 
 Span: (112, 119); 
@@ -4077,10 +3873,6 @@ Type: JSXIdentifier;
 Slice: "\"(item2, index2) in source2\""; 
 Span: (92, 120); 
 Type: JSXExpressionContainer; 
-
-Slice: "\n  "; 
-Span: (123, 126); 
-Type: JSXText; 
 
 Slice: "source3"; 
 Span: (168, 175); 
@@ -4141,10 +3933,6 @@ Type: JSXIdentifier;
 Slice: "\"(item3 = '1', index3 = 99) in source3\""; 
 Span: (137, 176); 
 Type: JSXExpressionContainer; 
-
-Slice: "\n  "; 
-Span: (179, 182); 
-Type: JSXText; 
 
 Slice: "users4"; 
 Span: (212, 218); 
@@ -4209,10 +3997,6 @@ Type: JSXIdentifier;
 Slice: "\"{ id4, name4 } in users4\""; 
 Span: (193, 219); 
 Type: JSXExpressionContainer; 
-
-Slice: "\n  "; 
-Span: (222, 225); 
-Type: JSXText; 
 
 Slice: "users5"; 
 Span: (264, 270); 
@@ -4289,10 +4073,6 @@ Type: JSXIdentifier;
 Slice: "\"({ id5, name5 }, index) in users5\""; 
 Span: (236, 271); 
 Type: JSXExpressionContainer; 
-
-Slice: "\n  "; 
-Span: (274, 277); 
-Type: JSXText; 
 
 Slice: "users6"; 
 Span: (330, 336); 
@@ -4386,10 +4166,6 @@ Slice: "\"({ id6 = 1, name6 = 'Liang' }, index) in users6\"";
 Span: (288, 337); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n  "; 
-Span: (340, 343); 
-Type: JSXText; 
-
 Slice: "someObj7"; 
 Span: (381, 389); 
 Type: IdentifierReference; 
@@ -4450,10 +4226,6 @@ Slice: "\"(key7, value7, index7) in someObj7\"";
 Span: (354, 390); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n  "; 
-Span: (393, 396); 
-Type: JSXText; 
-
 Slice: "someIter8"; 
 Span: (427, 436); 
 Type: IdentifierReference; 
@@ -4501,10 +4273,6 @@ Type: JSXIdentifier;
 Slice: "\"[item8, index8] in someIter8\""; 
 Span: (407, 437); 
 Type: JSXExpressionContainer; 
-
-Slice: "\n  "; 
-Span: (440, 443); 
-Type: JSXText; 
 
 Slice: "someIter9"; 
 Span: (481, 490); 
@@ -4562,18 +4330,10 @@ Slice: "\"[item9 = 'hi', index9] in someIter9\"";
 Span: (454, 491); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n"; 
-Span: (494, 495); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (495, 506); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
 Span: (497, 505); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (506, 507); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-if-error_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-if-error_vue.snap
@@ -139,21 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -283,21 +268,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 34,
-                                                                                            end: 37,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -401,36 +371,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 51,
-                                                                                            end: 55,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 71,
-                                                                                            end: 74,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -778,21 +718,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 89,
-                                                                                            end: 92,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -896,21 +821,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 104,
-                                                                                            end: 107,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1043,21 +953,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 127,
-                                                                                            end: 130,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -1164,21 +1059,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 147,
-                                                                                            end: 148,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -1203,21 +1083,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 159,
-                                                                            end: 161,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -1479,18 +1344,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  <div v-else-if:={}></>
-  <div v-else:></>
-
-  
-  {1 ? <><div v-if:={}></></> : undefined}<div v-if:={}></>
-  <div v-if:></>
-  <div v-else-if:={}></>
-  <div v-else-if:></>
-</template>
-
-</>;
+	<><template><div v-else-if:={}></><div v-else:></>{1 ? <><div v-if:={}></></> : undefined}<div v-if:={}></><div v-if:></><div v-else-if:={}></><div v-else-if:></></template></>;
 };
 
 
@@ -1510,10 +1364,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
 
 Slice: "<div v-else-if=\"1\" />"; 
 Span: (13, 34); 
@@ -1543,10 +1393,6 @@ Slice: "\"1\"";
 Span: (28, 31); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n  "; 
-Span: (34, 37); 
-Type: JSXText; 
-
 Slice: "<div v-else />"; 
 Span: (37, 51); 
 Type: JSXElement; 
@@ -1570,14 +1416,6 @@ Type: JSXNamespacedName;
 Slice: "v-else"; 
 Span: (42, 48); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n  "; 
-Span: (51, 55); 
-Type: JSXText; 
-
-Slice: "\n  "; 
-Span: (71, 74); 
-Type: JSXText; 
 
 Slice: "1"; 
 Span: (66, 67); 
@@ -1639,10 +1477,6 @@ Slice: "\"\"";
 Span: (84, 86); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n  "; 
-Span: (89, 92); 
-Type: JSXText; 
-
 Slice: "<div v-if />"; 
 Span: (92, 104); 
 Type: JSXElement; 
@@ -1666,10 +1500,6 @@ Type: JSXNamespacedName;
 Slice: "v-if"; 
 Span: (97, 101); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (104, 107); 
-Type: JSXText; 
 
 Slice: "<div v-else-if=\"\" />"; 
 Span: (107, 127); 
@@ -1699,10 +1529,6 @@ Slice: "\"\"";
 Span: (122, 124); 
 Type: JSXExpressionContainer; 
 
-Slice: "\n  "; 
-Span: (127, 130); 
-Type: JSXText; 
-
 Slice: "<div v-else-if />"; 
 Span: (130, 147); 
 Type: JSXElement; 
@@ -1727,18 +1553,10 @@ Slice: "v-else-if";
 Span: (135, 144); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (147, 148); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (148, 159); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
 Span: (150, 158); 
-Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (159, 161); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-if_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-if_vue.snap
@@ -139,81 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 34,
-                                                                                            end: 37,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 63,
-                                                                                            end: 66,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 92,
-                                                                                            end: 95,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 121,
-                                                                                            end: 124,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 ExpressionContainer(
                                                                                     JSXExpressionContainer {
                                                                                         span: Span {
@@ -369,23 +294,7 @@ Program {
                                                                                                                             ),
                                                                                                                         },
                                                                                                                         children: Vec(
-                                                                                                                            [
-                                                                                                                                Text(
-                                                                                                                                    JSXText {
-                                                                                                                                        span: Span {
-                                                                                                                                            start: 27,
-                                                                                                                                            end: 28,
-                                                                                                                                        },
-                                                                                                                                        node_id: Cell {
-                                                                                                                                            value: NodeId(0),
-                                                                                                                                        },
-                                                                                                                                        value: "A",
-                                                                                                                                        raw: Some(
-                                                                                                                                            "A",
-                                                                                                                                        ),
-                                                                                                                                    },
-                                                                                                                                ),
-                                                                                                                            ],
+                                                                                                                            [],
                                                                                                                         ),
                                                                                                                         closing_element: Some(
                                                                                                                             JSXClosingElement {
@@ -571,23 +480,7 @@ Program {
                                                                                                                                     ),
                                                                                                                                 },
                                                                                                                                 children: Vec(
-                                                                                                                                    [
-                                                                                                                                        Text(
-                                                                                                                                            JSXText {
-                                                                                                                                                span: Span {
-                                                                                                                                                    start: 56,
-                                                                                                                                                    end: 57,
-                                                                                                                                                },
-                                                                                                                                                node_id: Cell {
-                                                                                                                                                    value: NodeId(0),
-                                                                                                                                                },
-                                                                                                                                                value: "B",
-                                                                                                                                                raw: Some(
-                                                                                                                                                    "B",
-                                                                                                                                                ),
-                                                                                                                                            },
-                                                                                                                                        ),
-                                                                                                                                    ],
+                                                                                                                                    [],
                                                                                                                                 ),
                                                                                                                                 closing_element: Some(
                                                                                                                                     JSXClosingElement {
@@ -773,23 +666,7 @@ Program {
                                                                                                                                             ),
                                                                                                                                         },
                                                                                                                                         children: Vec(
-                                                                                                                                            [
-                                                                                                                                                Text(
-                                                                                                                                                    JSXText {
-                                                                                                                                                        span: Span {
-                                                                                                                                                            start: 85,
-                                                                                                                                                            end: 86,
-                                                                                                                                                        },
-                                                                                                                                                        node_id: Cell {
-                                                                                                                                                            value: NodeId(0),
-                                                                                                                                                        },
-                                                                                                                                                        value: "C",
-                                                                                                                                                        raw: Some(
-                                                                                                                                                            "C",
-                                                                                                                                                        ),
-                                                                                                                                                    },
-                                                                                                                                                ),
-                                                                                                                                            ],
+                                                                                                                                            [],
                                                                                                                                         ),
                                                                                                                                         closing_element: Some(
                                                                                                                                             JSXClosingElement {
@@ -975,23 +852,7 @@ Program {
                                                                                                                                                     ),
                                                                                                                                                 },
                                                                                                                                                 children: Vec(
-                                                                                                                                                    [
-                                                                                                                                                        Text(
-                                                                                                                                                            JSXText {
-                                                                                                                                                                span: Span {
-                                                                                                                                                                    start: 114,
-                                                                                                                                                                    end: 115,
-                                                                                                                                                                },
-                                                                                                                                                                node_id: Cell {
-                                                                                                                                                                    value: NodeId(0),
-                                                                                                                                                                },
-                                                                                                                                                                value: "D",
-                                                                                                                                                                raw: Some(
-                                                                                                                                                                    "D",
-                                                                                                                                                                ),
-                                                                                                                                                            },
-                                                                                                                                                        ),
-                                                                                                                                                    ],
+                                                                                                                                                    [],
                                                                                                                                                 ),
                                                                                                                                                 closing_element: Some(
                                                                                                                                                     JSXClosingElement {
@@ -1130,23 +991,7 @@ Program {
                                                                                                                                                     ),
                                                                                                                                                 },
                                                                                                                                                 children: Vec(
-                                                                                                                                                    [
-                                                                                                                                                        Text(
-                                                                                                                                                            JSXText {
-                                                                                                                                                                span: Span {
-                                                                                                                                                                    start: 136,
-                                                                                                                                                                    end: 137,
-                                                                                                                                                                },
-                                                                                                                                                                node_id: Cell {
-                                                                                                                                                                    value: NodeId(0),
-                                                                                                                                                                },
-                                                                                                                                                                value: "E",
-                                                                                                                                                                raw: Some(
-                                                                                                                                                                    "E",
-                                                                                                                                                                ),
-                                                                                                                                                            },
-                                                                                                                                                        ),
-                                                                                                                                                    ],
+                                                                                                                                                    [],
                                                                                                                                                 ),
                                                                                                                                                 closing_element: Some(
                                                                                                                                                     JSXClosingElement {
@@ -1193,36 +1038,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 143,
-                                                                                            end: 149,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  \n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  \n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 170,
-                                                                                            end: 173,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1381,23 +1196,7 @@ Program {
                                                                                                                             ),
                                                                                                                         },
                                                                                                                         children: Vec(
-                                                                                                                            [
-                                                                                                                                Text(
-                                                                                                                                    JSXText {
-                                                                                                                                        span: Span {
-                                                                                                                                            start: 163,
-                                                                                                                                            end: 164,
-                                                                                                                                        },
-                                                                                                                                        node_id: Cell {
-                                                                                                                                            value: NodeId(0),
-                                                                                                                                        },
-                                                                                                                                        value: "X",
-                                                                                                                                        raw: Some(
-                                                                                                                                            "X",
-                                                                                                                                        ),
-                                                                                                                                    },
-                                                                                                                                ),
-                                                                                                                            ],
+                                                                                                                            [],
                                                                                                                         ),
                                                                                                                         closing_element: Some(
                                                                                                                             JSXClosingElement {
@@ -1536,23 +1335,7 @@ Program {
                                                                                                                             ),
                                                                                                                         },
                                                                                                                         children: Vec(
-                                                                                                                            [
-                                                                                                                                Text(
-                                                                                                                                    JSXText {
-                                                                                                                                        span: Span {
-                                                                                                                                            start: 185,
-                                                                                                                                            end: 186,
-                                                                                                                                        },
-                                                                                                                                        node_id: Cell {
-                                                                                                                                            value: NodeId(0),
-                                                                                                                                        },
-                                                                                                                                        value: "Y",
-                                                                                                                                        raw: Some(
-                                                                                                                                            "Y",
-                                                                                                                                        ),
-                                                                                                                                    },
-                                                                                                                                ),
-                                                                                                                            ],
+                                                                                                                            [],
                                                                                                                         ),
                                                                                                                         closing_element: Some(
                                                                                                                             JSXClosingElement {
@@ -1593,36 +1376,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 192,
-                                                                                            end: 198,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  \n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  \n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 219,
-                                                                                            end: 222,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1781,23 +1534,7 @@ Program {
                                                                                                                             ),
                                                                                                                         },
                                                                                                                         children: Vec(
-                                                                                                                            [
-                                                                                                                                Text(
-                                                                                                                                    JSXText {
-                                                                                                                                        span: Span {
-                                                                                                                                            start: 212,
-                                                                                                                                            end: 213,
-                                                                                                                                        },
-                                                                                                                                        node_id: Cell {
-                                                                                                                                            value: NodeId(0),
-                                                                                                                                        },
-                                                                                                                                        value: "Z",
-                                                                                                                                        raw: Some(
-                                                                                                                                            "Z",
-                                                                                                                                        ),
-                                                                                                                                    },
-                                                                                                                                ),
-                                                                                                                            ],
+                                                                                                                            [],
                                                                                                                         ),
                                                                                                                         closing_element: Some(
                                                                                                                             JSXClosingElement {
@@ -1853,21 +1590,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 243,
-                                                                                            end: 246,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -2026,23 +1748,7 @@ Program {
                                                                                                                             ),
                                                                                                                         },
                                                                                                                         children: Vec(
-                                                                                                                            [
-                                                                                                                                Text(
-                                                                                                                                    JSXText {
-                                                                                                                                        span: Span {
-                                                                                                                                            start: 236,
-                                                                                                                                            end: 237,
-                                                                                                                                        },
-                                                                                                                                        node_id: Cell {
-                                                                                                                                            value: NodeId(0),
-                                                                                                                                        },
-                                                                                                                                        value: "W",
-                                                                                                                                        raw: Some(
-                                                                                                                                            "W",
-                                                                                                                                        ),
-                                                                                                                                    },
-                                                                                                                                ),
-                                                                                                                            ],
+                                                                                                                            [],
                                                                                                                         ),
                                                                                                                         closing_element: Some(
                                                                                                                             JSXClosingElement {
@@ -2136,23 +1842,7 @@ Program {
                                                                                             ),
                                                                                         },
                                                                                         children: Vec(
-                                                                                            [
-                                                                                                Text(
-                                                                                                    JSXText {
-                                                                                                        span: Span {
-                                                                                                            start: 251,
-                                                                                                            end: 252,
-                                                                                                        },
-                                                                                                        node_id: Cell {
-                                                                                                            value: NodeId(0),
-                                                                                                        },
-                                                                                                        value: "K",
-                                                                                                        raw: Some(
-                                                                                                            "K",
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
-                                                                                            ],
+                                                                                            [],
                                                                                         ),
                                                                                         closing_element: Some(
                                                                                             JSXClosingElement {
@@ -2176,21 +1866,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 258,
-                                                                                            end: 259,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -2218,21 +1893,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 270,
-                                                                            end: 271,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -2277,21 +1937,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  
-  
-  
-  
-  {a ? <><div v-if:={}>A</div></> : b ? <><div v-else-if:={}>B</div></> : c ? <><div v-else-if:={}>C</div></> : d ? <><div v-else-if:={}>D</div></> : <><div v-else:>E</div></>}
-  
-  
-  {x ? <><div v-if:={}>X</div></> : <><div v-else:>Y</div></>}
-  
-  
-  {z ? <><div v-if:={}>Z</div></> : undefined}
-  {w ? <><div v-if:={}>W</div></> : undefined}<div>K</div>
-</template>
-</>;
+	<><template>{a ? <><div v-if:={}></div></> : b ? <><div v-else-if:={}></div></> : c ? <><div v-else-if:={}></div></> : d ? <><div v-else-if:={}></div></> : <><div v-else:></div></>}{x ? <><div v-if:={}></div></> : <><div v-else:></div></>}{z ? <><div v-if:={}></div></> : undefined}{w ? <><div v-if:={}></div></> : undefined}<div></div></template></>;
 };
 
 
@@ -2311,26 +1957,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
-
-Slice: "\n  "; 
-Span: (34, 37); 
-Type: JSXText; 
-
-Slice: "\n  "; 
-Span: (63, 66); 
-Type: JSXText; 
-
-Slice: "\n  "; 
-Span: (92, 95); 
-Type: JSXText; 
-
-Slice: "\n  "; 
-Span: (121, 124); 
-Type: JSXText; 
 
 Slice: "a"; 
 Span: (24, 25); 
@@ -2363,10 +1989,6 @@ Type: JSXIdentifier;
 Slice: "\"a\""; 
 Span: (23, 26); 
 Type: JSXExpressionContainer; 
-
-Slice: "A"; 
-Span: (27, 28); 
-Type: JSXText; 
 
 Slice: "</div>"; 
 Span: (28, 34); 
@@ -2408,10 +2030,6 @@ Slice: "\"b\"";
 Span: (52, 55); 
 Type: JSXExpressionContainer; 
 
-Slice: "B"; 
-Span: (56, 57); 
-Type: JSXText; 
-
 Slice: "</div>"; 
 Span: (57, 63); 
 Type: JSXClosingElement; 
@@ -2451,10 +2069,6 @@ Type: JSXIdentifier;
 Slice: "\"c\""; 
 Span: (81, 84); 
 Type: JSXExpressionContainer; 
-
-Slice: "C"; 
-Span: (85, 86); 
-Type: JSXText; 
 
 Slice: "</div>"; 
 Span: (86, 92); 
@@ -2496,10 +2110,6 @@ Slice: "\"d\"";
 Span: (110, 113); 
 Type: JSXExpressionContainer; 
 
-Slice: "D"; 
-Span: (114, 115); 
-Type: JSXText; 
-
 Slice: "</div>"; 
 Span: (115, 121); 
 Type: JSXClosingElement; 
@@ -2532,10 +2142,6 @@ Slice: "v-else";
 Span: (129, 135); 
 Type: JSXIdentifier; 
 
-Slice: "E"; 
-Span: (136, 137); 
-Type: JSXText; 
-
 Slice: "</div>"; 
 Span: (137, 143); 
 Type: JSXClosingElement; 
@@ -2543,14 +2149,6 @@ Type: JSXClosingElement;
 Slice: "div"; 
 Span: (139, 142); 
 Type: JSXIdentifier; 
-
-Slice: "\n  \n  "; 
-Span: (143, 149); 
-Type: JSXText; 
-
-Slice: "\n  "; 
-Span: (170, 173); 
-Type: JSXText; 
 
 Slice: "x"; 
 Span: (160, 161); 
@@ -2584,10 +2182,6 @@ Slice: "\"x\"";
 Span: (159, 162); 
 Type: JSXExpressionContainer; 
 
-Slice: "X"; 
-Span: (163, 164); 
-Type: JSXText; 
-
 Slice: "</div>"; 
 Span: (164, 170); 
 Type: JSXClosingElement; 
@@ -2620,10 +2214,6 @@ Slice: "v-else";
 Span: (178, 184); 
 Type: JSXIdentifier; 
 
-Slice: "Y"; 
-Span: (185, 186); 
-Type: JSXText; 
-
 Slice: "</div>"; 
 Span: (186, 192); 
 Type: JSXClosingElement; 
@@ -2631,14 +2221,6 @@ Type: JSXClosingElement;
 Slice: "div"; 
 Span: (188, 191); 
 Type: JSXIdentifier; 
-
-Slice: "\n  \n  "; 
-Span: (192, 198); 
-Type: JSXText; 
-
-Slice: "\n  "; 
-Span: (219, 222); 
-Type: JSXText; 
 
 Slice: "z"; 
 Span: (209, 210); 
@@ -2672,10 +2254,6 @@ Slice: "\"z\"";
 Span: (208, 211); 
 Type: JSXExpressionContainer; 
 
-Slice: "Z"; 
-Span: (212, 213); 
-Type: JSXText; 
-
 Slice: "</div>"; 
 Span: (213, 219); 
 Type: JSXClosingElement; 
@@ -2683,10 +2261,6 @@ Type: JSXClosingElement;
 Slice: "div"; 
 Span: (215, 218); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (243, 246); 
-Type: JSXText; 
 
 Slice: "w"; 
 Span: (233, 234); 
@@ -2720,10 +2294,6 @@ Slice: "\"w\"";
 Span: (232, 235); 
 Type: JSXExpressionContainer; 
 
-Slice: "W"; 
-Span: (236, 237); 
-Type: JSXText; 
-
 Slice: "</div>"; 
 Span: (237, 243); 
 Type: JSXClosingElement; 
@@ -2744,10 +2314,6 @@ Slice: "div";
 Span: (247, 250); 
 Type: JSXIdentifier; 
 
-Slice: "K"; 
-Span: (251, 252); 
-Type: JSXText; 
-
 Slice: "</div>"; 
 Span: (252, 258); 
 Type: JSXClosingElement; 
@@ -2756,18 +2322,10 @@ Slice: "div";
 Span: (254, 257); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (258, 259); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (259, 270); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
 Span: (261, 269); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (270, 271); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-slot_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/directive_v-slot_vue.snap
@@ -139,21 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -509,21 +494,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 42,
-                                                                                            end: 45,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -818,21 +788,6 @@ Program {
                                                                                                                                                                     },
                                                                                                                                                                     children: Vec(
                                                                                                                                                                         [
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 73,
-                                                                                                                                                                                        end: 78,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n    ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n    ",
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
                                                                                                                                                                             ExpressionContainer(
                                                                                                                                                                                 JSXExpressionContainer {
                                                                                                                                                                                     span: Span {
@@ -856,21 +811,6 @@ Program {
                                                                                                                                                                                             },
                                                                                                                                                                                             name: "message",
                                                                                                                                                                                         },
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 91,
-                                                                                                                                                                                        end: 94,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n  ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n  ",
                                                                                                                                                                                     ),
                                                                                                                                                                                 },
                                                                                                                                                                             ),
@@ -933,21 +873,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 101,
-                                                                                            end: 104,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1148,23 +1073,7 @@ Program {
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                     children: Vec(
-                                                                                                                                                                        [
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 121,
-                                                                                                                                                                                        end: 126,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: " abc ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        " abc ",
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
-                                                                                                                                                                        ],
+                                                                                                                                                                        [],
                                                                                                                                                                     ),
                                                                                                                                                                     closing_fragment: JSXClosingFragment {
                                                                                                                                                                         span: Span {
@@ -1223,21 +1132,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 133,
-                                                                                            end: 136,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1494,21 +1388,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 151,
-                                                                                            end: 154,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -1806,21 +1685,6 @@ Program {
                                                                                                                                                                     },
                                                                                                                                                                     children: Vec(
                                                                                                                                                                         [
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 188,
-                                                                                                                                                                                        end: 193,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n    ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n    ",
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
                                                                                                                                                                             ExpressionContainer(
                                                                                                                                                                                 JSXExpressionContainer {
                                                                                                                                                                                     span: Span {
@@ -1844,21 +1708,6 @@ Program {
                                                                                                                                                                                             },
                                                                                                                                                                                             name: "message",
                                                                                                                                                                                         },
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 206,
-                                                                                                                                                                                        end: 209,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n  ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n  ",
                                                                                                                                                                                     ),
                                                                                                                                                                                 },
                                                                                                                                                                             ),
@@ -1921,21 +1770,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 216,
-                                                                                            end: 219,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -2233,21 +2067,6 @@ Program {
                                                                                                                                                                     },
                                                                                                                                                                     children: Vec(
                                                                                                                                                                         [
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 247,
-                                                                                                                                                                                        end: 252,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n    ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n    ",
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
                                                                                                                                                                             ExpressionContainer(
                                                                                                                                                                                 JSXExpressionContainer {
                                                                                                                                                                                     span: Span {
@@ -2271,21 +2090,6 @@ Program {
                                                                                                                                                                                             },
                                                                                                                                                                                             name: "message",
                                                                                                                                                                                         },
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 265,
-                                                                                                                                                                                        end: 268,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n  ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n  ",
                                                                                                                                                                                     ),
                                                                                                                                                                                 },
                                                                                                                                                                             ),
@@ -2348,21 +2152,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 275,
-                                                                                            end: 278,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -2663,21 +2452,6 @@ Program {
                                                                                                                                                                     },
                                                                                                                                                                     children: Vec(
                                                                                                                                                                         [
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 311,
-                                                                                                                                                                                        end: 316,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n    ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n    ",
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
                                                                                                                                                                             ExpressionContainer(
                                                                                                                                                                                 JSXExpressionContainer {
                                                                                                                                                                                     span: Span {
@@ -2701,21 +2475,6 @@ Program {
                                                                                                                                                                                             },
                                                                                                                                                                                             name: "message",
                                                                                                                                                                                         },
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 329,
-                                                                                                                                                                                        end: 332,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n  ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n  ",
                                                                                                                                                                                     ),
                                                                                                                                                                                 },
                                                                                                                                                                             ),
@@ -2778,21 +2537,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 339,
-                                                                                            end: 342,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -3051,21 +2795,6 @@ Program {
                                                                                                                                                                     },
                                                                                                                                                                     children: Vec(
                                                                                                                                                                         [
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 369,
-                                                                                                                                                                                        end: 374,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n    ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n    ",
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
                                                                                                                                                                             ExpressionContainer(
                                                                                                                                                                                 JSXExpressionContainer {
                                                                                                                                                                                     span: Span {
@@ -3111,21 +2840,6 @@ Program {
                                                                                                                                                                                                 name: "name",
                                                                                                                                                                                             },
                                                                                                                                                                                         },
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
-                                                                                                                                                                            Text(
-                                                                                                                                                                                JSXText {
-                                                                                                                                                                                    span: Span {
-                                                                                                                                                                                        start: 389,
-                                                                                                                                                                                        end: 392,
-                                                                                                                                                                                    },
-                                                                                                                                                                                    node_id: Cell {
-                                                                                                                                                                                        value: NodeId(0),
-                                                                                                                                                                                    },
-                                                                                                                                                                                    value: "\n  ",
-                                                                                                                                                                                    raw: Some(
-                                                                                                                                                                                        "\n  ",
                                                                                                                                                                                     ),
                                                                                                                                                                                 },
                                                                                                                                                                             ),
@@ -3191,21 +2905,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 399,
-                                                                                            end: 400,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -3230,21 +2929,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 411,
-                                                                            end: 412,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -3289,27 +2973,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  <Comp v-slot:={}>{{ default: ({ message }) => <></> }}</Comp>
-  <Comp v-slot:header={}>{{ header: ({ message }) => <>
-    {message}
-  </> }}</Comp>
-  <Comp v-slot:abc>{{ abc: () => <> abc </> }}</Comp>
-  <Comp v-slot:>{{ default: () => <></> }}</>
-  <Comp v-slot:header={}>{{ header: ({ message }) => <>
-    {message}
-  </> }}</Comp>
-  <Comp v-slot:={}>{{ default: ({ message }) => <>
-    {message}
-  </> }}</Comp>
-  <Comp v-slot:[key]={}>{{ [key]: ({ message }) => <>
-    {message}
-  </> }}</Comp>
-  <Comp v-slot:header={}>{{ header: (user) => <>
-    {user.name}
-  </> }}</Comp>
-</template>
-</>;
+	<><template><Comp v-slot:={}>{{ default: ({ message }) => <></> }}</Comp><Comp v-slot:header={}>{{ header: ({ message }) => <>{message}</> }}</Comp><Comp v-slot:abc>{{ abc: () => <></> }}</Comp><Comp v-slot:>{{ default: () => <></> }}</><Comp v-slot:header={}>{{ header: ({ message }) => <>{message}</> }}</Comp><Comp v-slot:={}>{{ default: ({ message }) => <>{message}</> }}</Comp><Comp v-slot:[key]={}>{{ [key]: ({ message }) => <>{message}</> }}</Comp><Comp v-slot:header={}>{{ header: (user) => <>{user.name}</> }}</Comp></template></>;
 };
 
 
@@ -3329,10 +2993,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
 
 Slice: "<Comp #=\"{ message }\"></Comp>"; 
 Span: (13, 42); 
@@ -3394,10 +3054,6 @@ Slice: "Comp";
 Span: (37, 41); 
 Type: IdentifierReference; 
 
-Slice: "\n  "; 
-Span: (42, 45); 
-Type: JSXText; 
-
 Slice: "<Comp #header=\"{ message }\">\n    {{ message }}\n  </Comp>"; 
 Span: (45, 101); 
 Type: JSXElement; 
@@ -3458,10 +3114,6 @@ Slice: "message";
 Span: (62, 69); 
 Type: BindingIdentifier; 
 
-Slice: "\n    "; 
-Span: (73, 78); 
-Type: JSXText; 
-
 Slice: "{{ message }}"; 
 Span: (78, 91); 
 Type: JSXExpressionContainer; 
@@ -3470,10 +3122,6 @@ Slice: "message";
 Span: (81, 88); 
 Type: IdentifierReference; 
 
-Slice: "\n  "; 
-Span: (91, 94); 
-Type: JSXText; 
-
 Slice: "</Comp>"; 
 Span: (94, 101); 
 Type: JSXClosingElement; 
@@ -3481,10 +3129,6 @@ Type: JSXClosingElement;
 Slice: "Comp"; 
 Span: (96, 100); 
 Type: IdentifierReference; 
-
-Slice: "\n  "; 
-Span: (101, 104); 
-Type: JSXText; 
 
 Slice: "<Comp v-slot:abc> abc </Comp>"; 
 Span: (104, 133); 
@@ -3518,10 +3162,6 @@ Slice: "abc";
 Span: (117, 120); 
 Type: IdentifierName; 
 
-Slice: " abc "; 
-Span: (121, 126); 
-Type: JSXText; 
-
 Slice: "</Comp>"; 
 Span: (126, 133); 
 Type: JSXClosingElement; 
@@ -3529,10 +3169,6 @@ Type: JSXClosingElement;
 Slice: "Comp"; 
 Span: (128, 132); 
 Type: IdentifierReference; 
-
-Slice: "\n  "; 
-Span: (133, 136); 
-Type: JSXText; 
 
 Slice: "<Comp v-slot />"; 
 Span: (136, 151); 
@@ -3557,10 +3193,6 @@ Type: JSXNamespacedName;
 Slice: "v-slot"; 
 Span: (142, 148); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (151, 154); 
-Type: JSXText; 
 
 Slice: "<Comp v-slot:header=\"{ message }\">\n    {{ message }}\n  </Comp>"; 
 Span: (154, 216); 
@@ -3622,10 +3254,6 @@ Slice: "message";
 Span: (177, 184); 
 Type: BindingIdentifier; 
 
-Slice: "\n    "; 
-Span: (188, 193); 
-Type: JSXText; 
-
 Slice: "{{ message }}"; 
 Span: (193, 206); 
 Type: JSXExpressionContainer; 
@@ -3634,10 +3262,6 @@ Slice: "message";
 Span: (196, 203); 
 Type: IdentifierReference; 
 
-Slice: "\n  "; 
-Span: (206, 209); 
-Type: JSXText; 
-
 Slice: "</Comp>"; 
 Span: (209, 216); 
 Type: JSXClosingElement; 
@@ -3645,10 +3269,6 @@ Type: JSXClosingElement;
 Slice: "Comp"; 
 Span: (211, 215); 
 Type: IdentifierReference; 
-
-Slice: "\n  "; 
-Span: (216, 219); 
-Type: JSXText; 
 
 Slice: "<Comp v-slot:=\"{ message }\">\n    {{ message }}\n  </Comp>"; 
 Span: (219, 275); 
@@ -3702,10 +3322,6 @@ Slice: "message";
 Span: (236, 243); 
 Type: BindingIdentifier; 
 
-Slice: "\n    "; 
-Span: (247, 252); 
-Type: JSXText; 
-
 Slice: "{{ message }}"; 
 Span: (252, 265); 
 Type: JSXExpressionContainer; 
@@ -3714,10 +3330,6 @@ Slice: "message";
 Span: (255, 262); 
 Type: IdentifierReference; 
 
-Slice: "\n  "; 
-Span: (265, 268); 
-Type: JSXText; 
-
 Slice: "</Comp>"; 
 Span: (268, 275); 
 Type: JSXClosingElement; 
@@ -3725,10 +3337,6 @@ Type: JSXClosingElement;
 Slice: "Comp"; 
 Span: (270, 274); 
 Type: IdentifierReference; 
-
-Slice: "\n  "; 
-Span: (275, 278); 
-Type: JSXText; 
 
 Slice: "<Comp v-slot:[key]=\"{ message }\">\n    {{ message }}\n  </Comp>"; 
 Span: (278, 339); 
@@ -3790,10 +3398,6 @@ Slice: "message";
 Span: (300, 307); 
 Type: BindingIdentifier; 
 
-Slice: "\n    "; 
-Span: (311, 316); 
-Type: JSXText; 
-
 Slice: "{{ message }}"; 
 Span: (316, 329); 
 Type: JSXExpressionContainer; 
@@ -3802,10 +3406,6 @@ Slice: "message";
 Span: (319, 326); 
 Type: IdentifierReference; 
 
-Slice: "\n  "; 
-Span: (329, 332); 
-Type: JSXText; 
-
 Slice: "</Comp>"; 
 Span: (332, 339); 
 Type: JSXClosingElement; 
@@ -3813,10 +3413,6 @@ Type: JSXClosingElement;
 Slice: "Comp"; 
 Span: (334, 338); 
 Type: IdentifierReference; 
-
-Slice: "\n  "; 
-Span: (339, 342); 
-Type: JSXText; 
 
 Slice: "<Comp v-slot:header=\"user\">\n    {{ user.name }}\n  </Comp>"; 
 Span: (342, 399); 
@@ -3866,10 +3462,6 @@ Slice: "user";
 Span: (363, 367); 
 Type: BindingIdentifier; 
 
-Slice: "\n    "; 
-Span: (369, 374); 
-Type: JSXText; 
-
 Slice: "{{ user.name }}"; 
 Span: (374, 389); 
 Type: JSXExpressionContainer; 
@@ -3886,10 +3478,6 @@ Slice: "name";
 Span: (382, 386); 
 Type: IdentifierName; 
 
-Slice: "\n  "; 
-Span: (389, 392); 
-Type: JSXText; 
-
 Slice: "</Comp>"; 
 Span: (392, 399); 
 Type: JSXClosingElement; 
@@ -3898,18 +3486,10 @@ Slice: "Comp";
 Span: (394, 398); 
 Type: IdentifierReference; 
 
-Slice: "\n"; 
-Span: (399, 400); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (400, 411); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
 Span: (402, 410); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (411, 412); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/error_directive_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/error_directive_vue.snap
@@ -139,21 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -434,21 +419,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 64,
-                                                                                            end: 67,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -578,21 +548,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 97,
-                                                                                            end: 98,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -617,21 +572,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 109,
-                                                                            end: 111,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -761,21 +701,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 144,
-                                                                            end: 146,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -835,21 +760,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 161,
-                                                                            end: 162,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -996,20 +906,12 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  <div v-bind:key={(() => {
+	<><template><div v-bind:key={(() => {
 		return {
 			a,
 			b
 		};
-	})}></div>
-  <div v-bind:key={}></div>
-</template>
-
-<script lang="ts" setup></script>
-
-<style></style>
-</>;
+	})}></div><div v-bind:key={}></div></template><script lang="ts" setup></script><style></style></>;
 };
 
 
@@ -1029,10 +931,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
 
 Slice: "<div :key=\"() => { return { a =1, b = 1 } }\"></div>"; 
 Span: (13, 64); 
@@ -1118,10 +1016,6 @@ Slice: "div";
 Span: (60, 63); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (64, 67); 
-Type: JSXText; 
-
 Slice: "<div :key=\"a 1 )`Hi '`\"></div>"; 
 Span: (67, 97); 
 Type: JSXElement; 
@@ -1162,10 +1056,6 @@ Slice: "div";
 Span: (93, 96); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (97, 98); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (98, 109); 
 Type: JSXClosingElement; 
@@ -1173,10 +1063,6 @@ Type: JSXClosingElement;
 Slice: "template"; 
 Span: (100, 108); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (109, 111); 
-Type: JSXText; 
 
 Slice: "<script lang=\"ts\" setup></script>"; 
 Span: (111, 144); 
@@ -1218,10 +1104,6 @@ Slice: "script";
 Span: (137, 143); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n"; 
-Span: (144, 146); 
-Type: JSXText; 
-
 Slice: "<style></style>"; 
 Span: (146, 161); 
 Type: JSXElement; 
@@ -1240,8 +1122,4 @@ Type: JSXClosingElement;
 
 Slice: "style"; 
 Span: (155, 160); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (161, 162); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/error_empty_multiple_scripts_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/error_empty_multiple_scripts_vue.snap
@@ -227,21 +227,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 31,
-                                                                            end: 33,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -304,21 +289,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 52,
-                                                                            end: 53,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                             ],
                                                         ),
                                                         closing_fragment: JSXClosingFragment {
@@ -363,10 +333,7 @@ Program {
 =============== Codegen ===============
 const a = 1;
 async () => {
-	<><script></script>
-
-<script></script>
-</>;
+	<><script></script><script></script></>;
 };
 
 
@@ -411,10 +378,6 @@ Slice: "script";
 Span: (24, 30); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n"; 
-Span: (31, 33); 
-Type: JSXText; 
-
 Slice: "<script>\n\n</script>"; 
 Span: (33, 52); 
 Type: JSXElement; 
@@ -433,8 +396,4 @@ Type: JSXClosingElement;
 
 Slice: "script"; 
 Span: (45, 51); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (52, 53); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/error_script_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/error_script_vue.snap
@@ -284,21 +284,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -361,21 +346,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 24,
-                                                                                            end: 25,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -400,21 +370,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 36,
-                                                                            end: 38,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -505,21 +460,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 90,
-                                                                            end: 92,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -582,21 +522,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 137,
-                                                                            end: 139,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -656,21 +581,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 154,
-                                                                            end: 155,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -807,16 +717,7 @@ async () => {
 		b,
 		c
 	};
-	<><template>
-  <div></div>
-</template>
-
-<script setup></script>
-
-<script></script>
-
-<style></style>
-</>;
+	<><template><div></div></template><script setup></script><script></script><style></style></>;
 };
 
 
@@ -877,10 +778,6 @@ Slice: "template";
 Span: (1, 9); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
-
 Slice: "<div></div>"; 
 Span: (13, 24); 
 Type: JSXElement; 
@@ -901,10 +798,6 @@ Slice: "div";
 Span: (20, 23); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (24, 25); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (25, 36); 
 Type: JSXClosingElement; 
@@ -912,10 +805,6 @@ Type: JSXClosingElement;
 Slice: "template"; 
 Span: (27, 35); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (36, 38); 
-Type: JSXText; 
 
 Slice: "<script setup>\nconst a = { b = 1, c = 1 };\n</script>"; 
 Span: (38, 90); 
@@ -945,10 +834,6 @@ Slice: "script";
 Span: (83, 89); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n"; 
-Span: (90, 92); 
-Type: JSXText; 
-
 Slice: "<script>\nlet const p { const w p =)\n</script>"; 
 Span: (92, 137); 
 Type: JSXElement; 
@@ -969,10 +854,6 @@ Slice: "script";
 Span: (130, 136); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n"; 
-Span: (137, 139); 
-Type: JSXText; 
-
 Slice: "<style></style>"; 
 Span: (139, 154); 
 Type: JSXElement; 
@@ -991,8 +872,4 @@ Type: JSXClosingElement;
 
 Slice: "style"; 
 Span: (148, 153); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (154, 155); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/root_texts_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/root_texts_vue.snap
@@ -227,21 +227,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 38,
-                                                                            end: 54,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n<!-- aaa -->\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n<!-- aaa -->\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -301,21 +286,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 71,
-                                                                            end: 102,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n<!-- <script> </script> -->\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n<!-- <script> </script> -->\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -381,21 +351,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 117,
-                                                                            end: 126,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n123123\n",
-                                                                        raw: Some(
-                                                                            "\n\n123123\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                             ],
                                                         ),
                                                         closing_fragment: JSXClosingFragment {
@@ -439,18 +394,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template></template><script></script>
-
-<!-- aaa -->
-
-<script></script>
-
-<!-- <script> </script> -->
-
-<style></style>
-
-123123
-</>;
+	<><template></template><script></script><script></script><style></style></>;
 };
 
 
@@ -499,10 +443,6 @@ Slice: "script";
 Span: (31, 37); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n<!-- aaa -->\n\n"; 
-Span: (38, 54); 
-Type: JSXText; 
-
 Slice: "<script></script>"; 
 Span: (54, 71); 
 Type: JSXElement; 
@@ -523,10 +463,6 @@ Slice: "script";
 Span: (64, 70); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n<!-- <script> </script> -->\n\n"; 
-Span: (71, 102); 
-Type: JSXText; 
-
 Slice: "<style></style>"; 
 Span: (102, 117); 
 Type: JSXElement; 
@@ -545,8 +481,4 @@ Type: JSXClosingElement;
 
 Slice: "style"; 
 Span: (111, 116); 
-Type: JSXIdentifier; 
-
-Slice: "\n\n123123\n"; 
-Span: (117, 126); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_basic_vue.snap
@@ -380,21 +380,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -457,21 +442,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 32,
-                                                                                            end: 33,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -496,21 +466,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 44,
-                                                                            end: 46,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -576,21 +531,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 146,
-                                                                            end: 148,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                             ],
                                                         ),
                                                         closing_fragment: JSXClosingFragment {
@@ -638,13 +578,7 @@ export default { data() {
 	return { count };
 } };
 async () => {
-	<><template>
-  <div></div>
-</template>
-
-<script></script>
-
-</>;
+	<><template><div></div></template><script></script></>;
 };
 
 
@@ -729,10 +663,6 @@ Slice: "template";
 Span: (1, 9); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
-
 Slice: "<div>\n    \n  </div>"; 
 Span: (13, 32); 
 Type: JSXElement; 
@@ -753,10 +683,6 @@ Slice: "div";
 Span: (28, 31); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (32, 33); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (33, 44); 
 Type: JSXClosingElement; 
@@ -764,10 +690,6 @@ Type: JSXClosingElement;
 Slice: "template"; 
 Span: (35, 43); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (44, 46); 
-Type: JSXText; 
 
 Slice: "<script>\nconst count = 0\n\nexport default..[OMIT]..turn {\n      count\n    }\n  }\n}\n</script>"; 
 Span: (46, 146); 
@@ -787,8 +709,4 @@ Type: JSXClosingElement;
 
 Slice: "script"; 
 Span: (139, 145); 
-Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (146, 148); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_both_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_both_vue.snap
@@ -558,21 +558,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -635,21 +620,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 32,
-                                                                                            end: 33,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -674,21 +644,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 44,
-                                                                            end: 46,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -779,21 +734,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 122,
-                                                                            end: 124,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -856,21 +796,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 226,
-                                                                            end: 227,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                             ],
                                                         ),
                                                         closing_fragment: JSXClosingFragment {
@@ -920,14 +845,7 @@ export default { data() {
 } };
 async () => {
 	const number = ref(-1);
-	<><template>
-  <div></div>
-</template>
-
-<script setup></script>
-
-<script></script>
-</>;
+	<><template><div></div></template><script setup></script><script></script></>;
 };
 
 
@@ -1060,10 +978,6 @@ Slice: "template";
 Span: (1, 9); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
-
 Slice: "<div>\n    \n  </div>"; 
 Span: (13, 32); 
 Type: JSXElement; 
@@ -1084,10 +998,6 @@ Slice: "div";
 Span: (28, 31); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (32, 33); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (33, 44); 
 Type: JSXClosingElement; 
@@ -1095,10 +1005,6 @@ Type: JSXClosingElement;
 Slice: "template"; 
 Span: (35, 43); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (44, 46); 
-Type: JSXText; 
 
 Slice: "<script setup>\nimport { ref } from 'vue';\n\nconst number = ref(-1);\n</script>"; 
 Span: (46, 122); 
@@ -1128,10 +1034,6 @@ Slice: "script";
 Span: (115, 121); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n"; 
-Span: (122, 124); 
-Type: JSXText; 
-
 Slice: "<script>\nconst count = 0;\n\nexport defaul..[OMIT]..urn {\n      count,\n    }\n  }\n}\n</script>"; 
 Span: (124, 226); 
 Type: JSXElement; 
@@ -1150,8 +1052,4 @@ Type: JSXClosingElement;
 
 Slice: "script"; 
 Span: (219, 225); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (226, 227); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_directives_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_directives_vue.snap
@@ -215,21 +215,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 32,
-                                                                            end: 34,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -317,21 +302,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 72,
-                                                                            end: 73,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                             ],
                                                         ),
                                                         closing_fragment: JSXClosingFragment {
@@ -377,10 +347,7 @@ Program {
 "use client";
 async () => {
 	"use server";
-	<><script></script>
-
-<script setup></script>
-</>;
+	<><script></script><script setup></script></>;
 };
 
 
@@ -425,10 +392,6 @@ Slice: "script";
 Span: (25, 31); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n"; 
-Span: (32, 34); 
-Type: JSXText; 
-
 Slice: "<script setup>\n\"use server\";\n</script>"; 
 Span: (34, 72); 
 Type: JSXElement; 
@@ -455,8 +418,4 @@ Type: JSXClosingElement;
 
 Slice: "script"; 
 Span: (65, 71); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (72, 73); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_empty_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_empty_vue.snap
@@ -139,21 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -216,21 +201,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 32,
-                                                                                            end: 33,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -255,21 +225,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 44,
-                                                                            end: 46,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -360,21 +315,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 69,
-                                                                            end: 71,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -437,21 +377,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 88,
-                                                                            end: 89,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                             ],
                                                         ),
                                                         closing_fragment: JSXClosingFragment {
@@ -495,14 +420,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  <div></div>
-</template>
-
-<script setup></script>
-
-<script></script>
-</>;
+	<><template><div></div></template><script setup></script><script></script></>;
 };
 
 
@@ -522,10 +440,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
 
 Slice: "<div>\n    \n  </div>"; 
 Span: (13, 32); 
@@ -547,10 +461,6 @@ Slice: "div";
 Span: (28, 31); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (32, 33); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (33, 44); 
 Type: JSXClosingElement; 
@@ -558,10 +468,6 @@ Type: JSXClosingElement;
 Slice: "template"; 
 Span: (35, 43); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (44, 46); 
-Type: JSXText; 
 
 Slice: "<script setup></script>"; 
 Span: (46, 69); 
@@ -591,10 +497,6 @@ Slice: "script";
 Span: (62, 68); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n"; 
-Span: (69, 71); 
-Type: JSXText; 
-
 Slice: "<script></script>"; 
 Span: (71, 88); 
 Type: JSXElement; 
@@ -613,8 +515,4 @@ Type: JSXClosingElement;
 
 Slice: "script"; 
 Span: (81, 87); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (88, 89); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_setup_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_setup_vue.snap
@@ -305,21 +305,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -382,21 +367,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 32,
-                                                                                            end: 33,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -421,21 +391,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 44,
-                                                                            end: 46,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -526,21 +481,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 118,
-                                                                            end: 119,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                             ],
                                                         ),
                                                         closing_fragment: JSXClosingFragment {
@@ -586,12 +526,7 @@ Program {
 import { ref } from "vue";
 async () => {
 	const count = ref(0);
-	<><template>
-  <div></div>
-</template>
-
-<script setup></script>
-</>;
+	<><template><div></div></template><script setup></script></>;
 };
 
 
@@ -656,10 +591,6 @@ Slice: "template";
 Span: (1, 9); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
-
 Slice: "<div>\n    \n  </div>"; 
 Span: (13, 32); 
 Type: JSXElement; 
@@ -680,10 +611,6 @@ Slice: "div";
 Span: (28, 31); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (32, 33); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (33, 44); 
 Type: JSXClosingElement; 
@@ -691,10 +618,6 @@ Type: JSXClosingElement;
 Slice: "template"; 
 Span: (35, 43); 
 Type: JSXIdentifier; 
-
-Slice: "\n\n"; 
-Span: (44, 46); 
-Type: JSXText; 
 
 Slice: "<script setup>\nimport { ref } from 'vue'\n\nconst count = ref(0)\n</script>"; 
 Span: (46, 118); 
@@ -722,8 +645,4 @@ Type: JSXClosingElement;
 
 Slice: "script"; 
 Span: (111, 117); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (118, 119); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/tags_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/tags_vue.snap
@@ -139,21 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -256,21 +241,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 46,
-                                                                                            end: 49,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -330,21 +300,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 66,
-                                                                                            end: 69,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -450,21 +405,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 88,
-                                                                                            end: 91,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -567,21 +507,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 109,
-                                                                                            end: 112,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -641,21 +566,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 119,
-                                                                                            end: 122,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -721,21 +631,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 128,
-                                                                                            end: 129,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -760,21 +655,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 140,
-                                                                            end: 141,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -819,15 +699,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  <div class="1"></div>
-  <div></div>
-  <div class="w-1"></>
-  <main class="1"></>
-  <img></>
-  <br></>
-</template>
-</>;
+	<><template><div class="1"></div><div></div><div class="w-1"></><main class="1"></><img></><br></></template></>;
 };
 
 
@@ -847,10 +719,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (1, 9); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
 
 Slice: "<div class=\"1\"    ></div        >"; 
 Span: (13, 46); 
@@ -884,10 +752,6 @@ Slice: "div";
 Span: (34, 37); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (46, 49); 
-Type: JSXText; 
-
 Slice: "<div      ></div>"; 
 Span: (49, 66); 
 Type: JSXElement; 
@@ -907,10 +771,6 @@ Type: JSXClosingElement;
 Slice: "div"; 
 Span: (62, 65); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (66, 69); 
-Type: JSXText; 
 
 Slice: "<div class=\"w-1\" />"; 
 Span: (69, 88); 
@@ -936,10 +796,6 @@ Slice: "w-1";
 Span: (81, 84); 
 Type: StringLiteral; 
 
-Slice: "\n  "; 
-Span: (88, 91); 
-Type: JSXText; 
-
 Slice: "<main class=\"1\" />"; 
 Span: (91, 109); 
 Type: JSXElement; 
@@ -964,10 +820,6 @@ Slice: "1";
 Span: (104, 105); 
 Type: StringLiteral; 
 
-Slice: "\n  "; 
-Span: (109, 112); 
-Type: JSXText; 
-
 Slice: "<img />"; 
 Span: (112, 119); 
 Type: JSXElement; 
@@ -979,10 +831,6 @@ Type: JSXOpeningElement;
 Slice: "img"; 
 Span: (113, 116); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (119, 122); 
-Type: JSXText; 
 
 Slice: "<br />"; 
 Span: (122, 128); 
@@ -996,18 +844,10 @@ Slice: "br";
 Span: (123, 125); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (128, 129); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (129, 140); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
 Span: (131, 139); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (140, 141); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/typescript_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/typescript_vue.snap
@@ -533,21 +533,6 @@ Program {
                                                                         ),
                                                                     },
                                                                 ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 124,
-                                                                            end: 126,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n\n",
-                                                                        raw: Some(
-                                                                            "\n\n",
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 Element(
                                                                     JSXElement {
                                                                         span: Span {
@@ -584,21 +569,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 136,
-                                                                                            end: 139,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -710,21 +680,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 161,
-                                                                                            end: 164,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -760,23 +715,7 @@ Program {
                                                                                             ),
                                                                                         },
                                                                                         children: Vec(
-                                                                                            [
-                                                                                                Text(
-                                                                                                    JSXText {
-                                                                                                        span: Span {
-                                                                                                            start: 169,
-                                                                                                            end: 195,
-                                                                                                        },
-                                                                                                        node_id: Cell {
-                                                                                                            value: NodeId(0),
-                                                                                                        },
-                                                                                                        value: " I think 1 < 2, isn't it? ",
-                                                                                                        raw: Some(
-                                                                                                            " I think 1 < 2, isn't it? ",
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
-                                                                                            ],
+                                                                                            [],
                                                                                         ),
                                                                                         closing_element: Some(
                                                                                             JSXClosingElement {
@@ -800,21 +739,6 @@ Program {
                                                                                                     },
                                                                                                 ),
                                                                                             },
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 201,
-                                                                                            end: 202,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n",
-                                                                                        raw: Some(
-                                                                                            "\n",
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -842,21 +766,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 213,
-                                                                            end: 214,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -907,13 +816,7 @@ async () => {
 		msg: 1;
 	}>();
 	const b = someFunction<SomeType>();
-	<><script lang="ts" setup></script>
-
-<template>
-  <div>{a.msg}</div>
-  <div> I think 1 < 2, isn't it? </div>
-</template>
-</>;
+	<><script lang="ts" setup></script><template><div>{a.msg}</div><div></div></template></>;
 };
 
 
@@ -1042,10 +945,6 @@ Slice: "script";
 Span: (117, 123); 
 Type: JSXIdentifier; 
 
-Slice: "\n\n"; 
-Span: (124, 126); 
-Type: JSXText; 
-
 Slice: "<template>\n  <div>{{ a.msg }}</div>\n  <d..[OMIT]..hink 1 < 2, isn't it? </div>\n</template>"; 
 Span: (126, 213); 
 Type: JSXElement; 
@@ -1057,10 +956,6 @@ Type: JSXOpeningElement;
 Slice: "template"; 
 Span: (127, 135); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (136, 139); 
-Type: JSXText; 
 
 Slice: "<div>{{ a.msg }}</div>"; 
 Span: (139, 161); 
@@ -1098,10 +993,6 @@ Slice: "div";
 Span: (157, 160); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (161, 164); 
-Type: JSXText; 
-
 Slice: "<div> I think 1 < 2, isn't it? </div>"; 
 Span: (164, 201); 
 Type: JSXElement; 
@@ -1114,10 +1005,6 @@ Slice: "div";
 Span: (165, 168); 
 Type: JSXIdentifier; 
 
-Slice: " I think 1 < 2, isn't it? "; 
-Span: (169, 195); 
-Type: JSXText; 
-
 Slice: "</div>"; 
 Span: (195, 201); 
 Type: JSXClosingElement; 
@@ -1126,18 +1013,10 @@ Slice: "div";
 Span: (197, 200); 
 Type: JSXIdentifier; 
 
-Slice: "\n"; 
-Span: (201, 202); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (202, 213); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
 Span: (204, 212); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (213, 214); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/void_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/void_vue.snap
@@ -139,21 +139,6 @@ Program {
                                                                         },
                                                                         children: Vec(
                                                                             [
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 10,
-                                                                                            end: 13,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -192,21 +177,6 @@ Program {
                                                                                             [],
                                                                                         ),
                                                                                         closing_element: None,
-                                                                                    },
-                                                                                ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 17,
-                                                                                            end: 20,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
                                                                                     },
                                                                                 ),
                                                                                 Element(
@@ -271,21 +241,6 @@ Program {
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 29,
-                                                                                            end: 32,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "\n  ",
-                                                                                        raw: Some(
-                                                                                            "\n  ",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                                 Element(
                                                                                     JSXElement {
                                                                                         span: Span {
@@ -326,21 +281,6 @@ Program {
                                                                                         closing_element: None,
                                                                                     },
                                                                                 ),
-                                                                                Text(
-                                                                                    JSXText {
-                                                                                        span: Span {
-                                                                                            start: 37,
-                                                                                            end: 44,
-                                                                                        },
-                                                                                        node_id: Cell {
-                                                                                            value: NodeId(0),
-                                                                                        },
-                                                                                        value: "</img>\n",
-                                                                                        raw: Some(
-                                                                                            "</img>\n",
-                                                                                        ),
-                                                                                    },
-                                                                                ),
                                                                             ],
                                                                         ),
                                                                         closing_element: Some(
@@ -365,21 +305,6 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                Text(
-                                                                    JSXText {
-                                                                        span: Span {
-                                                                            start: 55,
-                                                                            end: 56,
-                                                                        },
-                                                                        node_id: Cell {
-                                                                            value: NodeId(0),
-                                                                        },
-                                                                        value: "\n",
-                                                                        raw: Some(
-                                                                            "\n",
                                                                         ),
                                                                     },
                                                                 ),
@@ -452,12 +377,7 @@ Program {
 
 =============== Codegen ===============
 async () => {
-	<><template>
-  <br />
-  <input></>
-  <img /></img>
-</template>
-</>;
+	<><template><br /><input></><img /></template></>;
 };
 
 
@@ -478,10 +398,6 @@ Slice: "template";
 Span: (1, 9); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (10, 13); 
-Type: JSXText; 
-
 Slice: "<br>"; 
 Span: (13, 17); 
 Type: JSXElement; 
@@ -493,10 +409,6 @@ Type: JSXOpeningElement;
 Slice: "br"; 
 Span: (14, 16); 
 Type: JSXIdentifier; 
-
-Slice: "\n  "; 
-Span: (17, 20); 
-Type: JSXText; 
 
 Slice: "<input />"; 
 Span: (20, 29); 
@@ -510,10 +422,6 @@ Slice: "input";
 Span: (21, 26); 
 Type: JSXIdentifier; 
 
-Slice: "\n  "; 
-Span: (29, 32); 
-Type: JSXText; 
-
 Slice: "<img>"; 
 Span: (32, 37); 
 Type: JSXElement; 
@@ -526,18 +434,10 @@ Slice: "img";
 Span: (33, 36); 
 Type: JSXIdentifier; 
 
-Slice: "</img>\n"; 
-Span: (37, 44); 
-Type: JSXText; 
-
 Slice: "</template>"; 
 Span: (44, 55); 
 Type: JSXClosingElement; 
 
 Slice: "template"; 
 Span: (46, 54); 
-Type: JSXIdentifier; 
-
-Slice: "\n"; 
-Span: (55, 56); 
-Type: JSXText;
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/basic_vue.snap
@@ -1,21 +1,8 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
 	const count = 1;
-	<><template>
-  <div>
-    {count}
-  </div>
-</template>
-
-<script lang="js" setup></script>
-
-<style>
-div &#123;
-  color: red;
-&#125;
-</style>
-</>;
+	<><template><div>{count}</div></template><script lang="js" setup></script><style></style></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/comments_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/comments_vue.snap
@@ -1,14 +1,7 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
-	<><template>
-  <div v-bind:key={1}>{}</div>
-</template>
-
-<script lang="ts"></script>
-
-<script lang="ts" setup></script>
-</>;
+	<><template><div v-bind:key={1}>{}</div></template><script lang="ts"></script><script lang="ts" setup></script></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/components_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/components_vue.snap
@@ -1,18 +1,9 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 import SomeComponent from "./SomeComponent.vue";
 import { motion } from "motion-v";
 async () => {
-	<><template>
-  <SomeComponent />
-  <SomeComponent />
-  <Transition></Transition>
-  <component></component>
-  <motion.div></motion.div>
-</template>
-
-<script lang="ts" setup></script>
-</>;
+	<><template><SomeComponent /><SomeComponent /><Transition></Transition><component></component><motion.div></motion.div></template><script lang="ts" setup></script></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_basic_vue.snap
@@ -3,20 +3,8 @@ source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
-	<><template>
-  <div v-bind:class={"w-100"} />
-  <div v-bind:__v_some___={{ [some]: 2 }} />
-  <Some v-slot:default={undefined} />{{ default: ({ a }) => <></> }}
-  <input v-model:__v___={text} />
-  <Some v-bind:__v_some_none__={1} />
-  <div v-bind:id={id} />
-  <div v-bind:msg-id={msgId} />
-  <div {...{
+	<><template><div v-bind:class={"w-100"} /><div v-bind:__v_some___={{ [some]: 2 }} /><Some v-slot:default={undefined} />{{ default: ({ a }) => <></> }}<input v-model:__v___={text} /><Some v-bind:__v_some_none__={1} /><div v-bind:id={id} /><div v-bind:msg-id={msgId} /><div {...{
 		id: "app",
 		class: "w-100"
-	}} />
-  <div {...{ id: "app" }} />
-  <div v-bind:__v_1foo__={bar} />
-</template>
-</>;
+	}} /><div {...{ id: "app" }} /><div v-bind:__v_1foo__={bar} /></template></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for_vue.snap
@@ -1,19 +1,7 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
-	<><template>
-  {source((item) => <div v-for:__v___={undefined} />)}
-  {source1((item1) => <div v-for:__v___={undefined} />)}
-  {source2((item2, index2) => <div v-for:__v___={undefined} />)}
-  {source3((item3 = "1", index3 = 99) => <div v-for:__v___={undefined} />)}
-  {users4(({ id4, name4 }) => <div v-for:__v___={undefined} />)}
-  {users5(({ id5, name5 }, index) => <div v-for:__v___={undefined} />)}
-  {users6(({ id6 = 1, name6 = "Liang" }, index) => <div v-for:__v___={undefined} />)}
-  {someObj7((key7, value7, index7) => <div v-for:__v___={undefined} />)}
-  {someIter8(([item8, index8]) => <div v-for:__v___={undefined} />)}
-  {someIter9(([item9 = "hi", index9]) => <div v-for:__v___={undefined} />)}
-</template>
-</>;
+	<><template>{source((item) => <div v-for:__v___={undefined} />)}{source1((item1) => <div v-for:__v___={undefined} />)}{source2((item2, index2) => <div v-for:__v___={undefined} />)}{source3((item3 = "1", index3 = 99) => <div v-for:__v___={undefined} />)}{users4(({ id4, name4 }) => <div v-for:__v___={undefined} />)}{users5(({ id5, name5 }, index) => <div v-for:__v___={undefined} />)}{users6(({ id6 = 1, name6 = "Liang" }, index) => <div v-for:__v___={undefined} />)}{someObj7((key7, value7, index7) => <div v-for:__v___={undefined} />)}{someIter8(([item8, index8]) => <div v-for:__v___={undefined} />)}{someIter9(([item9 = "hi", index9]) => <div v-for:__v___={undefined} />)}</template></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-if_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-if_vue.snap
@@ -1,21 +1,7 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
-	<><template>
-  
-  
-  
-  
-  {a ? <><div v-if:__v___={undefined}>A</div></> : b ? <><div v-else-if:__v___={undefined}>B</div></> : c ? <><div v-else-if:__v___={undefined}>C</div></> : d ? <><div v-else-if:__v___={undefined}>D</div></> : <><div v-else:__v___>E</div></>}
-  
-  
-  {x ? <><div v-if:__v___={undefined}>X</div></> : <><div v-else:__v___>Y</div></>}
-  
-  
-  {z ? <><div v-if:__v___={undefined}>Z</div></> : undefined}
-  {w ? <><div v-if:__v___={undefined}>W</div></> : undefined}<div>K</div>
-</template>
-</>;
+	<><template>{a ? <><div v-if:__v___={undefined}></div></> : b ? <><div v-else-if:__v___={undefined}></div></> : c ? <><div v-else-if:__v___={undefined}></div></> : d ? <><div v-else-if:__v___={undefined}></div></> : <><div v-else:__v___></div></>}{x ? <><div v-if:__v___={undefined}></div></> : <><div v-else:__v___></div></>}{z ? <><div v-if:__v___={undefined}></div></> : undefined}{w ? <><div v-if:__v___={undefined}></div></> : undefined}<div></div></template></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-slot_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-slot_vue.snap
@@ -1,27 +1,7 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
-	<><template>
-  <Comp v-slot:__v___={undefined}>{{ default: ({ message }) => <></> }}</Comp>
-  <Comp v-slot:header={undefined}>{{ header: ({ message }) => <>
-    {message}
-  </> }}</Comp>
-  <Comp v-slot:abc>{{ abc: () => <> abc </> }}</Comp>
-  <Comp v-slot:__v___ />{{ default: () => <></> }}
-  <Comp v-slot:header={undefined}>{{ header: ({ message }) => <>
-    {message}
-  </> }}</Comp>
-  <Comp v-slot:__v___={undefined}>{{ default: ({ message }) => <>
-    {message}
-  </> }}</Comp>
-  <Comp v-slot:__v_key___={undefined}>{{ [key]: ({ message }) => <>
-    {message}
-  </> }}</Comp>
-  <Comp v-slot:header={undefined}>{{ header: (user) => <>
-    {user.name}
-  </> }}</Comp>
-</template>
-</>;
+	<><template><Comp v-slot:__v___={undefined}>{{ default: ({ message }) => <></> }}</Comp><Comp v-slot:header={undefined}>{{ header: ({ message }) => <>{message}</> }}</Comp><Comp v-slot:abc>{{ abc: () => <></> }}</Comp><Comp v-slot:__v___ />{{ default: () => <></> }}<Comp v-slot:header={undefined}>{{ header: ({ message }) => <>{message}</> }}</Comp><Comp v-slot:__v___={undefined}>{{ default: ({ message }) => <>{message}</> }}</Comp><Comp v-slot:__v_key___={undefined}>{{ [key]: ({ message }) => <>{message}</> }}</Comp><Comp v-slot:header={undefined}>{{ header: (user) => <>{user.name}</> }}</Comp></template></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/error_empty_multiple_scripts_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/error_empty_multiple_scripts_vue.snap
@@ -1,11 +1,8 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 const a = 1;
 async () => {
-	<><script></script>
-
-<script></script>
-</>;
+	<><script></script><script></script></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/root_texts_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/root_texts_vue.snap
@@ -1,18 +1,7 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
-	<><template></template><script></script>
-
-&lt;!-- aaa --&gt;
-
-<script></script>
-
-&lt;!-- &lt;script&gt; &lt;/script&gt; --&gt;
-
-<style></style>
-
-123123
-</>;
+	<><template></template><script></script><script></script><style></style></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_basic_vue.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 const count = 0;
@@ -7,11 +7,5 @@ export default { data() {
 	return { count };
 } };
 async () => {
-	<><template>
-  <div></div>
-</template>
-
-<script></script>
-
-</>;
+	<><template><div></div></template><script></script></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_both_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_both_vue.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 import { ref } from "vue";
@@ -9,12 +9,5 @@ export default { data() {
 } };
 async () => {
 	const number = ref(-1);
-	<><template>
-  <div></div>
-</template>
-
-<script setup></script>
-
-<script></script>
-</>;
+	<><template><div></div></template><script setup></script><script></script></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_directives_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_directives_vue.snap
@@ -1,12 +1,9 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 "use client";
 async () => {
 	"use server";
-	<><script></script>
-
-<script setup></script>
-</>;
+	<><script></script><script setup></script></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_empty_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_empty_vue.snap
@@ -1,14 +1,7 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
-	<><template>
-  <div></div>
-</template>
-
-<script setup></script>
-
-<script></script>
-</>;
+	<><template><div></div></template><script setup></script><script></script></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_setup_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_setup_vue.snap
@@ -1,14 +1,9 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 import { ref } from "vue";
 async () => {
 	const count = ref(0);
-	<><template>
-  <div></div>
-</template>
-
-<script setup></script>
-</>;
+	<><template><div></div></template><script setup></script></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/tags_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/tags_vue.snap
@@ -1,15 +1,7 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
-	<><template>
-  <div class="1"></div>
-  <div></div>
-  <div class="w-1" />
-  <main class="1" />
-  <img />
-  <br />
-</template>
-</>;
+	<><template><div class="1"></div><div></div><div class="w-1" /><main class="1" /><img /><br /></template></>;
 };

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/typescript_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/typescript_vue.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/codegen.rs
+source: crates/vue_oxlint_jsx/src/test/mod.rs
 expression: "&codegen"
 ---
 async () => {
@@ -7,11 +7,5 @@ async () => {
 		msg: 1;
 	}>();
 	const b = someFunction<SomeType>();
-	<><script lang="ts" setup></script>
-
-<template>
-  <div>{a.msg}</div>
-  <div> I think 1 &lt; 2, isn't it? </div>
-</template>
-</>;
+	<><script lang="ts" setup></script><template><div>{a.msg}</div><div></div></template></>;
 };


### PR DESCRIPTION
## Summary
- remove `JSXText` support from the parser and codegen paths entirely
- stop emitting template text nodes in the generated AST and codegen output
- update mapping docs and refresh AST/codegen snapshots for the new text-free behavior

## Why
This toolkit was originally designed around projecting a Vue SFC into a JSX-shaped program so the existing Oxc parser and linter pipeline could inspect the whole file. That made `JSXText` a natural representation for plain template text.

The current direction is narrower. The near-term value is in script-oriented linting and type checking, while template-specific linting is expected to keep relying on Vue ESLint tooling. Under that constraint, template text does not contribute useful semantics for the current downstream consumers, but it still increases parser complexity, output noise, snapshot churn, and future migration surface.

Removing `JSXText` now also reduces coupling to the current internal parser implementation. If the project later replaces the parsing backend or moves toward a more direct Rust AST integration, re-introducing a dedicated text-node representation will be comparatively cheap if it becomes necessary again.

## What Changed
- `AstNode::Text` is now dropped during Vue template traversal instead of being converted into JSX children
- text segments surrounding template elements and interpolations are no longer materialized as JSX children either
- codegen inherits the same behavior automatically because it is built on top of the parser output
- `MAPPING.md` now documents that plain template text is intentionally omitted

## Breaking Change
`vue_oxlint_jsx` no longer emits `JSXText` nodes for Vue template text. Any downstream consumer that relied on template text appearing in the JSX-shaped AST or generated source must be updated.

Concretely, this affects:
- AST consumers that previously visited `JSXText` children in template subtrees
- snapshot or fixture expectations that included plain text nodes
- codegen consumers that expected template text to survive in the generated JSX-like source

Interpolations such as `{{ msg }}` are unchanged and still become `JSXExpressionContainer` nodes.

## Testing
- `just lint`
- `just test`
