### PR TITLE
refactor: vendor oxc codegen in vue_oxlint_jsx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Cargo workspace members live in `crates/*`, `packages/*`, and `benchmark/`.
 - **`crates/vue_oxlint_jsx`** — the active crate. Parses a Vue SFC and produces either a JS/TS AST (`VueJsxParser`) or generated source text (`VueJsxCodegen`).
   - `parser/` — One of the most core part, including SFC tokenization, script/template handling, module-record building, irregular-whitespace tracking, and Vue-specific element handlers (`elements/v_for.rs`, `v_if.rs`, `v_slot.rs`, `directive.rs`).
   - `codegen/` — wraps `parser` and transform the ast into source_text, producing `VueJsxCodegenReturn { source_text, source_type, comments, irregular_whitespaces, errors, panicked }`.
+  - `codegen/oxc/` — vendored fork of `oxc_codegen`, scoped to the Vue crate so codegen changes can be made locally without waiting on upstream releases. The local fork intentionally omits sourcemap support.
   - `test/` — `test_ast!` and `test_module_record!` macros driving snapshot tests in `test/snapshots/`. `test_ast!` runs both AST and codegen checks on each fixture.
   - Public API is intentionally narrow: `VueJsxParser`/`VueJsxParserReturn` + `VueJsxCodegen`/`VueJsxCodegenReturn` (re-exported from `lib.rs`).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,16 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
-
-[[package]]
 name = "benchmark"
 version = "0.12.0"
 dependencies = [
@@ -608,12 +598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
-name = "json-escape-simd"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c2a6c0b4b5637c41719973ef40c6a1cf564f9db6958350de6193fbee9c23f5"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,12 +787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,28 +870,6 @@ dependencies = [
  "oxc_ast",
  "oxc_span",
  "oxc_syntax",
-]
-
-[[package]]
-name = "oxc_codegen"
-version = "0.128.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef50fad09eabcf3bd416036da34af8dd08979c0e9193745782c93fb7eed585f"
-dependencies = [
- "bitflags 2.11.0",
- "cow-utils",
- "dragonbox_ecma",
- "itoa",
- "oxc_allocator",
- "oxc_ast",
- "oxc_data_structures",
- "oxc_index",
- "oxc_semantic",
- "oxc_sourcemap",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
- "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -1025,19 +981,6 @@ dependencies = [
  "oxc_syntax",
  "rustc-hash 2.1.2",
  "self_cell",
-]
-
-[[package]]
-name = "oxc_sourcemap"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d378eb8bad20e89d66276aebab51f6a5408571092cac94abdd3eabb773713d6"
-dependencies = [
- "base64-simd",
- "json-escape-simd",
- "rustc-hash 2.1.2",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1658,12 +1601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
 name = "vue-compiler-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,17 +1618,25 @@ dependencies = [
 name = "vue_oxlint_jsx"
 version = "0.12.0"
 dependencies = [
+ "bitflags 2.11.0",
+ "cow-utils",
+ "dragonbox_ecma",
  "insta",
+ "itoa",
  "memchr",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
- "oxc_codegen",
+ "oxc_data_structures",
  "oxc_diagnostics",
+ "oxc_index",
  "oxc_parser",
+ "oxc_semantic",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "regex",
+ "rustc-hash 2.1.2",
  "vue-compiler-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,22 @@ vue_oxlint_parser = { path = "crates/vue_oxlint_parser" }
 oxc_allocator = ">=0.128.0"
 oxc_ast = ">=0.128.0"
 oxc_ast_visit = ">=0.128.0"
-oxc_codegen = ">=0.128.0"
+oxc_data_structures = ">=0.128.0"
 oxc_diagnostics = ">=0.128.0"
+oxc_index = ">=4.1.0"
 oxc_parser = ">=0.128.0"
+oxc_semantic = ">=0.128.0"
 oxc_span = ">=0.128.0"
+oxc_str = ">=0.128.0"
 oxc_syntax = ">=0.128.0"
 
+bitflags = "2.10.0"
+cow-utils = "0.1.3"
+dragonbox_ecma = "0.1.0"
+itoa = "1.0.17"
 memchr = "2.8.0"
 regex = "1.12.3"
+rustc-hash = "2.1.1"
 vue-compiler-core = "0.1.0"
 
 napi = { version = "3.8.6", features = ["napi9"] }

--- a/crates/vue_oxlint_jsx/Cargo.toml
+++ b/crates/vue_oxlint_jsx/Cargo.toml
@@ -13,14 +13,22 @@ description.workspace = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
-oxc_codegen = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["code_buffer", "slice_iter", "stack"] }
 oxc_diagnostics = { workspace = true }
+oxc_index = { workspace = true }
 oxc_parser = { workspace = true }
+oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+oxc_str = { workspace = true }
 oxc_syntax = { workspace = true }
 
+bitflags = { workspace = true }
+cow-utils = { workspace = true }
+dragonbox_ecma = { workspace = true }
+itoa = { workspace = true }
 memchr = { workspace = true }
 regex = { workspace = true }
+rustc-hash = { workspace = true }
 vue-compiler-core = { workspace = true }
 
 [dev-dependencies]

--- a/crates/vue_oxlint_jsx/src/codegen/mod.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/mod.rs
@@ -1,11 +1,24 @@
 use oxc_allocator::Allocator;
 use oxc_ast::Comment;
-use oxc_codegen::Codegen;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::ParseOptions;
 use oxc_span::{SourceType, Span};
 
 use crate::parser::{ParseConfig, ParserImpl};
+
+#[allow(
+  clippy::branches_sharing_code,
+  clippy::doc_markdown,
+  clippy::missing_const_for_fn,
+  clippy::option_if_let_else,
+  unfulfilled_lint_expectations,
+  clippy::useless_let_if_seq,
+  clippy::wildcard_imports
+)]
+#[path = "oxc/lib.rs"]
+mod oxc;
+
+pub use self::oxc::Codegen;
 
 /// The return value of [`VueJsxCodegen::build`].
 #[non_exhaustive]

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/binary_expr_visitor.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/binary_expr_visitor.rs
@@ -1,0 +1,228 @@
+//! Visit binary and logical expression in a loop without recursion.
+//!
+//! Reference: <https://github.com/evanw/esbuild/blob/78f89e41d5e8a7088f4820351c6305cc339f8820/internal/js_printer/js_printer.go#L3266>
+
+use std::ops::Not;
+
+use oxc_ast::ast::{BinaryExpression, Expression, LogicalExpression};
+use oxc_syntax::{
+  operator::{BinaryOperator, LogicalOperator},
+  precedence::{GetPrecedence, Precedence},
+};
+
+use super::{Codegen, Context, Operator, r#gen::GenExpr};
+
+#[derive(Clone, Copy)]
+pub enum Binaryish<'a> {
+  Binary(&'a BinaryExpression<'a>),
+  Logical(&'a LogicalExpression<'a>),
+}
+
+impl<'a> Binaryish<'a> {
+  pub fn left(&self) -> &'a Expression<'a> {
+    match self {
+      Self::Binary(e) => e.left.without_parentheses(),
+      Self::Logical(e) => e.left.without_parentheses(),
+    }
+  }
+
+  pub fn right(&self) -> &'a Expression<'a> {
+    match self {
+      Self::Binary(e) => e.right.without_parentheses(),
+      Self::Logical(e) => e.right.without_parentheses(),
+    }
+  }
+
+  pub fn operator(&self) -> BinaryishOperator {
+    match self {
+      Self::Binary(e) => BinaryishOperator::Binary(e.operator),
+      Self::Logical(e) => BinaryishOperator::Logical(e.operator),
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BinaryishOperator {
+  Binary(BinaryOperator),
+  Logical(LogicalOperator),
+}
+
+impl BinaryishOperator {
+  fn is_binary(self) -> bool {
+    matches!(self, Self::Binary(_))
+  }
+}
+
+fn print_binary_operator(op: BinaryOperator, p: &mut Codegen) {
+  let operator = op.as_str();
+  if op.is_keyword() {
+    p.print_space_before_identifier();
+    p.print_str(operator);
+  } else {
+    let op: Operator = op.into();
+    p.print_space_before_operator(op);
+    p.print_str(operator);
+    p.prev_op = Some(op);
+    p.prev_op_end = p.code().len();
+  }
+}
+
+impl BinaryishOperator {
+  fn r#gen(self, p: &mut Codegen) {
+    match self {
+      Self::Binary(op) => print_binary_operator(op, p),
+      Self::Logical(op) => p.print_str(op.as_str()),
+    }
+  }
+}
+
+impl GetPrecedence for BinaryishOperator {
+  fn precedence(&self) -> Precedence {
+    match self {
+      Self::Binary(op) => op.precedence(),
+      Self::Logical(op) => op.precedence(),
+    }
+  }
+}
+
+impl BinaryishOperator {
+  pub fn lower_precedence(self) -> Precedence {
+    match self {
+      Self::Binary(op) => op.lower_precedence(),
+      Self::Logical(op) => op.lower_precedence(),
+    }
+  }
+}
+
+#[derive(Clone, Copy)]
+pub struct BinaryExpressionVisitor<'a> {
+  pub e: Binaryish<'a>,
+  pub precedence: Precedence,
+  pub ctx: Context,
+
+  pub left_precedence: Precedence,
+
+  pub operator: BinaryishOperator,
+  pub wrap: bool,
+  pub right_precedence: Precedence,
+}
+
+impl<'a> BinaryExpressionVisitor<'a> {
+  pub fn gen_expr(v: Self, p: &mut Codegen<'a>) {
+    let mut v = v;
+    let stack_bottom = p.binary_expr_stack.len();
+    loop {
+      if !v.check_and_prepare(p) {
+        break;
+      }
+
+      let left = v.e.left();
+      let left_binary = match left {
+        Expression::BinaryExpression(e) => Some(Binaryish::Binary(e)),
+        Expression::LogicalExpression(e) => Some(Binaryish::Logical(e)),
+        _ => None,
+      };
+
+      let Some(left_binary) = left_binary else {
+        left.gen_expr(p, v.left_precedence, v.ctx);
+        v.visit_right_and_finish(p);
+        break;
+      };
+
+      p.binary_expr_stack.push(v);
+      v = BinaryExpressionVisitor {
+        e: left_binary,
+        precedence: v.left_precedence,
+        ctx: v.ctx,
+        left_precedence: Precedence::Lowest,
+        operator: v.operator,
+        wrap: false,
+        right_precedence: Precedence::Lowest,
+      };
+    }
+
+    loop {
+      let len = p.binary_expr_stack.len();
+      if len == 0 || len - 1 < stack_bottom {
+        break;
+      }
+      let v = p.binary_expr_stack.pop().unwrap();
+      v.visit_right_and_finish(p);
+    }
+  }
+
+  pub fn check_and_prepare(&mut self, p: &mut Codegen) -> bool {
+    let e = self.e;
+
+    // We don't need to print parentheses if both sides use the same logical operator
+    // For example: `(a     &&     b)         && c` should be printed as `a && b && c`
+    //                      ^^  e.operator()  ^^ self.operator
+    let precedence_check = self.precedence >= e.operator().precedence()
+      && (self.operator.is_binary() || self.precedence != self.operator.precedence());
+
+    self.operator = e.operator();
+    self.wrap = precedence_check
+      || (self.operator == BinaryishOperator::Binary(BinaryOperator::In)
+        && self.ctx.intersects(Context::FORBID_IN));
+
+    if self.wrap {
+      p.print_ascii_byte(b'(');
+      // `for (1 * (x == a in b);;);`
+      //           ^^^^^^^^^^^^ has been wrapped in parens, so it doesn't need to
+      //                        print parens for `a in b` again.
+      self.ctx &= Context::FORBID_IN.not();
+    }
+
+    self.left_precedence = self.operator.lower_precedence();
+    self.right_precedence = self.operator.lower_precedence();
+
+    if self.operator.precedence().is_right_associative() {
+      self.left_precedence = self.operator.precedence();
+    }
+
+    if self.operator.precedence().is_left_associative() {
+      self.right_precedence = self.operator.precedence();
+    }
+
+    match self.operator {
+      BinaryishOperator::Logical(LogicalOperator::Coalesce) => {
+        if let Expression::LogicalExpression(logical_expr) = e.left()
+          && matches!(logical_expr.operator, LogicalOperator::And | LogicalOperator::Or)
+        {
+          self.left_precedence = Precedence::Prefix;
+        }
+        if let Expression::LogicalExpression(logical_expr) = e.right()
+          && matches!(logical_expr.operator, LogicalOperator::And | LogicalOperator::Or)
+        {
+          self.right_precedence = Precedence::Prefix;
+        }
+      }
+      BinaryishOperator::Binary(BinaryOperator::Exponential) => {
+        // Negative numbers are printed using a unary operator
+        if matches!(e.left(), Expression::UnaryExpression(_) | Expression::NumericLiteral(_)) {
+          self.left_precedence = Precedence::Call;
+        }
+      }
+
+      _ => {}
+    }
+
+    if let Expression::PrivateInExpression(e) = self.e.left() {
+      e.gen_expr(p, Precedence::Lowest, Context::empty());
+      self.visit_right_and_finish(p);
+      return false;
+    }
+
+    true
+  }
+
+  pub fn visit_right_and_finish(&self, p: &mut Codegen) {
+    p.print_soft_space();
+    self.operator.r#gen(p);
+    p.print_soft_space();
+    self.e.right().gen_expr(p, self.right_precedence, self.ctx);
+    if self.wrap {
+      p.print_ascii_byte(b')');
+    }
+  }
+}

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/comment.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/comment.rs
@@ -1,0 +1,289 @@
+use std::borrow::Cow;
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use oxc_ast::{Comment, CommentKind, ast::Program};
+use oxc_syntax::line_terminator::LineTerminatorSplitter;
+
+use super::{Codegen, LegalComment, options::CommentOptions};
+
+pub type CommentsMap = FxHashMap</* attached_to */ u32, Vec<Comment>>;
+
+impl Codegen<'_> {
+  pub(crate) fn build_comments(&mut self, comments: &[Comment]) {
+    if self.options.comments == CommentOptions::disabled() {
+      return;
+    }
+    for comment in comments {
+      // Omit pure comments because they are handled separately.
+      if comment.is_pure() || comment.is_no_side_effects() {
+        continue;
+      }
+      let mut add = false;
+      if comment.is_leading() {
+        if comment.is_legal() && self.options.print_legal_comment() {
+          add = true;
+        }
+        if comment.is_jsdoc() && self.options.print_jsdoc_comment() {
+          add = true;
+        }
+        if comment.is_annotation() && self.options.print_annotation_comment() {
+          add = true;
+        }
+        if comment.is_normal() && self.options.print_normal_comment() {
+          add = true;
+        }
+      }
+      if add {
+        if comment.is_legal()
+          && let Err(idx) = self.legal_comment_keys.binary_search(&comment.attached_to)
+        {
+          self.legal_comment_keys.insert(idx, comment.attached_to);
+        }
+        self.comments.entry(comment.attached_to).or_default().push(*comment);
+      }
+    }
+  }
+
+  pub(crate) fn has_comment(&self, start: u32) -> bool {
+    self.comments.contains_key(&start)
+  }
+
+  pub(crate) fn print_leading_comments(&mut self, start: u32) {
+    if let Some(comments) = self.comments.remove(&start) {
+      self.print_comments(&comments);
+    }
+  }
+
+  pub(crate) fn get_comments(&mut self, start: u32) -> Option<Vec<Comment>> {
+    if self.comments.is_empty() {
+      return None;
+    }
+    self.comments.remove(&start)
+  }
+
+  #[inline]
+  pub(crate) fn print_comments_at(&mut self, start: u32) {
+    if let Some(comments) = self.get_comments(start) {
+      self.print_comments(&comments);
+    }
+  }
+
+  /// Whether a legal-comment orphan with `attached_to < end` is still
+  /// pending. Used by block emitters to keep an empty body multi-line.
+  #[inline]
+  pub(crate) fn has_legal_orphans_before(&self, end: u32) -> bool {
+    self.legal_comment_keys.iter().take_while(|&&k| k < end).any(|k| self.comments.contains_key(k))
+  }
+
+  /// Drain pending legal-comment orphans with `attached_to < end` and emit
+  /// them in source order. Called at every statement boundary so legal
+  /// comments survive when their original anchor was removed by DCE.
+  #[inline]
+  pub(crate) fn print_legal_orphans_before(&mut self, end: u32) {
+    if self.legal_comment_keys.is_empty() {
+      return;
+    }
+    let idx = self.legal_comment_keys.partition_point(|&k| k < end);
+    if idx == 0 {
+      return;
+    }
+    // Concatenate across keys so `print_comments` sees one sequence;
+    // per-key calls would leak `print_next_indent_as_space` and produce
+    // stray leading spaces.
+    let mut legals: Vec<Comment> = Vec::new();
+    let comments = &mut self.comments;
+    for k in self.legal_comment_keys.drain(..idx) {
+      let Some(entry) = comments.get_mut(&k) else { continue };
+      debug_assert!(entry.iter().any(|c| c.is_legal()));
+      legals.extend(entry.extract_if(.., |c| c.is_legal()));
+      if entry.is_empty() {
+        comments.remove(&k);
+      }
+    }
+    if !legals.is_empty() {
+      self.print_comments(&legals);
+    }
+  }
+
+  /// Print comments attached to any position in the given range `(start, end)` (exclusive).
+  /// Returns `true` if any comments were printed.
+  pub(crate) fn print_comments_in_range(&mut self, start: u32, end: u32) -> bool {
+    if self.comments.is_empty() {
+      return false;
+    }
+    // Find and remove the first key in the range.
+    let key = self.comments.keys().find(|&&k| k > start && k < end).copied();
+    if let Some(key) = key {
+      let comments = self.comments.remove(&key).unwrap();
+      self.print_comments(&comments);
+      return true;
+    }
+    false
+  }
+
+  pub(crate) fn print_expr_comments(&mut self, start: u32) -> bool {
+    if self.comments.is_empty() {
+      return false;
+    }
+    let Some(comments) = self.comments.remove(&start) else { return false };
+
+    for comment in &comments {
+      self.print_hard_newline();
+      self.print_indent();
+      self.print_comment(comment);
+    }
+
+    if comments.is_empty() {
+      false
+    } else {
+      self.print_hard_newline();
+      true
+    }
+  }
+
+  pub(crate) fn print_comments(&mut self, comments: &[Comment]) {
+    let Some((first, rest)) = comments.split_first() else {
+      return;
+    };
+
+    if first.preceded_by_newline() {
+      // Skip printing newline if this comment is already on a newline.
+      if let Some(b) = self.last_byte() {
+        match b {
+          b'\n' => self.print_indent(),
+          b'\t' => { /* noop */ }
+          _ => {
+            self.print_hard_newline();
+            self.print_indent();
+          }
+        }
+      }
+    } else {
+      self.print_indent();
+    }
+    self.print_comment(first);
+
+    if let Some((last, middle)) = rest.split_last() {
+      for comment in middle {
+        if comment.preceded_by_newline() {
+          self.print_hard_newline();
+          self.print_indent();
+        } else if comment.is_legal() {
+          self.print_hard_newline();
+        } else {
+          self.print_soft_space();
+        }
+        self.print_comment(comment);
+      }
+
+      if last.preceded_by_newline() {
+        self.print_hard_newline();
+        self.print_indent();
+      } else if last.is_legal() {
+        self.print_hard_newline();
+      } else {
+        self.print_soft_space();
+      }
+      self.print_comment(last);
+
+      if last.is_line() || last.followed_by_newline() {
+        self.print_hard_newline();
+      } else {
+        self.print_next_indent_as_space = true;
+      }
+    } else if first.is_line() || first.followed_by_newline() {
+      self.print_hard_newline();
+    } else {
+      self.print_next_indent_as_space = true;
+    }
+  }
+
+  fn print_comment(&mut self, comment: &Comment) {
+    let Some(source_text) = self.source_text else {
+      return;
+    };
+    let comment_source = comment.span.source_text(source_text);
+    match comment.kind {
+      CommentKind::Line | CommentKind::SingleLineBlock => {
+        self.print_str_escaping_script_close_tag(comment_source);
+      }
+      CommentKind::MultiLineBlock => {
+        for line in LineTerminatorSplitter::new(comment_source) {
+          if !line.starts_with("/*") {
+            self.print_indent();
+          }
+          self.print_str_escaping_script_close_tag(line.trim_start());
+          if !line.ends_with("*/") {
+            self.print_hard_newline();
+          }
+        }
+      }
+    }
+  }
+
+  /// Handle Eof / Linked / External Comments.
+  /// Return a list of comments of linked or external.
+  pub(crate) fn handle_eof_linked_or_external_comments(
+    &mut self,
+    program: &Program<'_>,
+  ) -> Vec<Comment> {
+    let legal_comments = &self.options.comments.legal;
+    if matches!(legal_comments, LegalComment::None | LegalComment::Inline) {
+      return vec![];
+    }
+
+    // Dedupe legal comments for smaller output size.
+    let mut set = FxHashSet::default();
+    let mut comments = vec![];
+
+    let source_text = program.source_text;
+    for comment in program.comments.iter().filter(|c| c.is_legal()) {
+      let mut text = Cow::Borrowed(comment.span.source_text(source_text));
+      if comment.is_multiline_block() {
+        let mut buffer = String::with_capacity(text.len());
+        // Print block comments with our own indentation.
+        for line in LineTerminatorSplitter::new(&text) {
+          if !line.starts_with("/*") {
+            buffer.push('\t');
+          }
+          buffer.push_str(line.trim_start());
+          if !line.ends_with("*/") {
+            buffer.push('\n');
+          }
+        }
+        text = Cow::Owned(buffer);
+      }
+      if set.insert(text) {
+        comments.push(*comment);
+      }
+    }
+
+    if comments.is_empty() {
+      return vec![];
+    }
+
+    match legal_comments {
+      LegalComment::Eof => {
+        self.print_hard_newline();
+        // Clear the flag to ensure consistent formatting for all EOF comments
+        self.print_next_indent_as_space = false;
+        for c in comments {
+          self.print_comment(&c);
+          self.print_hard_newline();
+        }
+        vec![]
+      }
+      LegalComment::Linked(path) => {
+        let path = path.clone();
+        self.print_hard_newline();
+        self.print_str("/*! For license information please see ");
+        self.print_str(&path);
+        self.print_str(" */");
+        comments
+      }
+      LegalComment::External => comments,
+      LegalComment::None | LegalComment::Inline => unreachable!(),
+    }
+  }
+}

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/context.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/context.rs
@@ -1,0 +1,53 @@
+//! Code generation context management
+//!
+//! This module provides the [`Context`] type for managing the state and configuration
+//! during code generation, including JavaScript/TypeScript-specific syntax rules.
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Code generation context flags
+    ///
+    /// Controls various aspects of code generation including operator precedence,
+    /// language features, and syntax restrictions.
+    #[derive(Debug, Default, Clone, Copy)]
+    pub struct Context: u8 {
+        /// Forbid the `in` operator in expressions
+        ///
+        /// Used in contexts where the `in` operator could be ambiguous,
+        /// such as in the init clause of a for loop.
+        const FORBID_IN   = 1 << 0;
+        /// Forbid call expressions
+        ///
+        /// Used to prevent ambiguity in contexts like new expressions
+        /// where parentheses could be interpreted differently.
+        const FORBID_CALL = 1 << 1;
+        /// Enable TypeScript-specific code generation
+        ///
+        /// When set, TypeScript syntax features are enabled in the output.
+        const TYPESCRIPT  = 1 << 2;
+    }
+}
+
+impl Context {
+  /// Create a new context with TypeScript support enabled
+  #[inline]
+  #[must_use]
+  pub fn with_typescript(mut self) -> Self {
+    self |= Self::TYPESCRIPT;
+    self
+  }
+
+  /// Conditionally set or unset the `FORBID_CALL` flag
+  #[inline]
+  #[must_use]
+  pub fn and_forbid_call(self, include: bool) -> Self {
+    self.and(Self::FORBID_CALL, include)
+  }
+
+  /// Helper method to conditionally set or unset a flag
+  #[inline]
+  fn and(self, flag: Self, set: bool) -> Self {
+    if set { self | flag } else { self - flag }
+  }
+}

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/gen.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/gen.rs
@@ -1,0 +1,3988 @@
+use std::ops::Not;
+
+use cow_utils::CowUtils;
+
+use oxc_ast::ast::*;
+use oxc_span::GetSpan;
+use oxc_syntax::{
+  operator::UnaryOperator,
+  precedence::{GetPrecedence, Precedence},
+};
+
+use super::{
+  Codegen, Context, Operator, Quote,
+  binary_expr_visitor::{BinaryExpressionVisitor, Binaryish, BinaryishOperator},
+};
+
+const PURE_COMMENT: &str = "/* @__PURE__ */ ";
+const NO_SIDE_EFFECTS_NEW_LINE_COMMENT: &str = "/* @__NO_SIDE_EFFECTS__ */\n";
+const NO_SIDE_EFFECTS_COMMENT: &str = "/* @__NO_SIDE_EFFECTS__ */ ";
+
+/// Generate source code for an AST node.
+pub trait Gen: GetSpan {
+  /// Generate code for an AST node.
+  fn r#gen(&self, p: &mut Codegen, ctx: Context);
+
+  /// Generate code for an AST node. Alias for `gen`.
+  #[inline]
+  fn print(&self, p: &mut Codegen, ctx: Context) {
+    self.r#gen(p, ctx);
+  }
+}
+
+/// Generate source code for an expression.
+pub trait GenExpr: GetSpan {
+  /// Generate code for an expression, respecting operator precedence.
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context);
+
+  /// Generate code for an expression, respecting operator precedence. Alias for `gen_expr`.
+  #[inline]
+  fn print_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    self.gen_expr(p, precedence, ctx);
+  }
+}
+
+impl Gen for Program<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.is_jsx = self.source_type.is_jsx();
+
+    // Allow for inserting comments to the top of the file.
+    p.print_comments_at(0);
+    if let Some(hashbang) = &self.hashbang {
+      hashbang.print(p, ctx);
+    }
+    p.print_directives_and_statements(&self.directives, &self.body, self.span.end, ctx);
+    p.print_semicolon_if_needed();
+    // Print trailing statement comments.
+    p.print_comments_at(self.span.end);
+  }
+}
+
+impl Gen for Hashbang<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_str("#!");
+    p.print_str(self.value.as_str());
+    p.print_hard_newline();
+  }
+}
+
+impl Gen for Directive<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.add_source_mapping(self.span);
+    p.print_indent();
+    // A Use Strict Directive may not contain an EscapeSequence or LineContinuation.
+    // So here should print original `directive` value, the `expression` value is escaped str.
+    // See https://github.com/babel/babel/blob/v7.26.2/packages/babel-generator/src/generators/base.ts#L64
+    let directive = self.directive.as_str();
+
+    let mut bytes = directive.as_bytes().iter();
+    let mut quote = p.quote;
+    while let Some(&b) = bytes.next() {
+      match b {
+        b'"' => {
+          quote = Quote::Single;
+          break;
+        }
+        b'\'' => {
+          quote = Quote::Double;
+          break;
+        }
+        b'\\' => {
+          bytes.next();
+        }
+        _ => {}
+      }
+    }
+    quote.print(p);
+    p.print_str(directive);
+    quote.print(p);
+    p.print_ascii_byte(b';');
+    p.print_soft_newline();
+  }
+}
+
+impl Gen for Statement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      // Most common statements first (based on parser order and frequency)
+      Self::BlockStatement(stmt) => {
+        p.print_comments_at(stmt.span.start);
+        stmt.print(p, ctx);
+      }
+      Self::ExpressionStatement(stmt) => stmt.print(p, ctx),
+      Self::VariableDeclaration(decl) => {
+        p.print_comments_at(decl.span.start);
+        p.print_indent();
+        decl.print(p, ctx);
+        p.print_semicolon_after_statement();
+      }
+      Self::IfStatement(stmt) => stmt.print(p, ctx),
+      Self::ReturnStatement(stmt) => stmt.print(p, ctx),
+      Self::FunctionDeclaration(decl) => {
+        p.print_comments_at(decl.span.start);
+        if decl.pure && p.options.print_annotation_comment() {
+          p.print_indent();
+          p.print_str(NO_SIDE_EFFECTS_NEW_LINE_COMMENT);
+        }
+        p.print_indent();
+        decl.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::ForStatement(stmt) => stmt.print(p, ctx),
+      Self::WhileStatement(stmt) => stmt.print(p, ctx),
+      Self::DoWhileStatement(stmt) => stmt.print(p, ctx),
+      Self::SwitchStatement(stmt) => stmt.print(p, ctx),
+      Self::BreakStatement(stmt) => stmt.print(p, ctx),
+      Self::ContinueStatement(stmt) => stmt.print(p, ctx),
+      Self::TryStatement(stmt) => stmt.print(p, ctx),
+      Self::ThrowStatement(stmt) => stmt.print(p, ctx),
+      Self::ForInStatement(stmt) => stmt.print(p, ctx),
+      Self::ForOfStatement(stmt) => stmt.print(p, ctx),
+      Self::ClassDeclaration(decl) => {
+        p.print_comments_at(decl.span.start);
+        p.print_indent();
+        decl.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::LabeledStatement(stmt) => stmt.print(p, ctx),
+      Self::EmptyStatement(stmt) => stmt.print(p, ctx),
+      Self::ImportDeclaration(decl) => decl.print(p, ctx),
+      Self::ExportNamedDeclaration(decl) => decl.print(p, ctx),
+      Self::ExportDefaultDeclaration(decl) => decl.print(p, ctx),
+      Self::ExportAllDeclaration(decl) => decl.print(p, ctx),
+      Self::WithStatement(stmt) => stmt.print(p, ctx),
+      Self::DebuggerStatement(stmt) => stmt.print(p, ctx),
+      // TypeScript-specific (less common)
+      Self::TSModuleDeclaration(decl) => {
+        p.print_comments_at(decl.span.start);
+        p.print_indent();
+        decl.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::TSGlobalDeclaration(decl) => {
+        p.print_comments_at(decl.span.start);
+        p.print_indent();
+        decl.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::TSTypeAliasDeclaration(decl) => {
+        p.print_indent();
+        p.print_comments_at(decl.span.start);
+        decl.print(p, ctx);
+        p.print_semicolon_after_statement();
+      }
+      Self::TSInterfaceDeclaration(decl) => {
+        p.print_indent();
+        p.print_comments_at(decl.span.start);
+        decl.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::TSEnumDeclaration(decl) => {
+        p.print_indent();
+        p.print_comments_at(decl.span.start);
+        decl.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::TSExportAssignment(decl) => decl.print(p, ctx),
+      Self::TSNamespaceExportDeclaration(decl) => decl.print(p, ctx),
+      Self::TSImportEqualsDeclaration(decl) => {
+        p.print_indent();
+        p.print_comments_at(decl.span.start);
+        decl.print(p, ctx);
+        p.print_semicolon_after_statement();
+      }
+    }
+  }
+}
+
+impl Gen for ExpressionStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_comments_at(self.span.start);
+    if !p.options.minify && (p.indent > 0 || p.print_next_indent_as_space) {
+      p.print_indent();
+      p.add_source_mapping(self.span);
+    }
+    p.start_of_stmt = p.code_len();
+    p.print_expression(&self.expression);
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for IfStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    print_if(self, p, ctx);
+  }
+}
+
+fn print_if(if_stmt: &IfStatement<'_>, p: &mut Codegen, ctx: Context) {
+  p.print_space_before_identifier();
+  p.add_source_mapping(if_stmt.span);
+  p.print_str("if");
+  p.print_soft_space();
+  p.print_ascii_byte(b'(');
+  p.print_expression(&if_stmt.test);
+  p.print_ascii_byte(b')');
+
+  match &if_stmt.consequent {
+    Statement::BlockStatement(block) => {
+      p.print_soft_space();
+      p.print_block_statement(block, ctx);
+      if if_stmt.alternate.is_some() {
+        p.print_soft_space();
+      } else {
+        p.print_soft_newline();
+      }
+    }
+    stmt if wrap_to_avoid_ambiguous_else(stmt) => {
+      p.print_soft_space();
+      p.print_block_start(stmt.span());
+      stmt.print(p, ctx);
+      p.needs_semicolon = false;
+      p.print_block_end(stmt.span());
+      if if_stmt.alternate.is_some() {
+        p.print_soft_space();
+      } else {
+        p.print_soft_newline();
+      }
+    }
+    stmt => {
+      p.print_body(stmt, false, ctx);
+      if if_stmt.alternate.is_some() {
+        p.print_indent();
+      }
+    }
+  }
+  if let Some(alternate) = if_stmt.alternate.as_ref() {
+    p.print_semicolon_if_needed();
+    p.print_space_before_identifier();
+    p.print_str("else");
+    match alternate {
+      Statement::BlockStatement(block) => {
+        p.print_soft_space();
+        p.print_block_statement(block, ctx);
+        p.print_soft_newline();
+      }
+      Statement::IfStatement(if_stmt) => {
+        p.print_hard_space();
+        print_if(if_stmt, p, ctx);
+      }
+      stmt => p.print_body(stmt, true, ctx),
+    }
+  }
+}
+
+// <https://github.com/evanw/esbuild/blob/e6a8169c3a574f4c67d4cdd5f31a938b53eb7421/internal/js_printer/js_printer.go#L3444>
+fn wrap_to_avoid_ambiguous_else(stmt: &Statement) -> bool {
+  let mut current = stmt;
+  loop {
+    current = match current {
+      Statement::IfStatement(if_stmt) => {
+        if let Some(stmt) = &if_stmt.alternate {
+          stmt
+        } else {
+          return true;
+        }
+      }
+      Statement::ForStatement(for_stmt) => &for_stmt.body,
+      Statement::ForOfStatement(for_of_stmt) => &for_of_stmt.body,
+      Statement::ForInStatement(for_in_stmt) => &for_in_stmt.body,
+      Statement::WhileStatement(while_stmt) => &while_stmt.body,
+      Statement::WithStatement(with_stmt) => &with_stmt.body,
+      Statement::LabeledStatement(labeled_stmt) => &labeled_stmt.body,
+      _ => return false,
+    }
+  }
+}
+
+impl Gen for BlockStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_indent();
+    p.print_block_statement(self, ctx);
+    p.print_soft_newline();
+  }
+}
+
+impl Gen for ForStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("for");
+    p.print_soft_space();
+    p.print_ascii_byte(b'(');
+
+    if let Some(init) = &self.init {
+      init.print(p, Context::FORBID_IN);
+    }
+
+    p.print_semicolon();
+
+    if let Some(test) = self.test.as_ref() {
+      p.print_soft_space();
+      p.print_expression(test);
+    }
+
+    p.print_semicolon();
+
+    if let Some(update) = self.update.as_ref() {
+      p.print_soft_space();
+      p.print_expression(update);
+    }
+
+    p.print_ascii_byte(b')');
+    p.print_body(&self.body, false, ctx);
+  }
+}
+
+impl Gen for ForInStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("for");
+    p.print_soft_space();
+    p.print_ascii_byte(b'(');
+    self.left.print(p, Context::FORBID_IN);
+    p.print_soft_space();
+    p.print_space_before_identifier();
+    p.print_str("in");
+    p.print_soft_space();
+    p.print_expression(&self.right);
+    p.print_ascii_byte(b')');
+    p.print_body(&self.body, false, ctx);
+  }
+}
+
+impl Gen for ForOfStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("for");
+    if self.r#await {
+      p.print_str(" await");
+    }
+    p.print_soft_space();
+    p.print_ascii_byte(b'(');
+    self.left.print(p, ctx);
+    p.print_soft_space();
+    p.print_space_before_identifier();
+    p.print_str("of");
+    p.print_soft_space();
+    self.right.print_expr(p, Precedence::Comma, Context::empty());
+    p.print_ascii_byte(b')');
+    p.print_body(&self.body, false, ctx);
+  }
+}
+
+impl Gen for ForStatementInit<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::VariableDeclaration(var) => var.print(p, ctx),
+      _ => self.to_expression().print_expr(p, Precedence::Lowest, ctx),
+    }
+  }
+}
+
+impl Gen for ForStatementLeft<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      ForStatementLeft::VariableDeclaration(var) => var.print(p, ctx),
+      ForStatementLeft::AssignmentTargetIdentifier(identifier) => {
+        let wrap = identifier.name == "async";
+        p.wrap(wrap, |p| self.to_assignment_target().print(p, ctx));
+      }
+      match_assignment_target!(ForStatementLeft) => {
+        p.wrap(false, |p| self.to_assignment_target().print(p, ctx));
+      }
+    }
+  }
+}
+
+impl Gen for WhileStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("while");
+    p.print_soft_space();
+    p.print_ascii_byte(b'(');
+    p.print_expression(&self.test);
+    p.print_ascii_byte(b')');
+    p.print_body(&self.body, false, ctx);
+  }
+}
+
+impl Gen for DoWhileStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("do");
+    match &self.body {
+      Statement::BlockStatement(block) => {
+        p.print_soft_space();
+        p.print_block_statement(block, ctx);
+        p.print_soft_space();
+      }
+      Statement::EmptyStatement(s) => s.print(p, ctx),
+      _ => {
+        p.print_soft_newline();
+        p.indent();
+        self.body.print(p, ctx);
+        p.print_semicolon_if_needed();
+        p.dedent();
+        p.print_indent();
+      }
+    }
+    p.print_str("while");
+    p.print_soft_space();
+    p.print_ascii_byte(b'(');
+    p.print_expression(&self.test);
+    p.print_ascii_byte(b')');
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for EmptyStatement {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.add_source_mapping(self.span);
+    p.print_semicolon();
+    p.print_soft_newline();
+  }
+}
+
+impl Gen for ContinueStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("continue");
+    if let Some(label) = &self.label {
+      p.print_soft_space();
+      label.print(p, ctx);
+    }
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for BreakStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("break");
+    if let Some(label) = &self.label {
+      p.print_soft_space();
+      label.print(p, ctx);
+    }
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for SwitchStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("switch");
+    p.print_soft_space();
+    p.print_ascii_byte(b'(');
+    p.print_expression(&self.discriminant);
+    p.print_ascii_byte(b')');
+    p.print_soft_space();
+    p.print_curly_braces(self.span, self.cases.is_empty(), |p| {
+      for case in &self.cases {
+        case.print(p, ctx);
+      }
+    });
+    p.print_soft_newline();
+    p.needs_semicolon = false;
+  }
+}
+
+impl Gen for SwitchCase<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_semicolon_if_needed();
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.add_source_mapping(self.span);
+    match &self.test {
+      Some(test) => {
+        p.print_str("case");
+        p.print_soft_space();
+        p.print_expression(test);
+      }
+      None => p.print_str("default"),
+    }
+    p.print_colon();
+
+    // Force multi-line if a legal orphan is pending; the inline path skips the flush.
+    let single_line =
+      self.consequent.len() == 1 && !p.has_legal_orphans_before(self.consequent[0].span().start);
+    if single_line {
+      p.print_body(&self.consequent[0], false, ctx);
+      return;
+    }
+
+    p.print_soft_newline();
+    p.indent();
+    p.print_stmts_with_orphan_flush(&self.consequent, self.span.end, ctx);
+    p.dedent();
+  }
+}
+
+impl Gen for ReturnStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("return");
+    if let Some(arg) = &self.argument {
+      p.print_soft_space();
+      p.print_expression(arg);
+    }
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for LabeledStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    if !p.options.minify && (p.indent > 0 || p.print_next_indent_as_space) {
+      p.print_indent();
+    }
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    self.label.print(p, ctx);
+    p.print_colon();
+    p.print_body(&self.body, false, ctx);
+  }
+}
+
+impl Gen for TryStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("try");
+    p.print_soft_space();
+    p.print_block_statement(&self.block, ctx);
+    if let Some(handler) = &self.handler {
+      handler.r#gen(p, ctx);
+    }
+    if let Some(finalizer) = &self.finalizer {
+      p.print_soft_space();
+      p.print_str("finally");
+      p.print_soft_space();
+      p.print_block_statement(finalizer, ctx);
+    }
+    p.print_soft_newline();
+  }
+}
+
+impl Gen for CatchClause<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_soft_space();
+    p.print_comments_at(self.span.start);
+    p.print_str("catch");
+    if let Some(param) = &self.param {
+      p.print_soft_space();
+      p.print_ascii_byte(b'(');
+      param.pattern.print(p, ctx);
+      if let Some(type_annotation) = &param.type_annotation {
+        p.print_colon();
+        p.print_soft_space();
+        type_annotation.print(p, ctx);
+      }
+      p.print_ascii_byte(b')');
+    }
+    p.print_soft_space();
+    p.print_comments_at(self.body.span.start);
+    // Consume the space flag set by comment printing to ensure proper spacing before the opening brace
+    if !p.options.minify && p.print_next_indent_as_space {
+      p.print_hard_space();
+      p.print_next_indent_as_space = false;
+    }
+    p.print_block_statement(&self.body, ctx);
+  }
+}
+
+impl Gen for ThrowStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("throw");
+    p.print_soft_space();
+    p.print_expression(&self.argument);
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for WithStatement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("with");
+    p.print_ascii_byte(b'(');
+    p.print_expression(&self.object);
+    p.print_ascii_byte(b')');
+    p.print_body(&self.body, false, ctx);
+  }
+}
+
+impl Gen for DebuggerStatement {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("debugger");
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for VariableDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_space_before_identifier();
+    if self.declare {
+      p.print_str("declare ");
+    }
+
+    p.print_str(match self.kind {
+      VariableDeclarationKind::Const => "const",
+      VariableDeclarationKind::Let => "let",
+      VariableDeclarationKind::Var => "var",
+      VariableDeclarationKind::Using => "using",
+      VariableDeclarationKind::AwaitUsing => "await using",
+    });
+    if !self.declarations.is_empty() {
+      p.print_soft_space();
+    }
+    p.print_list(&self.declarations, ctx);
+  }
+}
+
+impl Gen for VariableDeclarator<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.id.print(p, ctx);
+    if self.definite {
+      p.print_ascii_byte(b'!');
+    }
+    if let Some(type_annotation) = &self.type_annotation {
+      p.print_colon();
+      p.print_soft_space();
+      type_annotation.print(p, ctx);
+    }
+    if let Some(init) = &self.init {
+      p.print_soft_space();
+      p.print_equal();
+      p.print_soft_space();
+      init.print_expr(p, Precedence::Comma, ctx);
+    }
+  }
+}
+
+impl Gen for Function<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let n = p.code_len();
+    let wrap = self.is_expression()
+      && ((p.start_of_stmt == n || p.start_of_default_export == n) || self.pife);
+    let ctx = ctx.and_forbid_call(false);
+    p.wrap(wrap, |p| {
+      p.print_space_before_identifier();
+      p.add_source_mapping(self.span);
+      if self.declare {
+        p.print_str("declare ");
+      }
+      if self.r#async {
+        p.print_str("async ");
+      }
+      p.print_str("function");
+      if self.generator {
+        p.print_ascii_byte(b'*');
+        p.print_soft_space();
+      }
+      if let Some(id) = &self.id {
+        p.print_space_before_identifier();
+        id.print(p, ctx);
+      }
+      if let Some(type_parameters) = &self.type_parameters {
+        type_parameters.print(p, ctx);
+      }
+      p.print_ascii_byte(b'(');
+      if let Some(this_param) = &self.this_param {
+        this_param.print(p, ctx);
+        if !self.params.is_empty() || self.params.rest.is_some() {
+          p.print_ascii_byte(b',');
+          p.print_soft_space();
+        }
+      }
+      self.params.print(p, ctx);
+      p.print_ascii_byte(b')');
+      if let Some(return_type) = &self.return_type {
+        p.print_str(": ");
+        return_type.print(p, ctx);
+      }
+      if let Some(body) = &self.body {
+        p.print_soft_space();
+        body.print(p, ctx);
+      } else {
+        p.print_semicolon();
+      }
+    });
+  }
+}
+
+impl Gen for FunctionBody<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let span_end = self.span.end;
+    let comments_at_end = if span_end > 0 { p.get_comments(span_end - 1) } else { None };
+    let single_line = if self.is_empty() {
+      !p.has_legal_orphans_before(self.span.end)
+        && comments_at_end
+          .as_ref()
+          .is_none_or(|comments| comments.iter().all(|c| !c.has_newlines_around()))
+    } else {
+      false
+    };
+    p.print_curly_braces(self.span, single_line, |p| {
+      p.print_directives_and_statements(&self.directives, &self.statements, self.span.end, ctx);
+      // Print trailing statement comments.
+      if let Some(comments) = comments_at_end {
+        p.print_comments(&comments);
+        p.print_next_indent_as_space = false;
+      }
+    });
+    p.needs_semicolon = false;
+  }
+}
+
+impl Gen for FormalParameter<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_decorators(&self.decorators, ctx);
+    if let Some(accessibility) = self.accessibility {
+      p.print_space_before_identifier();
+      p.print_str(accessibility.as_str());
+      p.print_soft_space();
+    }
+    if self.r#override {
+      p.print_space_before_identifier();
+      p.print_str("override");
+      p.print_soft_space();
+    }
+    if self.readonly {
+      p.print_space_before_identifier();
+      p.print_str("readonly");
+      p.print_soft_space();
+    }
+    self.pattern.print(p, ctx);
+    if self.optional {
+      p.print_ascii_byte(b'?');
+    }
+    if let Some(type_annotation) = &self.type_annotation {
+      p.print_colon();
+      p.print_soft_space();
+      type_annotation.print(p, ctx);
+    }
+    if let Some(init) = &self.initializer {
+      p.print_soft_space();
+      p.print_equal();
+      p.print_soft_space();
+      init.print_expr(p, Precedence::Comma, ctx);
+    }
+  }
+}
+
+impl Gen for FormalParameterRest<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_decorators(&self.decorators, ctx);
+    self.rest.print(p, ctx);
+    if let Some(type_annotation) = &self.type_annotation {
+      p.print_colon();
+      p.print_soft_space();
+      type_annotation.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for FormalParameters<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_list(&self.items, ctx);
+    if let Some(rest) = &self.rest {
+      if !self.items.is_empty() {
+        p.print_comma();
+        p.print_soft_space();
+      }
+      rest.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for ImportDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.add_source_mapping(self.span);
+    p.print_indent();
+    p.print_space_before_identifier();
+    p.print_str("import");
+    if self.import_kind.is_type() {
+      p.print_str(" type");
+    }
+    if let Some(phase) = self.phase {
+      p.print_hard_space();
+      p.print_str(phase.as_str());
+    }
+    if let Some(specifiers) = &self.specifiers {
+      if specifiers.is_empty() {
+        p.print_soft_space();
+        p.print_str("{}");
+        p.print_soft_space();
+        p.print_str("from");
+        p.print_soft_space();
+        p.print_ascii_byte(b'"');
+        p.print_str(self.source.value.as_str());
+        p.print_ascii_byte(b'"');
+        if let Some(with_clause) = &self.with_clause {
+          p.print_hard_space();
+          with_clause.print(p, ctx);
+        }
+        p.print_semicolon_after_statement();
+        return;
+      }
+
+      let mut in_block = false;
+      for (index, specifier) in specifiers.iter().enumerate() {
+        match specifier {
+          ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
+            if in_block {
+              p.print_soft_space();
+              p.print_str("},");
+              in_block = false;
+            } else if index == 0 {
+              p.print_hard_space();
+            } else {
+              p.print_comma();
+              p.print_soft_space();
+            }
+            spec.local.print(p, ctx);
+            if index == specifiers.len() - 1 {
+              p.print_hard_space();
+            }
+          }
+          ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
+            if in_block {
+              p.print_soft_space();
+              p.print_str("},");
+              in_block = false;
+            } else if index == 0 {
+              p.print_soft_space();
+            } else {
+              p.print_comma();
+              p.print_soft_space();
+            }
+            p.print_ascii_byte(b'*');
+            p.print_soft_space();
+            p.print_str("as ");
+            spec.local.print(p, ctx);
+            p.print_hard_space();
+          }
+          ImportDeclarationSpecifier::ImportSpecifier(spec) => {
+            if in_block {
+              p.print_comma();
+              p.print_soft_space();
+            } else {
+              if index != 0 {
+                p.print_comma();
+              }
+              in_block = true;
+              p.print_soft_space();
+              p.print_ascii_byte(b'{');
+              p.print_soft_space();
+            }
+
+            if spec.import_kind.is_type() {
+              p.print_str("type ");
+            }
+
+            spec.imported.print(p, ctx);
+            let local_name = p.get_binding_identifier_name(&spec.local);
+            let imported_name = get_module_export_name(&spec.imported, p);
+            if imported_name != local_name {
+              p.print_str(" as ");
+              spec.local.print(p, ctx);
+            }
+          }
+        }
+      }
+      if in_block {
+        p.print_soft_space();
+        p.print_ascii_byte(b'}');
+        p.print_soft_space();
+      }
+      p.print_str("from");
+    }
+    p.print_soft_space();
+    p.print_string_literal(&self.source, false);
+    if let Some(with_clause) = &self.with_clause {
+      p.print_soft_space();
+      with_clause.print(p, ctx);
+    }
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for WithClause<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_str(match self.keyword {
+      WithClauseKeyword::With => "with",
+      WithClauseKeyword::Assert => "assert",
+    });
+    p.print_soft_space();
+    p.add_source_mapping(self.span);
+    p.print_ascii_byte(b'{');
+    if !self.with_entries.is_empty() {
+      p.print_soft_space();
+      p.print_list(&self.with_entries, ctx);
+      p.print_soft_space();
+    }
+    p.print_ascii_byte(b'}');
+  }
+}
+
+impl Gen for ImportAttribute<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    match &self.key {
+      ImportAttributeKey::Identifier(identifier) => {
+        p.print_str(identifier.name.as_str());
+      }
+      ImportAttributeKey::StringLiteral(literal) => {
+        p.print_string_literal(literal, false);
+      }
+    }
+    p.print_colon();
+    p.print_soft_space();
+    p.print_string_literal(&self.value, false);
+  }
+}
+
+impl Gen for ExportNamedDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    if let Some(Declaration::FunctionDeclaration(func)) = &self.declaration
+      && func.pure
+      && p.options.print_annotation_comment()
+    {
+      p.print_str(NO_SIDE_EFFECTS_NEW_LINE_COMMENT);
+    }
+    p.add_source_mapping(self.span);
+    p.print_indent();
+    p.print_str("export");
+    if let Some(decl) = &self.declaration {
+      p.print_hard_space();
+      match decl {
+        Declaration::VariableDeclaration(decl) => decl.print(p, ctx),
+        Declaration::FunctionDeclaration(decl) => decl.print(p, ctx),
+        Declaration::ClassDeclaration(decl) => decl.print(p, ctx),
+        Declaration::TSModuleDeclaration(decl) => decl.print(p, ctx),
+        Declaration::TSGlobalDeclaration(decl) => decl.print(p, ctx),
+        Declaration::TSTypeAliasDeclaration(decl) => decl.print(p, ctx),
+        Declaration::TSInterfaceDeclaration(decl) => decl.print(p, ctx),
+        Declaration::TSEnumDeclaration(decl) => decl.print(p, ctx),
+        Declaration::TSImportEqualsDeclaration(decl) => decl.print(p, ctx),
+      }
+      if matches!(
+        decl,
+        Declaration::VariableDeclaration(_)
+          | Declaration::TSTypeAliasDeclaration(_)
+          | Declaration::TSImportEqualsDeclaration(_)
+      ) {
+        p.print_semicolon_after_statement();
+      } else {
+        p.print_soft_newline();
+        p.needs_semicolon = false;
+      }
+    } else {
+      if self.export_kind.is_type() {
+        p.print_hard_space();
+        p.print_str("type");
+      }
+      p.print_soft_space();
+      p.print_ascii_byte(b'{');
+      if !self.specifiers.is_empty() {
+        p.print_soft_space();
+        p.print_list(&self.specifiers, ctx);
+        p.print_soft_space();
+      }
+      p.print_ascii_byte(b'}');
+      if let Some(source) = &self.source {
+        p.print_soft_space();
+        p.print_str("from");
+        p.print_soft_space();
+        p.print_string_literal(source, false);
+        if let Some(with_clause) = &self.with_clause {
+          p.print_soft_space();
+          with_clause.print(p, ctx);
+        }
+      }
+      p.print_semicolon_after_statement();
+    }
+  }
+}
+
+impl Gen for TSExportAssignment<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_indent();
+    p.print_comments_at(self.span.start);
+    p.print_str("export = ");
+    self.expression.print_expr(p, Precedence::Lowest, ctx);
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for TSNamespaceExportDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_indent();
+    p.print_comments_at(self.span.start);
+    p.print_str("export as namespace ");
+    self.id.print(p, ctx);
+    p.print_semicolon_after_statement();
+  }
+}
+
+fn get_module_export_name<'a>(
+  module_export_name: &ModuleExportName<'a>,
+  p: &Codegen<'a>,
+) -> &'a str {
+  match module_export_name {
+    ModuleExportName::IdentifierName(ident) => ident.name.as_str(),
+    ModuleExportName::IdentifierReference(ident) => p.get_identifier_reference_name(ident),
+    ModuleExportName::StringLiteral(s) => s.value.as_str(),
+  }
+}
+
+impl Gen for ExportSpecifier<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.export_kind.is_type() {
+      p.print_str("type ");
+    }
+    if let Some(comments) = p.get_comments(self.local.span().start) {
+      p.print_comments(&comments);
+      p.print_soft_space();
+      p.print_next_indent_as_space = false;
+    }
+    self.local.print(p, ctx);
+    let local_name = get_module_export_name(&self.local, p);
+    let exported_name = get_module_export_name(&self.exported, p);
+    if local_name != exported_name {
+      p.print_str(" as ");
+      if let Some(comments) = p.get_comments(self.exported.span().start) {
+        p.print_comments(&comments);
+        p.print_soft_space();
+        p.print_next_indent_as_space = false;
+      }
+      self.exported.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for ModuleExportName<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::IdentifierName(ident) => ident.print(p, ctx),
+      Self::IdentifierReference(ident) => ident.print(p, ctx),
+      Self::StringLiteral(literal) => p.print_string_literal(literal, false),
+    }
+  }
+}
+
+impl Gen for ExportAllDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    p.add_source_mapping(self.span);
+    p.print_indent();
+    p.print_str("export");
+    if self.export_kind.is_type() {
+      p.print_str(" type ");
+    } else {
+      p.print_soft_space();
+    }
+    p.print_ascii_byte(b'*');
+
+    if let Some(exported) = &self.exported {
+      p.print_soft_space();
+      p.print_str("as ");
+      exported.print(p, ctx);
+      p.print_hard_space();
+    } else {
+      p.print_soft_space();
+    }
+
+    p.print_str("from");
+    p.print_soft_space();
+    p.print_string_literal(&self.source, false);
+    if let Some(with_clause) = &self.with_clause {
+      p.print_hard_space();
+      with_clause.print(p, ctx);
+    }
+    p.print_semicolon_after_statement();
+  }
+}
+
+impl Gen for ExportDefaultDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_comments_at(self.span.start);
+    if let ExportDefaultDeclarationKind::FunctionDeclaration(func) = &self.declaration
+      && func.pure
+      && p.options.print_annotation_comment()
+    {
+      p.print_str(NO_SIDE_EFFECTS_NEW_LINE_COMMENT);
+    }
+    p.add_source_mapping(self.span);
+    p.print_indent();
+    p.print_str("export default ");
+    self.declaration.print(p, ctx);
+  }
+}
+impl Gen for ExportDefaultDeclarationKind<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::FunctionDeclaration(func) => {
+        func.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::ClassDeclaration(class) => {
+        class.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::TSInterfaceDeclaration(interface) => interface.print(p, ctx),
+      _ => {
+        p.start_of_default_export = p.code_len();
+        self.to_expression().print_expr(p, Precedence::Comma, Context::empty());
+        p.print_semicolon_after_statement();
+      }
+    }
+  }
+}
+
+impl GenExpr for Expression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    match self {
+      // Most common expressions first (identifiers, member access, calls)
+      Self::Identifier(ident) => ident.print(p, ctx),
+      Self::StaticMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::ComputedMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::CallExpression(expr) => expr.print_expr(p, precedence, ctx),
+      // Literals (very common)
+      Self::NumericLiteral(lit) => lit.print_expr(p, precedence, ctx),
+      Self::StringLiteral(lit) => lit.print(p, ctx),
+      Self::BooleanLiteral(lit) => lit.print(p, ctx),
+      Self::NullLiteral(lit) => lit.print(p, ctx),
+      // Binary and logical operations (common)
+      Self::BinaryExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::LogicalExpression(expr) => expr.print_expr(p, precedence, ctx),
+      // Object and array literals (common)
+      Self::ObjectExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::ArrayExpression(expr) => expr.print(p, ctx),
+      // Assignment and update (common)
+      Self::AssignmentExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::UpdateExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::UnaryExpression(expr) => expr.print_expr(p, precedence, ctx),
+      // Conditional and sequence
+      Self::ConditionalExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::SequenceExpression(expr) => expr.print_expr(p, precedence, ctx),
+      // Function expressions
+      Self::ArrowFunctionExpression(func) => {
+        if func.pure && p.options.print_annotation_comment() {
+          p.print_str(NO_SIDE_EFFECTS_COMMENT);
+        }
+        func.print_expr(p, precedence, ctx);
+      }
+      Self::FunctionExpression(func) => {
+        if func.pure && p.options.print_annotation_comment() {
+          p.print_str(NO_SIDE_EFFECTS_COMMENT);
+        }
+        func.print(p, ctx);
+      }
+      // This and super
+      Self::ThisExpression(expr) => expr.print(p, ctx),
+      Self::Super(sup) => sup.print(p, ctx),
+      // New expression
+      Self::NewExpression(expr) => expr.print_expr(p, precedence, ctx),
+      // Template literals
+      Self::TemplateLiteral(literal) => literal.print(p, ctx),
+      Self::TaggedTemplateExpression(expr) => expr.print(p, ctx),
+      // Other literals
+      Self::RegExpLiteral(lit) => lit.print(p, ctx),
+      Self::BigIntLiteral(lit) => lit.print_expr(p, precedence, ctx),
+      // Class expression
+      Self::ClassExpression(expr) => expr.print(p, ctx),
+      // Async/await and yield
+      Self::AwaitExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::YieldExpression(expr) => expr.print_expr(p, precedence, ctx),
+      // Import expression
+      Self::ImportExpression(expr) => expr.print_expr(p, precedence, ctx),
+      // Meta property
+      Self::MetaProperty(expr) => expr.print(p, ctx),
+      // Chain expression
+      Self::ChainExpression(expr) => expr.print_expr(p, precedence, ctx),
+      // Private field
+      Self::PrivateFieldExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::PrivateInExpression(expr) => expr.print_expr(p, precedence, ctx),
+      // Parenthesized
+      Self::ParenthesizedExpression(e) => e.print_expr(p, precedence, ctx),
+      // JSX (less common in typical JS code)
+      Self::JSXElement(el) => el.print(p, ctx),
+      Self::JSXFragment(fragment) => fragment.print(p, ctx),
+      // TypeScript (less common in runtime)
+      Self::TSAsExpression(e) => e.print_expr(p, precedence, ctx),
+      Self::TSSatisfiesExpression(e) => e.print_expr(p, precedence, ctx),
+      Self::TSTypeAssertion(e) => e.print_expr(p, precedence, ctx),
+      Self::TSNonNullExpression(e) => e.print_expr(p, precedence, ctx),
+      Self::TSInstantiationExpression(e) => e.print_expr(p, precedence, ctx),
+      // V8 intrinsics (rare)
+      Self::V8IntrinsicExpression(e) => e.print_expr(p, precedence, ctx),
+    }
+  }
+}
+
+impl GenExpr for ParenthesizedExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    self.expression.print_expr(p, precedence, ctx);
+  }
+}
+
+impl Gen for IdentifierReference<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    let name = p.get_identifier_reference_name(self);
+    p.print_space_before_identifier();
+    p.add_source_mapping_for_name(self.span, name);
+    p.print_str(name);
+  }
+}
+
+impl Gen for IdentifierName<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_space_before_identifier();
+    p.add_source_mapping_for_name(self.span, &self.name);
+    p.print_str(self.name.as_str());
+  }
+}
+
+impl Gen for BindingIdentifier<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    let name = p.get_binding_identifier_name(self);
+    p.print_space_before_identifier();
+    p.add_source_mapping_for_name(self.span, name);
+    p.print_str(name);
+  }
+}
+
+impl Gen for LabelIdentifier<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_space_before_identifier();
+    p.add_source_mapping_for_name(self.span, &self.name);
+    p.print_str(self.name.as_str());
+  }
+}
+
+impl Gen for BooleanLiteral {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_space_before_identifier();
+    p.print_str(self.as_str());
+  }
+}
+
+impl Gen for NullLiteral {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("null");
+  }
+}
+
+impl GenExpr for NumericLiteral<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    p.add_source_mapping(self.span);
+    let value = self.value;
+    if ctx.contains(Context::TYPESCRIPT) {
+      p.print_str(&self.raw_str());
+    } else if value.is_nan() {
+      p.print_space_before_identifier();
+      p.print_str("NaN");
+    } else if value.is_infinite() {
+      let wrap = (p.options.minify && precedence >= Precedence::Multiply)
+        || (value.is_sign_negative() && precedence >= Precedence::Prefix);
+      p.wrap(wrap, |p| {
+        if value.is_sign_negative() {
+          p.print_space_before_operator(Operator::Unary(UnaryOperator::UnaryNegation));
+          p.print_ascii_byte(b'-');
+        } else {
+          p.print_space_before_identifier();
+        }
+        if p.options.minify {
+          p.print_str("1/0");
+        } else {
+          p.print_str("Infinity");
+        }
+      });
+    } else if value.is_sign_positive() {
+      p.print_space_before_identifier();
+      p.print_non_negative_float(value);
+    } else if precedence >= Precedence::Prefix {
+      p.print_str("(-");
+      p.print_non_negative_float(value.abs());
+      p.print_ascii_byte(b')');
+    } else {
+      p.print_space_before_operator(Operator::Unary(UnaryOperator::UnaryNegation));
+      p.print_ascii_byte(b'-');
+      p.print_non_negative_float(value.abs());
+    }
+  }
+}
+
+impl GenExpr for BigIntLiteral<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, _ctx: Context) {
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    let value = self.value.as_str();
+    if value.starts_with('-') && precedence >= Precedence::Prefix {
+      p.print_ascii_byte(b'(');
+      p.print_str(value);
+      p.print_str("n)");
+    } else {
+      p.print_str(value);
+      p.print_ascii_byte(b'n');
+    }
+  }
+}
+
+impl Gen for RegExpLiteral<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.add_source_mapping(self.span);
+    // Avoid forming a single-line comment or "</script" sequence
+    let last = p.last_byte();
+    if last == Some(b'/')
+      || (last == Some(b'<')
+        && self
+          .regex
+          .pattern
+          .text
+          .get(..6)
+          .is_some_and(|first_six| first_six.cow_to_ascii_lowercase() == "script"))
+    {
+      p.print_hard_space();
+    }
+    p.print_ascii_byte(b'/');
+    p.print_str(self.regex.pattern.text.as_str());
+    p.print_ascii_byte(b'/');
+    p.print_str(self.regex.flags.to_inline_string().as_str());
+    p.prev_reg_exp_end = p.code().len();
+  }
+}
+
+impl Gen for StringLiteral<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_string_literal(self, true);
+  }
+}
+
+impl Gen for ThisExpression {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("this");
+  }
+}
+
+impl GenExpr for MemberExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    match self {
+      Self::ComputedMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::StaticMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::PrivateFieldExpression(expr) => expr.print_expr(p, precedence, ctx),
+    }
+  }
+}
+
+impl GenExpr for ComputedMemberExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
+    // `(let[0] = 100);` -> `(let)[0] = 100`;
+    let wrap = self.object.get_identifier_reference().is_some_and(|r| r.name == "let");
+    p.wrap(wrap, |p| {
+      self.object.print_expr(p, Precedence::Postfix, ctx.intersection(Context::FORBID_CALL));
+    });
+    if self.optional {
+      p.print_str("?.");
+    }
+    p.print_ascii_byte(b'[');
+    self.expression.print_expr(p, Precedence::Lowest, Context::empty());
+    p.print_ascii_byte(b']');
+  }
+}
+
+impl GenExpr for StaticMemberExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
+    self.object.print_expr(p, Precedence::Postfix, ctx.intersection(Context::FORBID_CALL));
+    if self.optional {
+      p.print_ascii_byte(b'?');
+    } else if p.need_space_before_dot == p.code_len() {
+      // `0.toExponential()` is invalid, add a space before the dot, `0 .toExponential()` is valid
+      p.print_hard_space();
+    }
+    p.print_ascii_byte(b'.');
+    self.property.print(p, ctx);
+  }
+}
+
+impl GenExpr for PrivateFieldExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
+    self.object.print_expr(p, Precedence::Postfix, ctx.intersection(Context::FORBID_CALL));
+    if self.optional {
+      p.print_ascii_byte(b'?');
+    }
+    p.print_ascii_byte(b'.');
+    self.field.print(p, ctx);
+  }
+}
+
+impl GenExpr for CallExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let is_statement = p.start_of_stmt == p.code_len();
+    let is_export_default = p.start_of_default_export == p.code_len();
+    let mut wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
+    let pure = self.pure && p.options.print_annotation_comment();
+    if !wrap && pure && precedence >= Precedence::Postfix {
+      wrap = true;
+    }
+
+    p.wrap(wrap, |p| {
+      if pure {
+        p.add_source_mapping(self.span);
+        p.print_str(PURE_COMMENT);
+      }
+      if is_export_default {
+        p.start_of_default_export = p.code_len();
+      } else if is_statement {
+        p.start_of_stmt = p.code_len();
+      }
+      self.callee.print_expr(p, Precedence::Postfix, Context::empty());
+      if self.optional {
+        p.print_str("?.");
+      }
+      if let Some(type_parameters) = &self.type_arguments {
+        type_parameters.print(p, ctx);
+      }
+      p.print_arguments(self.span, &self.arguments, ctx);
+    });
+  }
+}
+
+impl Gen for Argument<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::SpreadElement(elem) => elem.print(p, ctx),
+      _ => self.to_expression().print_expr(p, Precedence::Comma, Context::empty()),
+    }
+  }
+}
+
+impl Gen for ArrayExpressionElement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::SpreadElement(elem) => elem.print(p, ctx),
+      Self::Elision(_span) => {}
+      _ => self.to_expression().print_expr(p, Precedence::Comma, Context::empty()),
+    }
+  }
+}
+
+impl Gen for SpreadElement<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_ellipsis();
+    self.argument.print_expr(p, Precedence::Comma, Context::empty());
+  }
+}
+
+impl Gen for ArrayExpression<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let is_multi_line = self.elements.len() > 2;
+    p.add_source_mapping(self.span);
+    p.print_ascii_byte(b'[');
+    if is_multi_line {
+      p.indent();
+    }
+    for (i, item) in self.elements.iter().enumerate() {
+      if i != 0 {
+        p.print_comma();
+      }
+      if is_multi_line {
+        p.print_soft_newline();
+        p.print_indent();
+      } else if i != 0 {
+        p.print_soft_space();
+      }
+      item.print(p, ctx);
+      if i == self.elements.len() - 1 && matches!(item, ArrayExpressionElement::Elision(_)) {
+        p.print_comma();
+      }
+    }
+    if is_multi_line {
+      p.print_soft_newline();
+      p.dedent();
+      p.print_indent();
+    }
+    p.print_ascii_byte(b']');
+    p.add_source_mapping_end(self.span);
+  }
+}
+
+impl GenExpr for ObjectExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
+    let n = p.code_len();
+    let len = self.properties.len();
+    let is_multi_line = len > 1;
+    let has_comment = p.has_comment(self.span.start);
+    let wrap = has_comment || p.start_of_stmt == n || p.start_of_arrow_expr == n;
+    p.wrap(wrap, |p| {
+      // Print comments for lingui https://lingui.dev/ref/macro#definemessage
+      // `const message = /*i18n*/ { };`
+      if has_comment {
+        p.print_leading_comments(self.span.start);
+        p.print_indent();
+      }
+      p.add_source_mapping(self.span);
+      p.print_ascii_byte(b'{');
+      if is_multi_line {
+        p.indent();
+      }
+      for (i, item) in self.properties.iter().enumerate() {
+        if i != 0 {
+          p.print_comma();
+        }
+        if is_multi_line {
+          p.print_soft_newline();
+          p.print_comments_at(item.span().start);
+          p.print_indent();
+        } else {
+          p.print_soft_space();
+          if let Some(comments) = p.get_comments(item.span().start) {
+            p.print_comments(&comments);
+            if p.print_next_indent_as_space {
+              p.print_hard_space();
+              p.print_next_indent_as_space = false;
+            }
+          }
+        }
+        item.print(p, ctx);
+      }
+      if is_multi_line {
+        p.print_soft_newline();
+        p.dedent();
+        p.print_indent();
+      } else if len > 0 {
+        p.print_soft_space();
+      }
+      p.print_ascii_byte(b'}');
+      p.add_source_mapping_end(self.span);
+    });
+  }
+}
+
+impl Gen for ObjectPropertyKind<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::ObjectProperty(prop) => prop.print(p, ctx),
+      Self::SpreadProperty(elem) => elem.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for ObjectProperty<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if let Expression::FunctionExpression(func) = &self.value {
+      p.add_source_mapping(self.span);
+      let is_accessor = match &self.kind {
+        PropertyKind::Init => false,
+        PropertyKind::Get => {
+          p.print_str("get");
+          p.print_soft_space();
+          true
+        }
+        PropertyKind::Set => {
+          p.print_str("set");
+          p.print_soft_space();
+          true
+        }
+      };
+      if self.method || is_accessor {
+        if func.r#async {
+          p.print_space_before_identifier();
+          p.print_str("async");
+          p.print_soft_space();
+        }
+        if func.generator {
+          p.print_ascii_byte(b'*');
+        }
+        if self.computed {
+          p.print_ascii_byte(b'[');
+        }
+        self.key.print(p, ctx);
+        if self.computed {
+          p.print_ascii_byte(b']');
+        }
+        if let Some(type_parameters) = &func.type_parameters {
+          type_parameters.print(p, ctx);
+        }
+        p.print_ascii_byte(b'(');
+        if let Some(this_param) = &func.this_param {
+          this_param.print(p, ctx);
+          if !func.params.is_empty() || func.params.rest.is_some() {
+            p.print_ascii_byte(b',');
+            p.print_soft_space();
+          }
+        }
+        func.params.print(p, ctx);
+        p.print_ascii_byte(b')');
+        if let Some(return_type) = &func.return_type {
+          p.print_colon();
+          p.print_soft_space();
+          return_type.print(p, ctx);
+        }
+        if let Some(body) = &func.body {
+          p.print_soft_space();
+          body.print(p, ctx);
+        }
+        return;
+      }
+    }
+
+    let mut shorthand = false;
+    if let PropertyKey::StaticIdentifier(key) = &self.key {
+      if key.name == "__proto__" {
+        shorthand = self.shorthand;
+      } else if let Expression::Identifier(ident) = self.value.without_parentheses()
+        && key.name == p.get_identifier_reference_name(ident)
+      {
+        shorthand = true;
+      }
+    }
+
+    let mut computed = self.computed;
+
+    // "{ -1: 0 }" must be printed as "{ [-1]: 0 }"
+    // "{ 1/0: 0 }" must be printed as "{ [1/0]: 0 }"
+    if !computed
+      && let Some(Expression::NumericLiteral(n)) = self.key.as_expression()
+      && (n.value.is_sign_negative() || n.value.is_infinite())
+    {
+      computed = true;
+    }
+
+    if !shorthand {
+      if computed {
+        p.print_ascii_byte(b'[');
+      }
+      self.key.print(p, ctx);
+      if computed {
+        p.print_ascii_byte(b']');
+      }
+      p.print_colon();
+      p.print_soft_space();
+    }
+
+    self.value.print_expr(p, Precedence::Comma, Context::empty());
+  }
+}
+
+impl Gen for PropertyKey<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::StaticIdentifier(ident) => ident.print(p, ctx),
+      Self::PrivateIdentifier(ident) => ident.print(p, ctx),
+      Self::StringLiteral(s) => p.print_string_literal(s, /* allow_backtick */ false),
+      _ => self.to_expression().print_expr(p, Precedence::Comma, Context::empty()),
+    }
+  }
+}
+
+impl GenExpr for ArrowFunctionExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    p.wrap(precedence >= Precedence::Assign || self.pife, |p| {
+      if self.r#async {
+        p.print_space_before_identifier();
+        p.add_source_mapping(self.span);
+        p.print_str("async");
+        p.print_soft_space();
+      }
+      if let Some(type_parameters) = &self.type_parameters {
+        type_parameters.print(p, ctx);
+      }
+      let remove_params_wrap = p.options.minify
+        && self.params.items.len() == 1
+        && self.params.rest.is_none()
+        && self.type_parameters.is_none()
+        && self.return_type.is_none()
+        && {
+          let param = &self.params.items[0];
+          param.decorators.is_empty()
+            && !param.has_modifier()
+            && param.pattern.is_binding_identifier()
+            && param.type_annotation.is_none()
+            && param.initializer.is_none()
+            && !param.optional
+        };
+      p.wrap(!remove_params_wrap, |p| {
+        self.params.print(p, ctx);
+      });
+      if let Some(return_type) = &self.return_type {
+        p.print_colon();
+        p.print_soft_space();
+        return_type.print(p, ctx);
+      }
+      p.print_soft_space();
+      p.print_str("=>");
+      p.print_soft_space();
+      if self.expression {
+        if let Some(Statement::ExpressionStatement(stmt)) = &self.body.statements.first() {
+          p.start_of_arrow_expr = p.code_len();
+          stmt.expression.print_expr(p, Precedence::Comma, ctx);
+        }
+      } else {
+        self.body.print(p, ctx);
+      }
+    });
+  }
+}
+
+impl GenExpr for YieldExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, _ctx: Context) {
+    p.wrap(precedence >= Precedence::Assign, |p| {
+      p.print_space_before_identifier();
+      p.add_source_mapping(self.span);
+      p.print_str("yield");
+      if self.delegate {
+        p.print_ascii_byte(b'*');
+      }
+      if let Some(argument) = self.argument.as_ref() {
+        p.print_soft_space();
+        argument.print_expr(p, Precedence::Yield, Context::empty());
+      }
+    });
+  }
+}
+
+impl GenExpr for UpdateExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let operator = self.operator.as_str();
+    p.wrap(precedence >= self.precedence(), |p| {
+      if self.prefix {
+        p.print_space_before_operator(self.operator.into());
+        p.add_source_mapping(self.span);
+        p.print_str(operator);
+        p.prev_op = Some(self.operator.into());
+        p.prev_op_end = p.code().len();
+        self.argument.print_expr(p, Precedence::Prefix, ctx);
+      } else {
+        p.print_space_before_operator(self.operator.into());
+        p.add_source_mapping(self.span);
+        self.argument.print_expr(p, Precedence::Postfix, ctx);
+        p.print_str(operator);
+        p.prev_op = Some(self.operator.into());
+        p.prev_op_end = p.code().len();
+      }
+    });
+  }
+}
+
+impl GenExpr for UnaryExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    p.wrap(precedence >= self.precedence(), |p| {
+            let operator = self.operator.as_str();
+            if self.operator.is_keyword() {
+                p.print_space_before_identifier();
+                p.add_source_mapping(self.span);
+                p.print_str(operator);
+                p.print_soft_space();
+            } else {
+                p.print_space_before_operator(self.operator.into());
+                p.add_source_mapping(self.span);
+                p.print_str(operator);
+                p.prev_op = Some(self.operator.into());
+                p.prev_op_end = p.code().len();
+            }
+            // Forbid `delete Infinity`, which is syntax error in strict mode.
+            let is_delete_infinity = self.operator == UnaryOperator::Delete
+                && !p.options.minify
+                && matches!(&self.argument, Expression::NumericLiteral(lit) if lit.value.is_sign_positive() && lit.value.is_infinite());
+            if is_delete_infinity {
+                p.print_str("(0,");
+                p.print_soft_space();
+            }
+            self.argument.print_expr(p, Precedence::Exponentiation, ctx);
+            if is_delete_infinity{
+                p.print_ascii_byte(b')');
+            }
+        });
+  }
+}
+
+impl GenExpr for BinaryExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let v = BinaryExpressionVisitor {
+      // SAFETY:
+      // The pointer is stored on the heap and all will be consumed in the binary expression visitor.
+      e: Binaryish::Binary(unsafe {
+        std::mem::transmute::<&BinaryExpression<'_>, &BinaryExpression<'_>>(self)
+      }),
+      precedence,
+      ctx,
+      left_precedence: Precedence::Lowest,
+      operator: BinaryishOperator::Binary(self.operator),
+      wrap: false,
+      right_precedence: Precedence::Lowest,
+    };
+    BinaryExpressionVisitor::gen_expr(v, p);
+  }
+}
+
+impl GenExpr for PrivateInExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    p.wrap(precedence >= Precedence::Compare, |p| {
+      p.add_source_mapping(self.span);
+      self.left.print(p, ctx);
+      p.print_str(" in ");
+      self.right.print_expr(p, Precedence::Equals, Context::FORBID_IN);
+    });
+  }
+}
+
+impl GenExpr for LogicalExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let v = BinaryExpressionVisitor {
+      // SAFETY:
+      // The pointer is stored on the heap and all will be consumed in the binary expression visitor.
+      e: Binaryish::Logical(unsafe {
+        std::mem::transmute::<&LogicalExpression<'_>, &LogicalExpression<'_>>(self)
+      }),
+      precedence,
+      ctx,
+      left_precedence: Precedence::Lowest,
+      operator: BinaryishOperator::Logical(self.operator),
+      wrap: false,
+      right_precedence: Precedence::Lowest,
+    };
+    BinaryExpressionVisitor::gen_expr(v, p);
+  }
+}
+
+impl GenExpr for ConditionalExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let mut ctx = ctx;
+    let wrap = precedence >= self.precedence();
+    if wrap {
+      ctx &= Context::FORBID_IN.not();
+    }
+    p.wrap(wrap, |p| {
+      self.test.print_expr(p, Precedence::Conditional, ctx & Context::FORBID_IN);
+      p.print_soft_space();
+      p.print_ascii_byte(b'?');
+      p.print_soft_space();
+      self.consequent.print_expr(p, Precedence::Yield, Context::empty());
+      p.print_soft_space();
+      p.print_colon();
+      p.print_soft_space();
+      if let Some(comments) = p.get_comments(self.alternate.span().start) {
+        p.print_comments(&comments);
+        if p.print_next_indent_as_space {
+          p.print_hard_space();
+          p.print_next_indent_as_space = false;
+        }
+      }
+      self.alternate.print_expr(p, Precedence::Yield, ctx & Context::FORBID_IN);
+    });
+  }
+}
+
+impl GenExpr for AssignmentExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let n = p.code_len();
+    // Destructuring assignments must be parenthesized
+    let wrap = (p.start_of_stmt == n || p.start_of_arrow_expr == n)
+      && matches!(self.left, AssignmentTarget::ObjectAssignmentTarget(_));
+    p.wrap(wrap || precedence >= self.precedence(), |p| {
+      p.add_source_mapping(self.span);
+      self.left.print(p, ctx);
+      p.print_soft_space();
+      p.print_str(self.operator.as_str());
+      p.print_soft_space();
+      self.right.print_expr(p, Precedence::Comma, ctx);
+    });
+  }
+}
+
+impl Gen for AssignmentTarget<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      match_simple_assignment_target!(Self) => {
+        self.to_simple_assignment_target().print_expr(p, Precedence::Comma, Context::empty());
+      }
+      match_assignment_target_pattern!(Self) => {
+        self.to_assignment_target_pattern().print(p, ctx);
+      }
+    }
+  }
+}
+
+impl GenExpr for SimpleAssignmentTarget<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    match self {
+      Self::AssignmentTargetIdentifier(ident) => ident.print(p, ctx),
+      Self::ComputedMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::StaticMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::PrivateFieldExpression(expr) => expr.print_expr(p, precedence, ctx),
+      Self::TSAsExpression(e) => e.print_expr(p, precedence, ctx),
+      Self::TSSatisfiesExpression(e) => e.print_expr(p, precedence, ctx),
+      Self::TSNonNullExpression(e) => e.print_expr(p, precedence, ctx),
+      Self::TSTypeAssertion(e) => e.print_expr(p, precedence, ctx),
+    }
+  }
+}
+
+impl Gen for AssignmentTargetPattern<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::ArrayAssignmentTarget(target) => target.print(p, ctx),
+      Self::ObjectAssignmentTarget(target) => target.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for ArrayAssignmentTarget<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_ascii_byte(b'[');
+    for (i, item) in self.elements.iter().enumerate() {
+      if i != 0 {
+        p.print_comma();
+        p.print_soft_space();
+      }
+      if let Some(item) = item {
+        item.print(p, ctx);
+      }
+      if i == self.elements.len() - 1 && (item.is_none() || self.rest.is_some()) {
+        p.print_comma();
+      }
+    }
+    if let Some(target) = &self.rest {
+      if !self.elements.is_empty() {
+        p.print_soft_space();
+      }
+      target.print(p, ctx);
+    }
+    p.print_ascii_byte(b']');
+  }
+}
+
+impl Gen for ObjectAssignmentTarget<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_ascii_byte(b'{');
+    p.print_list(&self.properties, ctx);
+    if let Some(target) = &self.rest {
+      if !self.properties.is_empty() {
+        p.print_comma();
+        p.print_soft_space();
+      }
+      target.print(p, ctx);
+    }
+    p.print_ascii_byte(b'}');
+  }
+}
+
+impl Gen for AssignmentTargetMaybeDefault<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      match_assignment_target!(Self) => self.to_assignment_target().print(p, ctx),
+      Self::AssignmentTargetWithDefault(target) => target.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for AssignmentTargetWithDefault<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.binding.print(p, ctx);
+    p.print_soft_space();
+    p.print_equal();
+    p.print_soft_space();
+    self.init.print_expr(p, Precedence::Comma, Context::empty());
+  }
+}
+
+impl Gen for AssignmentTargetProperty<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::AssignmentTargetPropertyIdentifier(ident) => ident.print(p, ctx),
+      Self::AssignmentTargetPropertyProperty(prop) => prop.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for AssignmentTargetPropertyIdentifier<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let ident_name = p.get_identifier_reference_name(&self.binding);
+    if ident_name == self.binding.name.as_str() {
+      self.binding.print(p, ctx);
+    } else {
+      // `({x: a} = y);`
+      p.print_str(self.binding.name.as_str());
+      p.print_colon();
+      p.print_soft_space();
+      p.print_str(ident_name);
+    }
+    if let Some(expr) = &self.init {
+      p.print_soft_space();
+      p.print_equal();
+      p.print_soft_space();
+      expr.print_expr(p, Precedence::Comma, Context::empty());
+    }
+  }
+}
+
+impl Gen for AssignmentTargetPropertyProperty<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let omit_key = if p.options.minify {
+      let key_name = match &self.name {
+        PropertyKey::StaticIdentifier(ident) => Some(&ident.name),
+        _ => None,
+      };
+      let value_name = self.binding.identifier().map(|id| p.get_identifier_reference_name(id));
+      match (key_name, value_name) {
+        (Some(key_name), Some(value_name)) => key_name == value_name,
+        _ => false,
+      }
+    } else {
+      false
+    };
+    if !omit_key {
+      match &self.name {
+        PropertyKey::StaticIdentifier(ident) => {
+          ident.print(p, ctx);
+        }
+        PropertyKey::PrivateIdentifier(ident) => {
+          ident.print(p, ctx);
+        }
+        PropertyKey::StringLiteral(s) => {
+          if self.computed {
+            p.print_ascii_byte(b'[');
+          }
+          p.print_string_literal(s, /* allow_backtick */ false);
+          if self.computed {
+            p.print_ascii_byte(b']');
+          }
+        }
+        key => {
+          if self.computed {
+            p.print_ascii_byte(b'[');
+          }
+          key.to_expression().print_expr(p, Precedence::Comma, Context::empty());
+          if self.computed {
+            p.print_ascii_byte(b']');
+          }
+        }
+      }
+      p.print_colon();
+      p.print_soft_space();
+    }
+    self.binding.print(p, ctx);
+  }
+}
+
+impl Gen for AssignmentTargetRest<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_ellipsis();
+    self.target.print(p, ctx);
+  }
+}
+
+impl GenExpr for SequenceExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    p.wrap(precedence >= self.precedence(), |p| {
+      p.print_expressions(&self.expressions, Precedence::Lowest, ctx.and_forbid_call(false));
+    });
+  }
+}
+
+impl GenExpr for ImportExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
+
+    let has_comment_before_right_paren =
+      p.options.print_annotation_comment() && self.span.end > 0 && p.has_comment(self.span.end - 1);
+    let has_comment = p.options.print_annotation_comment()
+      && (has_comment_before_right_paren
+        || p.has_comment(self.source.span().start)
+        || self.options.as_ref().is_some_and(|options| p.has_comment(options.span().start)));
+
+    p.wrap(wrap, |p| {
+      p.print_space_before_identifier();
+      p.add_source_mapping(self.span);
+      p.print_str("import");
+      if let Some(phase) = self.phase {
+        p.print_ascii_byte(b'.');
+        p.print_str(phase.as_str());
+      }
+      p.print_ascii_byte(b'(');
+      if has_comment {
+        p.indent();
+      }
+      if p.print_expr_comments(self.source.span().start) {
+        p.print_indent();
+      } else if has_comment {
+        p.print_soft_newline();
+        p.print_indent();
+      }
+      self.source.print_expr(p, Precedence::Comma, Context::empty());
+      if let Some(options) = &self.options {
+        p.print_comma();
+        if has_comment {
+          p.print_soft_newline();
+          p.print_indent();
+        } else {
+          p.print_soft_space();
+        }
+        options.gen_expr(p, Precedence::Comma, Context::empty());
+      }
+      if has_comment {
+        // Handle `/* comment */);`
+        if !has_comment_before_right_paren || !p.print_expr_comments(self.span.end - 1) {
+          p.print_soft_newline();
+        }
+        p.dedent();
+      }
+      p.print_ascii_byte(b')');
+    });
+  }
+}
+
+impl Gen for TemplateLiteral<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_ascii_byte(b'`');
+    debug_assert_eq!(self.quasis.len(), self.expressions.len() + 1);
+    let (first_quasi, remaining_quasis) = self.quasis.split_first().unwrap();
+    p.print_str_escaping_script_close_tag(first_quasi.value.raw.as_str());
+    for (expr, quasi) in self.expressions.iter().zip(remaining_quasis) {
+      p.print_str("${");
+      p.print_expression(expr);
+      p.print_ascii_byte(b'}');
+      p.add_source_mapping(quasi.span);
+      p.print_str_escaping_script_close_tag(quasi.value.raw.as_str());
+    }
+    p.print_ascii_byte(b'`');
+  }
+}
+
+impl Gen for TaggedTemplateExpression<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    self.tag.print_expr(p, Precedence::Postfix, Context::empty());
+    if let Some(type_parameters) = &self.type_arguments {
+      type_parameters.print(p, ctx);
+    }
+    self.quasi.print(p, ctx);
+  }
+}
+
+impl Gen for Super {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    p.print_str("super");
+  }
+}
+
+impl GenExpr for AwaitExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    p.wrap(precedence >= self.precedence(), |p| {
+      p.print_space_before_identifier();
+      p.add_source_mapping(self.span);
+      p.print_str("await");
+      p.print_soft_space();
+      self.argument.print_expr(p, Precedence::Exponentiation, ctx);
+    });
+  }
+}
+
+impl GenExpr for ChainExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    p.wrap(precedence >= Precedence::Postfix, |p| match &self.expression {
+      ChainElement::CallExpression(expr) => expr.print_expr(p, precedence, ctx),
+      ChainElement::TSNonNullExpression(expr) => expr.print_expr(p, precedence, ctx),
+      ChainElement::ComputedMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
+      ChainElement::StaticMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
+      ChainElement::PrivateFieldExpression(expr) => expr.print_expr(p, precedence, ctx),
+    });
+  }
+}
+
+impl GenExpr for NewExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let mut wrap = precedence >= self.precedence();
+    let pure = self.pure && p.options.print_annotation_comment();
+    if precedence >= Precedence::Postfix && pure {
+      wrap = true;
+    }
+    p.wrap(wrap, |p| {
+      if pure {
+        p.print_str(PURE_COMMENT);
+      }
+      p.print_space_before_identifier();
+      p.add_source_mapping(self.span);
+      p.print_str("new");
+      p.print_soft_space();
+      self.callee.print_expr(p, Precedence::New, Context::FORBID_CALL);
+      if let Some(type_parameters) = &self.type_arguments {
+        type_parameters.print(p, ctx);
+      }
+
+      // Omit the "()" when minifying, but only when safe to do so
+      if !p.options.minify || !self.arguments.is_empty() || precedence >= Precedence::Postfix {
+        p.print_arguments(self.span, &self.arguments, ctx);
+      }
+    });
+  }
+}
+
+impl GenExpr for TSAsExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let wrap = precedence >= Precedence::Compare;
+
+    p.wrap(wrap, |p| {
+      self.expression.print_expr(p, Precedence::Exponentiation, ctx);
+      p.print_str(" as ");
+      self.type_annotation.print(p, ctx);
+    });
+  }
+}
+
+impl GenExpr for TSSatisfiesExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let wrap = precedence >= Precedence::Compare;
+
+    p.wrap(wrap, |p| {
+      self.expression.print_expr(p, Precedence::Exponentiation, ctx);
+      p.print_str(" satisfies ");
+      self.type_annotation.print(p, ctx);
+    });
+  }
+}
+
+impl GenExpr for TSNonNullExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
+    self.expression.print_expr(p, Precedence::Postfix, ctx);
+    p.print_ascii_byte(b'!');
+    if p.options.minify {
+      p.print_hard_space();
+    }
+  }
+}
+
+impl GenExpr for TSInstantiationExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    self.expression.print_expr(p, precedence, ctx);
+    self.type_arguments.print(p, ctx);
+    if p.options.minify {
+      p.print_hard_space();
+    }
+  }
+}
+
+impl GenExpr for TSTypeAssertion<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    p.wrap(precedence >= self.precedence(), |p| {
+      p.print_ascii_byte(b'<');
+      // var r = < <T>(x: T) => T > ((x) => { return null; });
+      //          ^ make sure space is printed here.
+      if matches!(self.type_annotation, TSType::TSFunctionType(_)) {
+        p.print_hard_space();
+      }
+      self.type_annotation.print(p, ctx);
+      p.print_ascii_byte(b'>');
+      self.expression.print_expr(p, Precedence::Member, ctx);
+    });
+  }
+}
+
+impl Gen for MetaProperty<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_space_before_identifier();
+    p.add_source_mapping(self.span);
+    self.meta.print(p, ctx);
+    p.print_ascii_byte(b'.');
+    self.property.print(p, ctx);
+  }
+}
+
+impl Gen for Class<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let n = p.code_len();
+    let wrap = self.is_expression() && (p.start_of_stmt == n || p.start_of_default_export == n);
+    let ctx = ctx.and_forbid_call(false);
+    p.wrap(wrap, |p| {
+      p.enter_class();
+      p.print_decorators(&self.decorators, ctx);
+      p.print_space_before_identifier();
+      p.add_source_mapping(self.span);
+      if self.declare {
+        p.print_str("declare ");
+      }
+      if self.r#abstract {
+        p.print_str("abstract ");
+      }
+      p.print_str("class");
+      if let Some(id) = &self.id {
+        p.print_hard_space();
+        id.print(p, ctx);
+      }
+      if let Some(type_parameters) = self.type_parameters.as_ref() {
+        type_parameters.print(p, ctx);
+      }
+      if let Some(super_class) = self.super_class.as_ref() {
+        p.print_str(" extends ");
+        super_class.print_expr(p, Precedence::Postfix, Context::empty());
+        if let Some(super_type_parameters) = &self.super_type_arguments {
+          super_type_parameters.print(p, ctx);
+        }
+      }
+      if !self.implements.is_empty() {
+        p.print_str(" implements ");
+        p.print_list(&self.implements, ctx);
+      }
+      p.print_soft_space();
+      self.body.print(p, ctx);
+      p.needs_semicolon = false;
+      p.exit_class();
+    });
+  }
+}
+
+impl Gen for ClassBody<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_curly_braces(self.span, self.body.is_empty(), |p| {
+      for item in &self.body {
+        p.print_semicolon_if_needed();
+        p.print_leading_comments(item.span().start);
+        p.print_indent();
+        item.print(p, ctx);
+      }
+    });
+  }
+}
+
+impl Gen for ClassElement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::StaticBlock(elem) => {
+        elem.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::MethodDefinition(elem) => {
+        elem.print(p, ctx);
+        p.print_soft_newline();
+      }
+      Self::PropertyDefinition(elem) => {
+        elem.print(p, ctx);
+        p.print_semicolon_after_statement();
+      }
+      Self::AccessorProperty(elem) => {
+        elem.print(p, ctx);
+        p.print_semicolon_after_statement();
+      }
+      Self::TSIndexSignature(elem) => {
+        elem.print(p, ctx);
+        p.print_semicolon_after_statement();
+      }
+    }
+  }
+}
+
+impl Gen for JSXIdentifier<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.add_source_mapping_for_name(self.span, &self.name);
+    p.print_str(self.name.as_str());
+  }
+}
+
+impl Gen for JSXMemberExpressionObject<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::IdentifierReference(ident) => ident.print(p, ctx),
+      Self::MemberExpression(member_expr) => member_expr.print(p, ctx),
+      Self::ThisExpression(expr) => expr.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for JSXMemberExpression<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.object.print(p, ctx);
+    p.print_ascii_byte(b'.');
+    self.property.print(p, ctx);
+  }
+}
+
+impl Gen for JSXElementName<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::Identifier(identifier) => identifier.print(p, ctx),
+      Self::IdentifierReference(identifier) => identifier.print(p, ctx),
+      Self::NamespacedName(namespaced_name) => namespaced_name.print(p, ctx),
+      Self::MemberExpression(member_expr) => member_expr.print(p, ctx),
+      Self::ThisExpression(expr) => expr.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for JSXNamespacedName<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.namespace.print(p, ctx);
+    p.print_colon();
+    self.name.print(p, ctx);
+  }
+}
+
+impl Gen for JSXAttributeName<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::Identifier(ident) => ident.print(p, ctx),
+      Self::NamespacedName(namespaced_name) => namespaced_name.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for JSXAttribute<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.name.print(p, ctx);
+    if let Some(value) = &self.value {
+      p.print_equal();
+      value.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for JSXEmptyExpression {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_comments_at(self.span.end);
+  }
+}
+
+impl Gen for JSXExpression<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if let Self::EmptyExpression(expr) = self {
+      expr.print(p, ctx);
+    } else {
+      let expr = self.to_expression();
+      let start = expr.span().start;
+      if p.has_comment(start) {
+        p.print_comments_at(start);
+        p.print_indent();
+      }
+      p.print_expression(expr);
+    }
+  }
+}
+
+impl Gen for JSXExpressionContainer<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_ascii_byte(b'{');
+    self.expression.print(p, ctx);
+    p.print_ascii_byte(b'}');
+  }
+}
+
+impl Gen for JSXAttributeValue<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::Fragment(fragment) => fragment.print(p, ctx),
+      Self::Element(el) => el.print(p, ctx),
+      Self::StringLiteral(lit) => {
+        let quote = if lit.value.contains('"') { b'\'' } else { b'"' };
+        p.print_ascii_byte(quote);
+        p.print_str(&lit.value);
+        p.print_ascii_byte(quote);
+      }
+      Self::ExpressionContainer(expr_container) => expr_container.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for JSXSpreadAttribute<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_ascii_byte(b'{');
+    if p.print_comments_in_range(self.span.start, self.argument.span().start) {
+      p.print_indent();
+    }
+    p.print_str("...");
+    self.argument.print_expr(p, Precedence::Comma, Context::empty());
+    p.print_ascii_byte(b'}');
+  }
+}
+
+impl Gen for JSXAttributeItem<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::Attribute(attr) => attr.print(p, ctx),
+      Self::SpreadAttribute(spread_attr) => spread_attr.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for JSXElement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    // Opening element.
+    // Cannot `impl Gen for JSXOpeningElement` because it needs to know value of `self.closing_element`
+    // to determine whether to print a trailing `/`.
+    p.add_source_mapping(self.opening_element.span);
+    p.print_ascii_byte(b'<');
+    self.opening_element.name.print(p, ctx);
+    if let Some(type_arguments) = &self.opening_element.type_arguments {
+      type_arguments.print(p, ctx);
+    }
+    for attr in &self.opening_element.attributes {
+      match attr {
+        JSXAttributeItem::Attribute(_) => {
+          p.print_hard_space();
+        }
+        JSXAttributeItem::SpreadAttribute(_) => {
+          p.print_soft_space();
+        }
+      }
+      attr.print(p, ctx);
+    }
+    if self.closing_element.is_none() {
+      p.print_soft_space();
+      p.print_ascii_byte(b'/');
+    }
+    p.print_ascii_byte(b'>');
+
+    // Children
+    for child in &self.children {
+      child.print(p, ctx);
+    }
+
+    // Closing element
+    if let Some(closing_element) = &self.closing_element {
+      p.add_source_mapping(closing_element.span);
+      p.print_str("</");
+      closing_element.name.print(p, ctx);
+      p.print_ascii_byte(b'>');
+    }
+  }
+}
+
+impl Gen for JSXOpeningFragment {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_str("<>");
+  }
+}
+
+impl Gen for JSXClosingFragment {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_str("</>");
+  }
+}
+
+impl Gen for JSXText<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_str(self.value.as_str());
+  }
+}
+
+impl Gen for JSXSpreadChild<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.print_str("{...");
+    p.print_expression(&self.expression);
+    p.print_ascii_byte(b'}');
+  }
+}
+
+impl Gen for JSXChild<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::Fragment(fragment) => fragment.print(p, ctx),
+      Self::Element(el) => el.print(p, ctx),
+      Self::Spread(spread) => spread.print(p, ctx),
+      Self::ExpressionContainer(expr_container) => expr_container.print(p, ctx),
+      Self::Text(text) => text.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for JSXFragment<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.opening_fragment.print(p, ctx);
+    for child in &self.children {
+      child.print(p, ctx);
+    }
+    self.closing_fragment.print(p, ctx);
+  }
+}
+
+impl Gen for StaticBlock<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_str("static");
+    p.print_soft_space();
+    let single_line = self.body.is_empty() && !p.has_legal_orphans_before(self.span.end);
+    p.print_curly_braces(self.span, single_line, |p| {
+      p.print_stmts_with_orphan_flush(&self.body, self.span.end, ctx);
+    });
+    p.needs_semicolon = false;
+  }
+}
+
+impl Gen for MethodDefinition<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_decorators(&self.decorators, ctx);
+    if let Some(accessibility) = &self.accessibility {
+      p.print_space_before_identifier();
+      p.print_str(accessibility.as_str());
+      p.print_soft_space();
+    }
+    if self.r#type == MethodDefinitionType::TSAbstractMethodDefinition {
+      p.print_space_before_identifier();
+      p.print_str("abstract");
+      p.print_soft_space();
+    }
+    if self.r#static {
+      p.print_space_before_identifier();
+      p.print_str("static");
+      p.print_soft_space();
+    }
+    if self.r#override {
+      p.print_space_before_identifier();
+      p.print_str("override");
+      p.print_soft_space();
+    }
+    match &self.kind {
+      MethodDefinitionKind::Constructor | MethodDefinitionKind::Method => {}
+      MethodDefinitionKind::Get => {
+        p.print_space_before_identifier();
+        p.print_str("get");
+        p.print_soft_space();
+      }
+      MethodDefinitionKind::Set => {
+        p.print_space_before_identifier();
+        p.print_str("set");
+        p.print_soft_space();
+      }
+    }
+    if self.value.r#async {
+      p.print_space_before_identifier();
+      p.print_str("async");
+      p.print_soft_space();
+    }
+    if self.value.generator {
+      p.print_ascii_byte(b'*');
+    }
+    if self.computed {
+      p.print_ascii_byte(b'[');
+    }
+    self.key.print(p, ctx);
+    if self.computed {
+      p.print_ascii_byte(b']');
+    }
+    if self.optional {
+      p.print_ascii_byte(b'?');
+    }
+    if let Some(type_parameters) = self.value.type_parameters.as_ref() {
+      type_parameters.print(p, ctx);
+    }
+    p.print_ascii_byte(b'(');
+    if let Some(this_param) = &self.value.this_param {
+      this_param.print(p, ctx);
+      if !self.value.params.is_empty() || self.value.params.rest.is_some() {
+        p.print_ascii_byte(b',');
+        p.print_soft_space();
+      }
+    }
+    self.value.params.print(p, ctx);
+    p.print_ascii_byte(b')');
+    if let Some(return_type) = &self.value.return_type {
+      p.print_colon();
+      p.print_soft_space();
+      return_type.print(p, ctx);
+    }
+    if let Some(body) = &self.value.body {
+      p.print_soft_space();
+      body.print(p, ctx);
+    } else {
+      p.print_semicolon();
+    }
+  }
+}
+
+impl Gen for PropertyDefinition<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_decorators(&self.decorators, ctx);
+    if self.declare {
+      p.print_space_before_identifier();
+      p.print_str("declare");
+      p.print_soft_space();
+    }
+    if let Some(accessibility) = self.accessibility {
+      p.print_space_before_identifier();
+      p.print_str(accessibility.as_str());
+      p.print_soft_space();
+    }
+    if self.r#type == PropertyDefinitionType::TSAbstractPropertyDefinition {
+      p.print_space_before_identifier();
+      p.print_str("abstract");
+      p.print_soft_space();
+    }
+    if self.r#static {
+      p.print_space_before_identifier();
+      p.print_str("static");
+      p.print_soft_space();
+    }
+    if self.r#override {
+      p.print_space_before_identifier();
+      p.print_str("override");
+      p.print_soft_space();
+    }
+    if self.readonly {
+      p.print_space_before_identifier();
+      p.print_str("readonly");
+      p.print_soft_space();
+    }
+    if self.computed {
+      p.print_ascii_byte(b'[');
+    }
+    self.key.print(p, ctx);
+    if self.computed {
+      p.print_ascii_byte(b']');
+    }
+    if self.optional {
+      p.print_ascii_byte(b'?');
+    }
+    if self.definite {
+      p.print_ascii_byte(b'!');
+    }
+    if let Some(type_annotation) = &self.type_annotation {
+      p.print_colon();
+      p.print_soft_space();
+      type_annotation.print(p, ctx);
+    }
+    if let Some(value) = &self.value {
+      p.print_soft_space();
+      p.print_equal();
+      p.print_soft_space();
+      value.print_expr(p, Precedence::Comma, Context::empty());
+    }
+  }
+}
+
+impl Gen for AccessorProperty<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_decorators(&self.decorators, ctx);
+    if self.r#type.is_abstract() {
+      p.print_space_before_identifier();
+      p.print_str("abstract");
+      p.print_soft_space();
+    }
+    if let Some(accessibility) = self.accessibility {
+      p.print_space_before_identifier();
+      p.print_str(accessibility.as_str());
+      p.print_soft_space();
+    }
+    if self.r#static {
+      p.print_space_before_identifier();
+      p.print_str("static");
+      p.print_soft_space();
+    }
+    if self.r#override {
+      p.print_space_before_identifier();
+      p.print_str("override");
+      p.print_soft_space();
+    }
+    p.print_space_before_identifier();
+    p.print_str("accessor");
+    if self.computed {
+      p.print_soft_space();
+      p.print_ascii_byte(b'[');
+    } else {
+      p.print_hard_space();
+    }
+    self.key.print(p, ctx);
+    if self.computed {
+      p.print_ascii_byte(b']');
+    }
+    if self.definite {
+      p.print_ascii_byte(b'!');
+    }
+    if let Some(type_annotation) = &self.type_annotation {
+      p.print_colon();
+      p.print_soft_space();
+      type_annotation.print(p, ctx);
+    }
+    if let Some(value) = &self.value {
+      p.print_soft_space();
+      p.print_equal();
+      p.print_soft_space();
+      value.print_expr(p, Precedence::Comma, Context::empty());
+    }
+  }
+}
+
+impl Gen for PrivateIdentifier<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    p.add_source_mapping_for_name(self.span, &self.name);
+    p.print_ascii_byte(b'#');
+
+    if let Some(mangled) = p.private_member_mappings.as_ref().and_then(|mappings| {
+      p.current_class_ids()
+        .find_map(|class_id| mappings.get(class_id).and_then(|m| m.get(self.name.as_str())))
+        .cloned()
+    }) {
+      p.print_str(mangled.as_str());
+    } else {
+      p.print_str(self.name.as_str());
+    }
+  }
+}
+
+impl Gen for BindingPattern<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      BindingPattern::BindingIdentifier(ident) => ident.print(p, ctx),
+      BindingPattern::ObjectPattern(pattern) => pattern.print(p, ctx),
+      BindingPattern::ArrayPattern(pattern) => pattern.print(p, ctx),
+      BindingPattern::AssignmentPattern(pattern) => pattern.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for ObjectPattern<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    if self.is_empty() {
+      p.print_str("{}");
+      return;
+    }
+    p.print_ascii_byte(b'{');
+    p.print_soft_space();
+    p.print_list(&self.properties, ctx);
+    if let Some(rest) = &self.rest {
+      if !self.properties.is_empty() {
+        p.print_comma();
+        p.print_soft_space();
+      }
+      rest.print(p, ctx);
+    }
+    p.print_soft_space();
+    p.print_ascii_byte(b'}');
+  }
+}
+
+impl Gen for BindingProperty<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let mut shorthand = false;
+    if let PropertyKey::StaticIdentifier(key) = &self.key {
+      match &self.value {
+        BindingPattern::BindingIdentifier(ident)
+          if key.name == p.get_binding_identifier_name(ident) =>
+        {
+          shorthand = true;
+        }
+        BindingPattern::AssignmentPattern(assignment_pattern) => {
+          if let BindingPattern::BindingIdentifier(ident) = &assignment_pattern.left
+            && key.name == p.get_binding_identifier_name(ident)
+          {
+            shorthand = true;
+          }
+        }
+        _ => {}
+      }
+    }
+
+    if !shorthand {
+      if self.computed {
+        p.print_ascii_byte(b'[');
+      }
+      self.key.print(p, ctx);
+      if self.computed {
+        p.print_ascii_byte(b']');
+      }
+      p.print_colon();
+      p.print_soft_space();
+    }
+
+    self.value.print(p, ctx);
+  }
+}
+
+impl Gen for BindingRestElement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_ellipsis();
+    self.argument.print(p, ctx);
+  }
+}
+
+impl Gen for ArrayPattern<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.add_source_mapping(self.span);
+    p.print_ascii_byte(b'[');
+    for (index, item) in self.elements.iter().enumerate() {
+      if index != 0 {
+        p.print_comma();
+        p.print_soft_space();
+      }
+      if let Some(item) = item {
+        item.print(p, ctx);
+      }
+      if index == self.elements.len() - 1 && (item.is_none() || self.rest.is_some()) {
+        p.print_comma();
+      }
+    }
+    if let Some(rest) = &self.rest {
+      p.print_soft_space();
+      rest.print(p, ctx);
+    }
+    p.print_ascii_byte(b']');
+  }
+}
+
+impl Gen for AssignmentPattern<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.left.print(p, ctx);
+    p.print_soft_space();
+    p.print_equal();
+    p.print_soft_space();
+    self.right.print_expr(p, Precedence::Comma, Context::empty());
+  }
+}
+
+impl Gen for Decorator<'_> {
+  fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+    fn need_wrap(expr: &Expression) -> bool {
+      match expr {
+        // "@foo"
+        // "@foo.bar"
+        // "@foo.#bar"
+        Expression::Identifier(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::PrivateFieldExpression(_) => false,
+        Expression::CallExpression(call_expr) => need_wrap(&call_expr.callee),
+        // "@(foo + bar)"
+        // "@(() => {})"
+        // "@(foo['bar'])"
+        _ => true,
+      }
+    }
+
+    p.add_source_mapping(self.span);
+    p.print_ascii_byte(b'@');
+    let wrap = need_wrap(&self.expression);
+    p.wrap(wrap, |p| {
+      self.expression.print_expr(p, Precedence::Lowest, Context::empty());
+    });
+  }
+}
+
+impl Gen for TSClassImplements<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.expression.print(p, ctx);
+    if let Some(type_parameters) = self.type_arguments.as_ref() {
+      type_parameters.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for TSTypeParameterDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let is_multi_line = self.params.len() >= 2;
+    p.print_ascii_byte(b'<');
+    if is_multi_line {
+      p.indent();
+    }
+    for (index, item) in self.params.iter().enumerate() {
+      if index != 0 {
+        p.print_comma();
+      }
+      if is_multi_line {
+        p.print_soft_newline();
+        p.print_indent();
+      } else if index != 0 {
+        p.print_soft_space();
+      }
+      item.print(p, ctx);
+    }
+    if is_multi_line {
+      p.print_soft_newline();
+      p.dedent();
+      p.print_indent();
+    } else if p.is_jsx {
+      // `<T,>() => {}`
+      //    ^ We need a comma here, otherwise it will be regarded as a JSX element.
+      p.print_ascii_byte(b',');
+    }
+    p.print_ascii_byte(b'>');
+  }
+}
+
+impl Gen for TSTypeAnnotation<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.type_annotation.print(p, ctx);
+  }
+}
+
+impl Gen for TSType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let ctx = ctx.with_typescript();
+    match self {
+      Self::TSFunctionType(ty) => ty.print(p, ctx),
+      Self::TSConstructorType(ty) => ty.print(p, ctx),
+      Self::TSArrayType(ty) => ty.print(p, ctx),
+      Self::TSTupleType(ty) => ty.print(p, ctx),
+      Self::TSUnionType(ty) => ty.print(p, ctx),
+      Self::TSParenthesizedType(ty) => ty.print(p, ctx),
+      Self::TSIntersectionType(ty) => ty.print(p, ctx),
+      Self::TSConditionalType(ty) => ty.print(p, ctx),
+      Self::TSInferType(ty) => ty.print(p, ctx),
+      Self::TSIndexedAccessType(ty) => ty.print(p, ctx),
+      Self::TSMappedType(ty) => ty.print(p, ctx),
+      Self::TSNamedTupleMember(ty) => ty.print(p, ctx),
+      Self::TSLiteralType(ty) => ty.literal.print(p, ctx),
+      Self::TSImportType(ty) => ty.print(p, ctx),
+      Self::TSAnyKeyword(_) => p.print_str("any"),
+      Self::TSBigIntKeyword(_) => p.print_str("bigint"),
+      Self::TSBooleanKeyword(_) => p.print_str("boolean"),
+      Self::TSIntrinsicKeyword(_) => p.print_str("intrinsic"),
+      Self::TSNeverKeyword(_) => p.print_str("never"),
+      Self::TSNullKeyword(_) => p.print_str("null"),
+      Self::TSNumberKeyword(_) => p.print_str("number"),
+      Self::TSObjectKeyword(_) => p.print_str("object"),
+      Self::TSStringKeyword(_) => p.print_str("string"),
+      Self::TSSymbolKeyword(_) => p.print_str("symbol"),
+      Self::TSThisType(_) => p.print_str("this"),
+      Self::TSUndefinedKeyword(_) => p.print_str("undefined"),
+      Self::TSUnknownKeyword(_) => p.print_str("unknown"),
+      Self::TSVoidKeyword(_) => p.print_str("void"),
+      Self::TSTemplateLiteralType(ty) => ty.print(p, ctx),
+      Self::TSTypeLiteral(ty) => ty.print(p, ctx),
+      Self::TSTypeOperatorType(ty) => ty.print(p, ctx),
+      Self::TSTypePredicate(ty) => ty.print(p, ctx),
+      Self::TSTypeQuery(ty) => ty.print(p, ctx),
+      Self::TSTypeReference(ty) => ty.print(p, ctx),
+      Self::JSDocNullableType(ty) => ty.print(p, ctx),
+      Self::JSDocNonNullableType(ty) => ty.print(p, ctx),
+      Self::JSDocUnknownType(_ty) => p.print_str("unknown"),
+    }
+  }
+}
+
+impl Gen for TSArrayType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.wrap(parenthesize_check_type_of_postfix_type(&self.element_type), |p| {
+      self.element_type.print(p, ctx);
+    });
+    p.print_str("[]");
+  }
+}
+
+impl Gen for TSTupleType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_ascii_byte(b'[');
+    p.print_list(&self.element_types, ctx);
+    p.print_ascii_byte(b']');
+  }
+}
+
+fn parenthesize_check_type_of_union_type(ty: &TSType<'_>) -> bool {
+  match ty {
+    TSType::TSUnionType(ty) => ty.types.len() > 1,
+    TSType::TSFunctionType(_)
+    | TSType::TSConstructorType(_)
+    | TSType::TSConditionalType(_)
+    | TSType::TSInferType(_) => true,
+    _ => false,
+  }
+}
+
+fn parenthesize_check_type_of_intersection_type(ty: &TSType<'_>) -> bool {
+  match ty {
+    TSType::TSIntersectionType(ty) => ty.types.len() > 1,
+    _ => parenthesize_check_type_of_union_type(ty),
+  }
+}
+
+fn parenthesize_check_type_of_postfix_type(ty: &TSType<'_>) -> bool {
+  matches!(
+    ty,
+    TSType::TSUnionType(_)
+      | TSType::TSIntersectionType(_)
+      | TSType::TSFunctionType(_)
+      | TSType::TSConstructorType(_)
+      | TSType::TSConditionalType(_)
+      | TSType::TSInferType(_)
+      | TSType::TSTypeOperatorType(_)
+  )
+}
+
+impl Gen for TSUnionType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let Some((first, rest)) = self.types.split_first() else {
+      return;
+    };
+    p.wrap(parenthesize_check_type_of_union_type(first), |p| {
+      first.print(p, ctx);
+    });
+    for item in rest {
+      p.print_soft_space();
+      p.print_ascii_byte(b'|');
+      p.print_soft_space();
+      p.wrap(parenthesize_check_type_of_union_type(item), |p| {
+        item.print(p, ctx);
+      });
+    }
+  }
+}
+
+impl Gen for TSParenthesizedType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_ascii_byte(b'(');
+    self.type_annotation.print(p, ctx);
+    p.print_ascii_byte(b')');
+  }
+}
+
+impl Gen for TSIntersectionType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let Some((first, rest)) = self.types.split_first() else {
+      return;
+    };
+    p.wrap(parenthesize_check_type_of_intersection_type(first), |p| {
+      first.print(p, ctx);
+    });
+    for item in rest {
+      p.print_soft_space();
+      p.print_ascii_byte(b'&');
+      p.print_soft_space();
+      p.wrap(parenthesize_check_type_of_intersection_type(item), |p| {
+        item.print(p, ctx);
+      });
+    }
+  }
+}
+
+impl Gen for TSConditionalType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.wrap(
+      matches!(
+        &self.check_type,
+        TSType::TSFunctionType(_) | TSType::TSConstructorType(_) | TSType::TSConditionalType(_)
+      ),
+      |p| {
+        self.check_type.print(p, ctx);
+      },
+    );
+    p.print_str(" extends ");
+    p.wrap(matches!(self.extends_type, TSType::TSConditionalType(_)), |p| {
+      self.extends_type.print(p, ctx);
+    });
+    p.print_str(" ? ");
+    self.true_type.print(p, ctx);
+    p.print_str(" : ");
+    self.false_type.print(p, ctx);
+  }
+}
+
+impl Gen for TSInferType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_str("infer ");
+    self.type_parameter.print(p, ctx);
+  }
+}
+
+impl Gen for TSIndexedAccessType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.wrap(parenthesize_check_type_of_postfix_type(&self.object_type), |p| {
+      self.object_type.print(p, ctx);
+    });
+    p.print_ascii_byte(b'[');
+    self.index_type.print(p, ctx);
+    p.print_ascii_byte(b']');
+  }
+}
+
+impl Gen for TSMappedType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_ascii_byte(b'{');
+    p.print_soft_space();
+    match self.readonly {
+      Some(TSMappedTypeModifierOperator::True) => p.print_str("readonly "),
+      Some(TSMappedTypeModifierOperator::Plus) => p.print_str("+readonly "),
+      Some(TSMappedTypeModifierOperator::Minus) => p.print_str("-readonly "),
+      None => {}
+    }
+    p.print_ascii_byte(b'[');
+    self.key.print(p, ctx);
+    p.print_str(" in ");
+    self.constraint.print(p, ctx);
+    if let Some(name_type) = &self.name_type {
+      p.print_str(" as ");
+      name_type.print(p, ctx);
+    }
+    p.print_ascii_byte(b']');
+    match self.optional {
+      Some(TSMappedTypeModifierOperator::True) => p.print_ascii_byte(b'?'),
+      Some(TSMappedTypeModifierOperator::Plus) => p.print_str("+?"),
+      Some(TSMappedTypeModifierOperator::Minus) => p.print_str("-?"),
+      None => {}
+    }
+    p.print_soft_space();
+    if let Some(type_annotation) = &self.type_annotation {
+      p.print_colon();
+      p.print_soft_space();
+      type_annotation.print(p, ctx);
+    }
+    p.print_soft_space();
+    p.print_ascii_byte(b'}');
+  }
+}
+
+impl Gen for TSQualifiedName<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.left.print(p, ctx);
+    p.print_ascii_byte(b'.');
+    self.right.print(p, ctx);
+  }
+}
+
+impl Gen for TSTypeOperator<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_str(self.operator.to_str());
+    p.print_hard_space();
+    p.wrap(
+      matches!(
+        &self.type_annotation,
+        TSType::TSUnionType(_)
+          | TSType::TSIntersectionType(_)
+          | TSType::TSFunctionType(_)
+          | TSType::TSConstructorType(_)
+          | TSType::TSConditionalType(_)
+      ),
+      |p| {
+        self.type_annotation.print(p, ctx);
+      },
+    );
+  }
+}
+
+impl Gen for TSTypePredicate<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.asserts {
+      p.print_str("asserts ");
+    }
+    match &self.parameter_name {
+      TSTypePredicateName::Identifier(ident) => {
+        ident.print(p, ctx);
+      }
+      TSTypePredicateName::This(_ident) => {
+        p.print_str("this");
+      }
+    }
+    if let Some(type_annotation) = &self.type_annotation {
+      p.print_str(" is ");
+      type_annotation.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for TSTypeReference<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.type_name.print(p, ctx);
+    if let Some(type_parameters) = &self.type_arguments {
+      type_parameters.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for JSDocNullableType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.postfix {
+      self.type_annotation.print(p, ctx);
+      p.print_ascii_byte(b'?');
+    } else {
+      p.print_ascii_byte(b'?');
+      self.type_annotation.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for JSDocNonNullableType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.postfix {
+      self.type_annotation.print(p, ctx);
+      p.print_ascii_byte(b'!');
+    } else {
+      p.print_ascii_byte(b'!');
+      self.type_annotation.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for TSTemplateLiteralType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_ascii_byte(b'`');
+    for (index, item) in self.quasis.iter().enumerate() {
+      if index != 0
+        && let Some(types) = self.types.get(index - 1)
+      {
+        p.print_str("${");
+        types.print(p, ctx);
+        p.print_ascii_byte(b'}');
+      }
+      p.print_str(item.value.raw.as_str());
+    }
+    p.print_ascii_byte(b'`');
+  }
+}
+
+impl Gen for TSTypeLiteral<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_curly_braces(self.span, self.members.is_empty(), |p| {
+      for item in &self.members {
+        p.print_leading_comments(item.span().start);
+        p.print_indent();
+        item.print(p, ctx);
+        p.print_semicolon();
+        p.print_soft_newline();
+      }
+    });
+  }
+}
+
+impl Gen for TSTypeName<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::IdentifierReference(ident) => {
+        ident.print(p, ctx);
+      }
+      Self::QualifiedName(decl) => {
+        decl.left.print(p, ctx);
+        p.print_ascii_byte(b'.');
+        decl.right.print(p, ctx);
+      }
+      Self::ThisExpression(e) => {
+        e.print(p, ctx);
+      }
+    }
+  }
+}
+
+impl Gen for TSLiteral<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::BooleanLiteral(decl) => decl.print(p, ctx),
+      Self::NumericLiteral(decl) => decl.print_expr(p, Precedence::Lowest, ctx),
+      Self::BigIntLiteral(decl) => decl.print_expr(p, Precedence::Lowest, ctx),
+      Self::StringLiteral(decl) => decl.print(p, ctx),
+      Self::TemplateLiteral(decl) => decl.print(p, ctx),
+      Self::UnaryExpression(decl) => decl.print_expr(p, Precedence::Comma, ctx),
+    }
+  }
+}
+
+impl Gen for TSTypeParameter<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.r#const {
+      p.print_str("const ");
+    }
+    if self.r#in {
+      p.print_str("in ");
+    }
+    if self.out {
+      p.print_str("out ");
+    }
+    self.name.print(p, ctx);
+    if let Some(constraint) = &self.constraint {
+      p.print_str(" extends ");
+      constraint.print(p, ctx);
+    }
+    if let Some(default) = &self.default {
+      p.print_soft_space();
+      p.print_ascii_byte(b'=');
+      p.print_soft_space();
+      default.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for TSFunctionType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if let Some(type_parameters) = &self.type_parameters {
+      type_parameters.print(p, ctx);
+    }
+    p.print_ascii_byte(b'(');
+    if let Some(this_param) = &self.this_param {
+      this_param.print(p, ctx);
+      if !self.params.is_empty() || self.params.rest.is_some() {
+        p.print_ascii_byte(b',');
+        p.print_soft_space();
+      }
+    }
+    self.params.print(p, ctx);
+    p.print_ascii_byte(b')');
+    p.print_soft_space();
+    p.print_str("=>");
+    p.print_soft_space();
+    self.return_type.print(p, ctx);
+  }
+}
+
+impl Gen for TSThisParameter<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_str("this");
+    if let Some(type_annotation) = &self.type_annotation {
+      p.print_str(": ");
+      type_annotation.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for TSSignature<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::TSIndexSignature(signature) => signature.print(p, ctx),
+      Self::TSPropertySignature(signature) => signature.r#gen(p, ctx),
+      Self::TSCallSignatureDeclaration(signature) => {
+        if let Some(type_parameters) = signature.type_parameters.as_ref() {
+          type_parameters.print(p, ctx);
+        }
+        p.print_ascii_byte(b'(');
+        if let Some(this_param) = &signature.this_param {
+          this_param.print(p, ctx);
+          if !signature.params.is_empty() || signature.params.rest.is_some() {
+            p.print_ascii_byte(b',');
+            p.print_soft_space();
+          }
+        }
+        signature.params.print(p, ctx);
+        p.print_ascii_byte(b')');
+        if let Some(return_type) = &signature.return_type {
+          p.print_colon();
+          p.print_soft_space();
+          return_type.print(p, ctx);
+        }
+      }
+      Self::TSConstructSignatureDeclaration(signature) => {
+        p.print_str("new ");
+        if let Some(type_parameters) = signature.type_parameters.as_ref() {
+          type_parameters.print(p, ctx);
+        }
+        p.print_ascii_byte(b'(');
+        signature.params.print(p, ctx);
+        p.print_ascii_byte(b')');
+        if let Some(return_type) = &signature.return_type {
+          p.print_colon();
+          p.print_soft_space();
+          return_type.print(p, ctx);
+        }
+      }
+      Self::TSMethodSignature(signature) => {
+        match signature.kind {
+          TSMethodSignatureKind::Method => {}
+          TSMethodSignatureKind::Get => p.print_str("get "),
+          TSMethodSignatureKind::Set => p.print_str("set "),
+        }
+        if signature.computed {
+          p.print_ascii_byte(b'[');
+          signature.key.print(p, ctx);
+          p.print_ascii_byte(b']');
+        } else {
+          match &signature.key {
+            PropertyKey::StaticIdentifier(key) => {
+              key.print(p, ctx);
+            }
+            PropertyKey::PrivateIdentifier(key) => {
+              p.print_str(key.name.as_str());
+            }
+            PropertyKey::StringLiteral(key) => {
+              p.print_string_literal(key, false);
+            }
+            key => {
+              key.to_expression().print_expr(p, Precedence::Comma, ctx);
+            }
+          }
+        }
+        if signature.optional {
+          p.print_ascii_byte(b'?');
+        }
+        if let Some(type_parameters) = &signature.type_parameters {
+          type_parameters.print(p, ctx);
+        }
+        p.print_ascii_byte(b'(');
+        if let Some(this_param) = &signature.this_param {
+          this_param.print(p, ctx);
+          if !signature.params.is_empty() || signature.params.rest.is_some() {
+            p.print_ascii_byte(b',');
+            p.print_soft_space();
+          }
+        }
+        signature.params.print(p, ctx);
+        p.print_ascii_byte(b')');
+        if let Some(return_type) = &signature.return_type {
+          p.print_colon();
+          p.print_soft_space();
+          return_type.print(p, ctx);
+        }
+      }
+    }
+  }
+}
+
+impl Gen for TSPropertySignature<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.readonly {
+      p.print_str("readonly ");
+    }
+    if self.computed {
+      p.print_ascii_byte(b'[');
+      self.key.print(p, ctx);
+      p.print_ascii_byte(b']');
+    } else {
+      match &self.key {
+        PropertyKey::StaticIdentifier(key) => {
+          key.print(p, ctx);
+        }
+        PropertyKey::PrivateIdentifier(key) => {
+          p.print_str(key.name.as_str());
+        }
+        PropertyKey::StringLiteral(key) => {
+          p.print_string_literal(key, false);
+        }
+        key => {
+          key.to_expression().print_expr(p, Precedence::Comma, ctx);
+        }
+      }
+    }
+    if self.optional {
+      p.print_ascii_byte(b'?');
+    }
+    if let Some(type_annotation) = &self.type_annotation {
+      p.print_colon();
+      p.print_soft_space();
+      type_annotation.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for TSTypeQuery<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_str("typeof ");
+    self.expr_name.print(p, ctx);
+    if let Some(type_params) = &self.type_arguments {
+      type_params.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for TSTypeQueryExprName<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      match_ts_type_name!(Self) => self.to_ts_type_name().print(p, ctx),
+      Self::TSImportType(decl) => decl.print(p, ctx),
+    }
+  }
+}
+
+impl Gen for TSImportType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_str("import(");
+    p.print_string_literal(&self.source, false);
+    if let Some(options) = &self.options {
+      p.print_str(", ");
+      options.print_expr(p, Precedence::Lowest, ctx);
+    }
+    p.print_ascii_byte(b')');
+    if let Some(qualifier) = &self.qualifier {
+      p.print_ascii_byte(b'.');
+      qualifier.print(p, ctx);
+    }
+    if let Some(type_parameters) = &self.type_arguments {
+      type_parameters.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for TSImportTypeQualifier<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      TSImportTypeQualifier::Identifier(ident) => {
+        p.print_str(ident.name.as_str());
+      }
+      TSImportTypeQualifier::QualifiedName(qualified) => {
+        qualified.print(p, ctx);
+      }
+    }
+  }
+}
+
+impl Gen for TSImportTypeQualifiedName<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.left.print(p, ctx);
+    p.print_ascii_byte(b'.');
+    p.print_str(self.right.name.as_str());
+  }
+}
+
+impl Gen for TSTypeParameterInstantiation<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_ascii_byte(b'<');
+    p.print_list(&self.params, ctx);
+    p.print_ascii_byte(b'>');
+  }
+}
+
+impl Gen for TSIndexSignature<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.r#static {
+      p.print_str("static ");
+    }
+    if self.readonly {
+      p.print_str("readonly ");
+    }
+    p.print_ascii_byte(b'[');
+    for (index, parameter) in self.parameters.iter().enumerate() {
+      if index != 0 {
+        p.print_ascii_byte(b',');
+        p.print_soft_space();
+      }
+      p.print_str(parameter.name.as_str());
+      p.print_colon();
+      p.print_soft_space();
+      parameter.type_annotation.print(p, ctx);
+    }
+    p.print_ascii_byte(b']');
+    p.print_colon();
+    p.print_soft_space();
+    self.type_annotation.print(p, ctx);
+  }
+}
+
+impl Gen for TSTupleElement<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      match_ts_type!(TSTupleElement) => self.to_ts_type().print(p, ctx),
+      TSTupleElement::TSOptionalType(ts_type) => {
+        p.wrap(parenthesize_check_type_of_postfix_type(&ts_type.type_annotation), |p| {
+          ts_type.type_annotation.print(p, ctx);
+        });
+        p.print_ascii_byte(b'?');
+      }
+      TSTupleElement::TSRestType(ts_type) => {
+        p.print_str("...");
+        ts_type.type_annotation.print(p, ctx);
+      }
+    }
+  }
+}
+
+impl Gen for TSNamedTupleMember<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.label.print(p, ctx);
+    if self.optional {
+      p.print_ascii_byte(b'?');
+    }
+    p.print_colon();
+    p.print_soft_space();
+    self.element_type.print(p, ctx);
+  }
+}
+
+impl Gen for TSModuleDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.declare {
+      p.print_str("declare ");
+    }
+    p.print_str(self.kind.as_str());
+    p.print_space_before_identifier();
+    self.id.print(p, ctx);
+
+    if let Some(body) = &self.body {
+      let mut body = body;
+      loop {
+        match body {
+          TSModuleDeclarationBody::TSModuleDeclaration(b) => {
+            p.print_ascii_byte(b'.');
+            b.id.print(p, ctx);
+            if let Some(b) = &b.body {
+              body = b;
+            } else {
+              break;
+            }
+          }
+          TSModuleDeclarationBody::TSModuleBlock(body) => {
+            p.print_soft_space();
+            body.print(p, ctx);
+            break;
+          }
+        }
+      }
+    } else {
+      p.print_semicolon();
+    }
+    p.needs_semicolon = false;
+  }
+}
+
+impl Gen for TSModuleDeclarationName<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::Identifier(ident) => ident.print(p, ctx),
+      Self::StringLiteral(s) => p.print_string_literal(s, false),
+    }
+  }
+}
+
+impl Gen for TSGlobalDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.declare {
+      p.print_str("declare ");
+    }
+    p.print_str("global");
+    p.print_soft_space();
+    self.body.print(p, ctx);
+    p.needs_semicolon = false;
+  }
+}
+
+impl Gen for TSModuleBlock<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    let is_empty = self.directives.is_empty() && self.body.is_empty();
+    p.print_curly_braces(self.span, is_empty, |p| {
+      p.print_directives_and_statements(&self.directives, &self.body, self.span.end, ctx);
+    });
+    p.needs_semicolon = false;
+  }
+}
+
+impl Gen for TSTypeAliasDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.declare {
+      p.print_str("declare ");
+    }
+    p.print_str("type");
+    p.print_space_before_identifier();
+    self.id.print(p, ctx);
+    if let Some(type_parameters) = &self.type_parameters {
+      type_parameters.print(p, ctx);
+    }
+    p.print_soft_space();
+    p.print_ascii_byte(b'=');
+    p.print_soft_space();
+    self.type_annotation.print(p, ctx);
+  }
+}
+
+impl Gen for TSInterfaceDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.declare {
+      p.print_str("declare ");
+    }
+    p.print_str("interface");
+    p.print_hard_space();
+    self.id.print(p, ctx);
+    if let Some(type_parameters) = &self.type_parameters {
+      type_parameters.print(p, ctx);
+    }
+    if !self.extends.is_empty() {
+      p.print_str(" extends ");
+      p.print_list(&self.extends, ctx);
+    }
+    p.print_soft_space();
+    p.print_curly_braces(self.body.span, self.body.body.is_empty(), |p| {
+      for item in &self.body.body {
+        p.print_leading_comments(item.span().start);
+        p.print_indent();
+        item.print(p, ctx);
+        p.print_semicolon();
+        p.print_soft_newline();
+      }
+    });
+  }
+}
+
+impl Gen for TSInterfaceHeritage<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    self.expression.print_expr(p, Precedence::Call, ctx);
+    if let Some(type_parameters) = &self.type_arguments {
+      type_parameters.print(p, ctx);
+    }
+  }
+}
+
+impl Gen for TSEnumDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.declare {
+      p.print_str("declare ");
+    }
+    if self.r#const {
+      p.print_str("const ");
+    }
+    p.print_space_before_identifier();
+    p.print_str("enum ");
+    self.id.print(p, ctx);
+    p.print_space_before_identifier();
+    self.body.print(p, ctx);
+  }
+}
+
+impl Gen for TSEnumBody<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_curly_braces(self.span, self.members.is_empty(), |p| {
+      for (index, member) in self.members.iter().enumerate() {
+        p.print_leading_comments(member.span().start);
+        p.print_indent();
+        member.print(p, ctx);
+        if index != self.members.len() - 1 {
+          p.print_comma();
+        }
+        p.print_soft_newline();
+      }
+    });
+  }
+}
+
+impl Gen for TSEnumMember<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match &self.id {
+      TSEnumMemberName::Identifier(decl) => decl.print(p, ctx),
+      TSEnumMemberName::String(decl) => p.print_string_literal(decl, false),
+      TSEnumMemberName::ComputedString(decl) => {
+        p.print_ascii_byte(b'[');
+        p.print_string_literal(decl, false);
+        p.print_ascii_byte(b']');
+      }
+      TSEnumMemberName::ComputedTemplateString(decl) => {
+        let quasi = decl.quasis.first().unwrap();
+        p.add_source_mapping(quasi.span);
+
+        p.print_str("[`");
+        p.print_str(quasi.value.raw.as_str());
+        p.print_str("`]");
+      }
+    }
+
+    if let Some(init) = &self.initializer {
+      p.print_soft_space();
+      p.print_equal();
+      p.print_soft_space();
+      init.print_expr(p, Precedence::Lowest, ctx);
+    }
+  }
+}
+
+impl Gen for TSConstructorType<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    if self.r#abstract {
+      p.print_str("abstract ");
+    }
+    p.print_str("new ");
+    if let Some(type_parameters) = &self.type_parameters {
+      type_parameters.print(p, ctx);
+    }
+    p.print_ascii_byte(b'(');
+    self.params.print(p, ctx);
+    p.print_ascii_byte(b')');
+    p.print_soft_space();
+    p.print_str("=>");
+    p.print_soft_space();
+    self.return_type.print(p, ctx);
+  }
+}
+
+impl Gen for TSImportEqualsDeclaration<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    p.print_str("import ");
+    if self.import_kind.is_type() {
+      p.print_str("type ");
+    }
+    self.id.print(p, ctx);
+    p.print_soft_space();
+    p.print_ascii_byte(b'=');
+    p.print_soft_space();
+    self.module_reference.print(p, ctx);
+  }
+}
+
+impl Gen for TSModuleReference<'_> {
+  fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    match self {
+      Self::ExternalModuleReference(decl) => {
+        p.print_str("require(");
+        p.print_string_literal(&decl.expression, false);
+        p.print_ascii_byte(b')');
+      }
+      Self::IdentifierReference(ident) => ident.print(p, ctx),
+      Self::QualifiedName(qualified) => qualified.print(p, ctx),
+    }
+  }
+}
+
+impl GenExpr for V8IntrinsicExpression<'_> {
+  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    let is_statement = p.start_of_stmt == p.code_len();
+    let is_export_default = p.start_of_default_export == p.code_len();
+    let mut wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
+    if precedence >= Precedence::Postfix {
+      wrap = true;
+    }
+
+    p.wrap(wrap, |p| {
+      if is_export_default {
+        p.start_of_default_export = p.code_len();
+      } else if is_statement {
+        p.start_of_stmt = p.code_len();
+      }
+      p.add_source_mapping(self.span);
+      p.print_ascii_byte(b'%');
+      self.name.print(p, Context::empty());
+      p.print_arguments(self.span, &self.arguments, ctx);
+    });
+  }
+}

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/lib.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/lib.rs
@@ -1,0 +1,890 @@
+//! Oxc Codegen
+//!
+//! Code adapted from
+//! * [esbuild](https://github.com/evanw/esbuild/blob/v0.24.0/internal/js_printer/js_printer.go)
+
+use std::{borrow::Cow, cmp, slice};
+
+use cow_utils::CowUtils;
+
+use oxc_ast::ast::*;
+use oxc_data_structures::{code_buffer::CodeBuffer, stack::Stack};
+use oxc_index::IndexVec;
+use oxc_semantic::Scoping;
+use oxc_span::{GetSpan, Span};
+use oxc_str::CompactStr;
+use oxc_syntax::{
+  class::ClassId,
+  identifier::{is_identifier_part, is_identifier_part_ascii},
+  operator::{BinaryOperator, UnaryOperator, UpdateOperator},
+  precedence::Precedence,
+};
+use rustc_hash::FxHashMap;
+
+mod binary_expr_visitor;
+mod comment;
+mod context;
+mod r#gen;
+mod operator;
+mod options;
+mod str;
+
+use binary_expr_visitor::BinaryExpressionVisitor;
+use comment::CommentsMap;
+use operator::Operator;
+use str::{Quote, cold_branch, is_script_close_tag};
+
+pub use context::Context;
+pub use r#gen::{Gen, GenExpr};
+pub use options::{CodegenOptions, LegalComment};
+
+/// Output from [`Codegen::build`]
+#[non_exhaustive]
+pub struct CodegenReturn {
+  /// The generated source code.
+  pub code: String,
+
+  /// All the legal comments returned from [LegalComment::Linked] or [LegalComment::External].
+  pub legal_comments: Vec<Comment>,
+}
+
+/// A code generator for printing JavaScript and TypeScript code.
+///
+/// ## Example
+/// ```ignore
+/// use crate::codegen::oxc::Codegen;
+/// use oxc_ast::ast::Program;
+/// use oxc_parser::Parser;
+/// use oxc_allocator::Allocator;
+/// use oxc_span::SourceType;
+///
+/// let allocator = Allocator::default();
+/// let source = "const a = 1 + 2;";
+/// let parsed = Parser::new(&allocator, source, SourceType::mjs()).parse();
+/// assert!(parsed.errors.is_empty());
+///
+/// let js = Codegen::new().build(&parsed.program);
+/// assert_eq!(js.code, "const a = 1 + 2;\n");
+/// ```
+pub struct Codegen<'a> {
+  pub(crate) options: CodegenOptions,
+
+  /// Original source code of the AST
+  source_text: Option<&'a str>,
+
+  scoping: Option<Scoping>,
+
+  /// Private member name mappings for mangling
+  private_member_mappings: Option<IndexVec<ClassId, FxHashMap<String, CompactStr>>>,
+
+  /// Output Code
+  code: CodeBuffer,
+
+  // states
+  prev_op_end: usize,
+  prev_reg_exp_end: usize,
+  need_space_before_dot: usize,
+  print_next_indent_as_space: bool,
+  binary_expr_stack: Stack<BinaryExpressionVisitor<'a>>,
+  class_stack: Stack<ClassId>,
+  next_class_id: ClassId,
+  /// Indicates the output is JSX type, it is set in [`Program::gen`] and the result
+  /// is obtained by [`oxc_span::SourceType::is_jsx`]
+  is_jsx: bool,
+
+  /// For avoiding `;` if the previous statement ends with `}`.
+  needs_semicolon: bool,
+
+  prev_op: Option<Operator>,
+
+  start_of_stmt: usize,
+  start_of_arrow_expr: usize,
+  start_of_default_export: usize,
+
+  /// Track the current indentation level
+  indent: u32,
+
+  /// Fast path for [CodegenOptions::single_quote]
+  quote: Quote,
+
+  // Builders
+  comments: CommentsMap,
+
+  /// Sorted, deduped `attached_to` keys for pending legal comments. Lets
+  /// `print_legal_orphans_before` flush via `partition_point` + `drain`.
+  legal_comment_keys: Vec<u32>,
+}
+
+impl Default for Codegen<'_> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<'a> From<Codegen<'a>> for String {
+  fn from(val: Codegen<'a>) -> Self {
+    val.into_source_text()
+  }
+}
+
+impl<'a> From<Codegen<'a>> for Cow<'a, str> {
+  fn from(val: Codegen<'a>) -> Self {
+    Cow::Owned(val.into_source_text())
+  }
+}
+
+// Public APIs
+impl<'a> Codegen<'a> {
+  /// Create a new code generator.
+  ///
+  /// This is equivalent to [`Codegen::default`].
+  #[must_use]
+  pub fn new() -> Self {
+    let options = CodegenOptions::default();
+    Self {
+      options,
+      source_text: None,
+      scoping: None,
+      private_member_mappings: None,
+      code: CodeBuffer::default(),
+      needs_semicolon: false,
+      need_space_before_dot: 0,
+      print_next_indent_as_space: false,
+      binary_expr_stack: Stack::with_capacity(12),
+      class_stack: Stack::with_capacity(4),
+      next_class_id: ClassId::from_usize(0),
+      prev_op_end: 0,
+      prev_reg_exp_end: 0,
+      prev_op: None,
+      start_of_stmt: 0,
+      start_of_arrow_expr: 0,
+      start_of_default_export: 0,
+      is_jsx: false,
+      indent: 0,
+      quote: Quote::Double,
+      comments: CommentsMap::default(),
+      legal_comment_keys: Vec::new(),
+    }
+  }
+
+  /// Pass options to the code generator.
+  #[must_use]
+  pub fn with_options(mut self, options: CodegenOptions) -> Self {
+    self.quote = if options.single_quote { Quote::Single } else { Quote::Double };
+    self.code = CodeBuffer::with_indent(options.indent_char, options.indent_width);
+    self.options = options;
+    self
+  }
+
+  /// Sets the source text for the code generator.
+  #[must_use]
+  pub fn with_source_text(mut self, source_text: &'a str) -> Self {
+    self.source_text = Some(source_text);
+    self
+  }
+
+  /// Set the symbol table used for identifier renaming.
+  ///
+  /// Can be used for easy renaming of variables (based on semantic analysis).
+  #[must_use]
+  pub fn with_scoping(mut self, scoping: Option<Scoping>) -> Self {
+    self.scoping = scoping;
+    self
+  }
+
+  /// Set private member name mappings for mangling.
+  ///
+  /// This allows renaming of private class members like `#field` -> `#a`.
+  /// The Vec contains per-class mappings, indexed by class declaration order.
+  #[must_use]
+  pub fn with_private_member_mappings(
+    mut self,
+    mappings: Option<IndexVec<ClassId, FxHashMap<String, CompactStr>>>,
+  ) -> Self {
+    self.private_member_mappings = mappings;
+    self
+  }
+
+  /// Print a [`Program`] into a string of source code.
+  ///
+  #[must_use]
+  pub fn build(mut self, program: &Program<'a>) -> CodegenReturn {
+    self.quote = if self.options.single_quote { Quote::Single } else { Quote::Double };
+    self.source_text = Some(program.source_text);
+    self.indent = self.options.initial_indent;
+    self.code.reserve(program.source_text.len());
+    self.build_comments(&program.comments);
+    program.print(&mut self, Context::default());
+    let legal_comments = self.handle_eof_linked_or_external_comments(program);
+    let code = self.code.into_string();
+    CodegenReturn { code, legal_comments }
+  }
+
+  /// Turn what's been built so far into a string. Like [`build`],
+  /// this fininishes a print and returns the generated source code. Unlike
+  /// [`build`], no source map is generated.
+  ///
+  /// This is more useful for cases that progressively build code using [`print_expression`].
+  ///
+  /// [`build`]: Codegen::build
+  /// [`print_expression`]: Codegen::print_expression
+  #[must_use]
+  pub fn into_source_text(self) -> String {
+    self.code.into_string()
+  }
+
+  /// Push a single ASCII byte into the buffer.
+  ///
+  /// # Panics
+  /// Panics if `byte` is not an ASCII byte (`0 - 0x7F`).
+  #[inline]
+  pub fn print_ascii_byte(&mut self, byte: u8) {
+    self.code.print_ascii_byte(byte);
+  }
+
+  /// Push str into the buffer
+  #[inline]
+  pub fn print_str(&mut self, s: &str) {
+    self.code.print_str(s);
+  }
+
+  /// Push str into the buffer, escaping `</script` to `<\/script`.
+  #[inline]
+  pub fn print_str_escaping_script_close_tag(&mut self, s: &str) {
+    // `</script` will be very rare. So we try to make the search as quick as possible by:
+    // 1. Searching for `<` first, and only checking if followed by `/script` once `<` is found.
+    // 2. Searching longer strings for `<` in chunks of 16 bytes using SIMD, and only doing the
+    //    more expensive byte-by-byte search once a `<` is found.
+
+    let bytes = s.as_bytes();
+    let mut consumed = 0;
+
+    // Search range of bytes for `</script`, byte by byte.
+    //
+    // Bytes between `ptr` and `last_ptr` (inclusive) are searched for `<`.
+    // If `<` is found, the following 7 bytes are checked to see if they're `/script`.
+    //
+    // Requirements for the closure below:
+    // * `ptr` and `last_ptr` must be within bounds of `bytes`.
+    // * `last_ptr` must be greater or equal to `ptr`.
+    // * `last_ptr` must be no later than 8 bytes before end of string.
+    //   i.e. safe to read 8 bytes at `end_ptr`.
+    let mut search_bytes = |mut ptr: *const u8, last_ptr| {
+      loop {
+        // SAFETY: `ptr` is always less than or equal to `last_ptr`.
+        // `last_ptr` is within bounds of `bytes`, so safe to read a byte at `ptr`.
+        let byte = unsafe { *ptr.as_ref().unwrap_unchecked() };
+        if byte == b'<' {
+          // SAFETY: `ptr <= last_ptr`, and `last_ptr` points to no later than
+          // 8 bytes before end of string, so safe to read 8 bytes from `ptr`
+          let slice = unsafe { slice::from_raw_parts(ptr, 8) };
+          if is_script_close_tag(slice) {
+            // Push str up to and including `<`. Skip `/`. Write `\/` instead.
+            // SAFETY:
+            // `consumed` is initially 0, and only updated below to be after `/`,
+            // so in bounds, and on a UTF-8 char boundary.
+            // `index` is on `<`, so `index + 1` is in bounds and a UTF-8 char boundary.
+            // `consumed` is always less than `index + 1` as it's set on a previous round.
+            unsafe {
+              let index = ptr.offset_from_unsigned(bytes.as_ptr());
+              let before = bytes.get_unchecked(consumed..=index);
+              self.code.print_bytes_unchecked(before);
+
+              // Set `consumed` to after `/`
+              consumed = index + 2;
+            }
+            self.print_str("\\/");
+            // Note: We could advance `ptr` by 8 bytes here to skip over `</script`,
+            // but this branch will be very rarely taken, so it's better to keep it simple
+          }
+        }
+
+        if ptr == last_ptr {
+          break;
+        }
+        // SAFETY: `ptr` is less than `last_ptr`, which is in bounds, so safe to increment `ptr`
+        ptr = unsafe { ptr.add(1) };
+      }
+    };
+
+    // Search string in chunks of 16 bytes
+    let mut chunks = bytes.chunks_exact(16);
+    for (chunk_index, chunk) in chunks.by_ref().enumerate() {
+      #[expect(clippy::missing_panics_doc, reason = "infallible")]
+      let chunk: &[u8; 16] = chunk.try_into().unwrap();
+
+      // Compiler vectorizes this loop to a few SIMD ops
+      let mut contains_lt = false;
+      for &byte in chunk {
+        if byte == b'<' {
+          contains_lt = true;
+        }
+      }
+
+      if contains_lt {
+        // Chunk contains at least one `<`.
+        // Find them, and check if they're the start of `</script`.
+        //
+        // SAFETY: `index` is byte index of start of chunk.
+        // We search bytes starting with first byte of chunk, and ending with last byte of chunk.
+        // i.e. `index` to `index + 15` (inclusive).
+        // If this chunk is towards the end of the string, reduce the range of bytes searched
+        // so the last byte searched has at least 7 further bytes after it.
+        // i.e. safe to read 8 bytes at `last_ptr`.
+        cold_branch(|| unsafe {
+          let index = chunk_index * 16;
+          let remaining_bytes = bytes.len() - index;
+          let last_offset = cmp::min(remaining_bytes - 8, 15);
+          let ptr = bytes.as_ptr().add(index);
+          let last_ptr = ptr.add(last_offset);
+          search_bytes(ptr, last_ptr);
+        });
+      }
+    }
+
+    // Search last chunk byte-by-byte.
+    // Skip this if less than 8 bytes remaining, because less than 8 bytes can't contain `</script`.
+    let last_chunk = chunks.remainder();
+    if last_chunk.len() >= 8 {
+      let ptr = last_chunk.as_ptr();
+      // SAFETY: `last_chunk.len() >= 8`, so `- 8` cannot wrap.
+      // `last_chunk.as_ptr().add(last_chunk.len() - 8)` is in bounds of `last_chunk`.
+      let last_ptr = unsafe { ptr.add(last_chunk.len() - 8) };
+      search_bytes(ptr, last_ptr);
+    }
+
+    // SAFETY: `consumed` is either 0, or after `/`, so on a UTF-8 char boundary, and in bounds
+    unsafe {
+      let remaining = bytes.get_unchecked(consumed..);
+      self.code.print_bytes_unchecked(remaining);
+    }
+  }
+
+  /// Print a single [`Expression`], adding it to the code generator's
+  /// internal buffer. Unlike [`Codegen::build`], this does not consume `self`.
+  #[inline]
+  pub fn print_expression(&mut self, expr: &Expression<'_>) {
+    expr.print_expr(self, Precedence::Lowest, Context::empty());
+  }
+}
+
+// Private APIs
+impl<'a> Codegen<'a> {
+  fn code(&self) -> &CodeBuffer {
+    &self.code
+  }
+
+  fn code_len(&self) -> usize {
+    self.code().len()
+  }
+
+  #[inline]
+  fn print_soft_space(&mut self) {
+    if !self.options.minify {
+      self.print_ascii_byte(b' ');
+    }
+  }
+
+  #[inline]
+  fn print_hard_space(&mut self) {
+    self.print_ascii_byte(b' ');
+  }
+
+  #[inline]
+  fn print_soft_newline(&mut self) {
+    if !self.options.minify {
+      self.print_ascii_byte(b'\n');
+    }
+  }
+
+  #[inline]
+  fn print_hard_newline(&mut self) {
+    self.print_ascii_byte(b'\n');
+  }
+
+  #[inline]
+  fn print_semicolon(&mut self) {
+    self.print_ascii_byte(b';');
+  }
+
+  #[inline]
+  fn print_comma(&mut self) {
+    self.print_ascii_byte(b',');
+  }
+
+  #[inline]
+  fn print_space_before_identifier(&mut self) {
+    let Some(byte) = self.last_byte() else { return };
+
+    if self.prev_reg_exp_end != self.code.len() {
+      let is_identifier = if byte.is_ascii() {
+        // Fast path for ASCII (very common case)
+        is_identifier_part_ascii(byte as char)
+      } else {
+        is_identifier_part(self.last_char().unwrap())
+      };
+      if !is_identifier {
+        return;
+      }
+    }
+
+    self.print_hard_space();
+  }
+
+  #[inline]
+  fn last_byte(&self) -> Option<u8> {
+    self.code.last_byte()
+  }
+
+  #[inline]
+  fn last_char(&self) -> Option<char> {
+    self.code.last_char()
+  }
+
+  #[inline]
+  fn indent(&mut self) {
+    if !self.options.minify {
+      self.indent += 1;
+    }
+  }
+
+  #[inline]
+  fn dedent(&mut self) {
+    if !self.options.minify {
+      self.indent -= 1;
+    }
+  }
+
+  #[inline]
+  fn enter_class(&mut self) {
+    let class_id = self.next_class_id;
+    self.next_class_id = ClassId::from_usize(self.next_class_id.index() + 1);
+    self.class_stack.push(class_id);
+  }
+
+  #[inline]
+  fn exit_class(&mut self) {
+    self.class_stack.pop();
+  }
+
+  #[inline]
+  fn current_class_ids(&self) -> impl Iterator<Item = ClassId> {
+    self.class_stack.iter().rev().copied()
+  }
+
+  #[inline]
+  fn wrap<F: FnMut(&mut Self)>(&mut self, wrap: bool, mut f: F) {
+    if wrap {
+      self.print_ascii_byte(b'(');
+    }
+    f(self);
+    if wrap {
+      self.print_ascii_byte(b')');
+    }
+  }
+
+  #[inline]
+  fn print_indent(&mut self) {
+    if self.options.minify {
+      return;
+    }
+    if self.print_next_indent_as_space {
+      self.print_hard_space();
+      self.print_next_indent_as_space = false;
+      return;
+    }
+    self.code.print_indent(self.indent as usize);
+  }
+
+  #[inline]
+  fn print_semicolon_after_statement(&mut self) {
+    if self.options.minify {
+      self.needs_semicolon = true;
+    } else {
+      self.print_str(";\n");
+    }
+  }
+
+  #[inline]
+  fn print_semicolon_if_needed(&mut self) {
+    if self.needs_semicolon {
+      self.print_semicolon();
+      self.needs_semicolon = false;
+    }
+  }
+
+  #[inline]
+  fn print_ellipsis(&mut self) {
+    self.print_str("...");
+  }
+
+  #[inline]
+  fn print_colon(&mut self) {
+    self.print_ascii_byte(b':');
+  }
+
+  #[inline]
+  fn print_equal(&mut self) {
+    self.print_ascii_byte(b'=');
+  }
+
+  fn print_curly_braces<F: FnOnce(&mut Self)>(&mut self, span: Span, single_line: bool, op: F) {
+    self.add_source_mapping(span);
+    self.print_ascii_byte(b'{');
+    if !single_line {
+      self.print_soft_newline();
+      self.indent();
+    }
+    op(self);
+    if !single_line {
+      self.dedent();
+      self.print_indent();
+    }
+    self.print_ascii_byte(b'}');
+  }
+
+  fn print_block_start(&mut self, span: Span) {
+    self.add_source_mapping(span);
+    self.print_ascii_byte(b'{');
+    self.print_soft_newline();
+    self.indent();
+  }
+
+  fn print_block_end(&mut self, _span: Span) {
+    self.dedent();
+    self.print_indent();
+    self.print_ascii_byte(b'}');
+  }
+
+  fn print_body(&mut self, stmt: &Statement<'_>, need_space: bool, ctx: Context) {
+    match stmt {
+      Statement::BlockStatement(stmt) => {
+        self.print_soft_space();
+        self.print_block_statement(stmt, ctx);
+        self.print_soft_newline();
+      }
+      Statement::EmptyStatement(_) => {
+        self.print_semicolon();
+        self.print_soft_newline();
+      }
+      stmt => {
+        if need_space && self.options.minify {
+          self.print_hard_space();
+        }
+        self.print_next_indent_as_space = true;
+        stmt.print(self, ctx);
+      }
+    }
+  }
+
+  fn print_block_statement(&mut self, stmt: &BlockStatement<'_>, ctx: Context) {
+    let single_line = stmt.body.is_empty() && !self.has_legal_orphans_before(stmt.span.end);
+    self.print_curly_braces(stmt.span, single_line, |p| {
+      p.print_stmts_with_orphan_flush(&stmt.body, stmt.span.end, ctx);
+    });
+    self.needs_semicolon = false;
+  }
+
+  /// Print `stmts`, flushing legal-comment orphans before each and at `scope_end`.
+  fn print_stmts_with_orphan_flush(
+    &mut self,
+    stmts: &[Statement<'_>],
+    scope_end: u32,
+    ctx: Context,
+  ) {
+    for stmt in stmts {
+      self.print_legal_orphans_before(stmt.span().start);
+      self.print_semicolon_if_needed();
+      stmt.print(self, ctx);
+    }
+    self.print_legal_orphans_before(scope_end);
+  }
+
+  fn print_directives_and_statements(
+    &mut self,
+    directives: &[Directive<'_>],
+    stmts: &[Statement<'_>],
+    scope_end: u32,
+    ctx: Context,
+  ) {
+    for directive in directives {
+      directive.print(self, ctx);
+    }
+    let Some((first, rest)) = stmts.split_first() else {
+      self.print_legal_orphans_before(scope_end);
+      return;
+    };
+
+    self.print_legal_orphans_before(first.span().start);
+
+    // Ensure first string literal is not a directive.
+    let mut first_needs_parens = false;
+    if directives.is_empty()
+      && !self.options.minify
+      && let Statement::ExpressionStatement(s) = first
+    {
+      let s = s.expression.without_parentheses();
+      if matches!(s, Expression::StringLiteral(_)) {
+        first_needs_parens = true;
+        self.print_ascii_byte(b'(');
+        s.print_expr(self, Precedence::Lowest, ctx);
+        self.print_ascii_byte(b')');
+        self.print_semicolon_after_statement();
+      }
+    }
+
+    if !first_needs_parens {
+      first.print(self, ctx);
+    }
+
+    self.print_stmts_with_orphan_flush(rest, scope_end, ctx);
+  }
+
+  #[inline]
+  fn print_list<T: Gen>(&mut self, items: &[T], ctx: Context) {
+    let Some((first, rest)) = items.split_first() else {
+      return;
+    };
+    first.print(self, ctx);
+    for item in rest {
+      self.print_comma();
+      self.print_soft_space();
+      item.print(self, ctx);
+    }
+  }
+
+  #[inline]
+  fn print_expressions<T: GenExpr>(&mut self, items: &[T], precedence: Precedence, ctx: Context) {
+    let Some((first, rest)) = items.split_first() else {
+      return;
+    };
+    first.print_expr(self, precedence, ctx);
+    for item in rest {
+      self.print_comma();
+      self.print_soft_space();
+      item.print_expr(self, precedence, ctx);
+    }
+  }
+
+  fn print_arguments(&mut self, span: Span, arguments: &[Argument<'_>], ctx: Context) {
+    self.print_ascii_byte(b'(');
+
+    let has_comment_before_right_paren = span.end > 0 && self.has_comment(span.end - 1);
+
+    let has_comment = has_comment_before_right_paren
+      || arguments.iter().any(|item| self.has_comment(item.span().start));
+
+    if has_comment {
+      self.indent();
+      self.print_list_with_comments(arguments, ctx);
+      // Handle `/* comment */);`
+      if !has_comment_before_right_paren
+        || (span.end > 0 && !self.print_expr_comments(span.end - 1))
+      {
+        self.print_soft_newline();
+      }
+      self.dedent();
+      self.print_indent();
+    } else {
+      self.print_list(arguments, ctx);
+    }
+    self.print_ascii_byte(b')');
+    self.add_source_mapping_end(span);
+  }
+
+  fn print_list_with_comments(&mut self, items: &[Argument<'_>], ctx: Context) {
+    let Some((first, rest)) = items.split_first() else {
+      return;
+    };
+    if self.print_expr_comments(first.span().start) {
+      self.print_indent();
+    } else {
+      self.print_soft_newline();
+      self.print_indent();
+    }
+    first.print(self, ctx);
+    for item in rest {
+      self.print_comma();
+      if self.print_expr_comments(item.span().start) {
+        self.print_indent();
+      } else {
+        self.print_soft_newline();
+        self.print_indent();
+      }
+      item.print(self, ctx);
+    }
+  }
+
+  fn get_identifier_reference_name(&self, reference: &IdentifierReference<'a>) -> &'a str {
+    if let Some(scoping) = &self.scoping
+      && let Some(reference_id) = reference.reference_id.get()
+      && let Some(name) = scoping.get_reference_name(reference_id)
+    {
+      // SAFETY: Hack the lifetime to be part of the allocator.
+      return unsafe { std::mem::transmute_copy(&name) };
+    }
+    reference.name.as_str()
+  }
+
+  fn get_binding_identifier_name(&self, ident: &BindingIdentifier<'a>) -> &'a str {
+    if let Some(scoping) = &self.scoping
+      && let Some(symbol_id) = ident.symbol_id.get()
+    {
+      let name = scoping.symbol_name(symbol_id);
+      // SAFETY: Hack the lifetime to be part of the allocator.
+      return unsafe { std::mem::transmute_copy(&name) };
+    }
+    ident.name.as_str()
+  }
+
+  fn print_space_before_operator(&mut self, next: Operator) {
+    if self.prev_op_end != self.code.len() {
+      return;
+    }
+    let Some(prev) = self.prev_op else { return };
+    // "+ + y" => "+ +y"
+    // "+ ++ y" => "+ ++y"
+    // "x + + y" => "x+ +y"
+    // "x ++ + y" => "x+++y"
+    // "x + ++ y" => "x+ ++y"
+    // "-- >" => "-- >"
+    // "< ! --" => "<! --"
+    let bin_op_add = Operator::Binary(BinaryOperator::Addition);
+    let bin_op_sub = Operator::Binary(BinaryOperator::Subtraction);
+    let un_op_pos = Operator::Unary(UnaryOperator::UnaryPlus);
+    let un_op_pre_inc = Operator::Update(UpdateOperator::Increment);
+    let un_op_neg = Operator::Unary(UnaryOperator::UnaryNegation);
+    let un_op_pre_dec = Operator::Update(UpdateOperator::Decrement);
+    let un_op_post_dec = Operator::Update(UpdateOperator::Decrement);
+    let bin_op_gt = Operator::Binary(BinaryOperator::GreaterThan);
+    let un_op_not = Operator::Unary(UnaryOperator::LogicalNot);
+    if ((prev == bin_op_add || prev == un_op_pos)
+      && (next == bin_op_add || next == un_op_pos || next == un_op_pre_inc))
+      || ((prev == bin_op_sub || prev == un_op_neg)
+        && (next == bin_op_sub || next == un_op_neg || next == un_op_pre_dec))
+      || (prev == un_op_post_dec && next == bin_op_gt)
+      || (prev == un_op_not
+                && next == un_op_pre_dec
+                // `prev == UnaryOperator::LogicalNot` which means last byte is ASCII,
+                // and therefore previous character is 1 byte from end of buffer
+                && self.code.peek_nth_byte_back(1) == Some(b'<'))
+    {
+      self.print_hard_space();
+    }
+  }
+
+  fn print_non_negative_float(&mut self, num: f64) {
+    // Inline the buffer here to avoid heap allocation on `buffer.format(*self).to_string()`.
+    let mut buffer = dragonbox_ecma::Buffer::new();
+    if num < 1000.0 && num.fract() == 0.0 {
+      self.print_str(buffer.format(num));
+      self.need_space_before_dot = self.code_len();
+    } else {
+      self.print_minified_number(num, &mut buffer);
+    }
+  }
+
+  fn print_decorators(&mut self, decorators: &[Decorator<'_>], ctx: Context) {
+    for decorator in decorators {
+      decorator.print(self, ctx);
+      self.print_hard_space();
+    }
+  }
+
+  // Optimized version of `get_minified_number` from terser
+  // https://github.com/terser/terser/blob/c5315c3fd6321d6b2e076af35a70ef532f498505/lib/output.js#L2418
+  // Instead of building all candidates and finding the shortest, we track the shortest as we go
+  // and use self.print_str directly instead of returning intermediate strings
+  #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+  fn print_minified_number(&mut self, num: f64, buffer: &mut dragonbox_ecma::Buffer) {
+    if num < 1000.0 && num.fract() == 0.0 {
+      self.print_str(buffer.format(num));
+      self.need_space_before_dot = self.code_len();
+      return;
+    }
+
+    let mut s = buffer.format(num);
+
+    if s.starts_with("0.") {
+      s = &s[1..];
+    }
+
+    let mut best_candidate = s.cow_replacen("e+", "e", 1);
+    let mut is_hex = false;
+
+    // Track the best candidate found so far
+    if num.fract() == 0.0 {
+      // For integers, check hex format and other optimizations
+      let hex_candidate = format!("0x{:x}", num as u128);
+      if hex_candidate.len() < best_candidate.len() {
+        is_hex = true;
+        best_candidate = hex_candidate.into();
+      }
+    }
+    // Check for scientific notation optimizations for numbers starting with ".0"
+    else if best_candidate.starts_with(".0") {
+      // Skip the first '0' since we know it's there from the starts_with check
+      if let Some(i) = best_candidate.bytes().skip(2).position(|c| c != b'0') {
+        let len = i + 2; // `+2` to include the dot and first zero.
+        let digits = &best_candidate[len..];
+        let exp = digits.len() + len - 1;
+        let exp_str_len = itoa::Buffer::new().format(exp).len();
+        // Calculate expected length: digits + 'e-' + exp_length
+        let expected_len = digits.len() + 2 + exp_str_len;
+        if expected_len < best_candidate.len() {
+          best_candidate = format!("{digits}e-{exp}").into();
+          debug_assert_eq!(best_candidate.len(), expected_len);
+        }
+      }
+    }
+
+    // Check for numbers ending with zeros (but not hex numbers)
+    // The `!is_hex` check is necessary to prevent hex numbers like `0x8000000000000000`
+    // from being incorrectly converted to scientific notation
+    if !is_hex
+      && best_candidate.ends_with('0')
+      && let Some(len) = best_candidate.bytes().rev().position(|c| c != b'0')
+    {
+      let base = &best_candidate[0..best_candidate.len() - len];
+      let exp_str_len = itoa::Buffer::new().format(len).len();
+      // Calculate expected length: base + 'e' + len
+      let expected_len = base.len() + 1 + exp_str_len;
+      if expected_len < best_candidate.len() {
+        best_candidate = format!("{base}e{len}").into();
+        debug_assert_eq!(best_candidate.len(), expected_len);
+      }
+    }
+
+    // Check for scientific notation optimization: `1.2e101` -> `12e100`
+    if let Some((integer, point, exponent)) =
+      best_candidate.split_once('.').and_then(|(a, b)| b.split_once('e').map(|e| (a, e.0, e.1)))
+    {
+      let new_expr = exponent.parse::<isize>().unwrap() - point.len() as isize;
+      let new_exp_str_len = itoa::Buffer::new().format(new_expr).len();
+      // Calculate expected length: integer + point + 'e' + new_exp_str_len
+      let expected_len = integer.len() + point.len() + 1 + new_exp_str_len;
+      if expected_len < best_candidate.len() {
+        best_candidate = format!("{integer}{point}e{new_expr}").into();
+        debug_assert_eq!(best_candidate.len(), expected_len);
+      }
+    }
+
+    // Print the best candidate and update need_space_before_dot
+    self.print_str(&best_candidate);
+    if !best_candidate.bytes().any(|b| matches!(b, b'.' | b'e' | b'x')) {
+      self.need_space_before_dot = self.code_len();
+    }
+  }
+
+  #[inline]
+  #[expect(clippy::needless_pass_by_ref_mut, clippy::unused_self)]
+  fn add_source_mapping(&mut self, _span: Span) {}
+
+  #[inline]
+  #[expect(clippy::needless_pass_by_ref_mut, clippy::unused_self)]
+  fn add_source_mapping_end(&mut self, _span: Span) {}
+
+  #[inline]
+  #[expect(clippy::needless_pass_by_ref_mut, clippy::unused_self)]
+  fn add_source_mapping_for_name(&mut self, _span: Span, _name: &str) {}
+}

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/operator.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/operator.rs
@@ -1,0 +1,26 @@
+use oxc_syntax::operator::{BinaryOperator, UnaryOperator, UpdateOperator};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Operator {
+  Binary(BinaryOperator),
+  Unary(UnaryOperator),
+  Update(UpdateOperator),
+}
+
+impl From<BinaryOperator> for Operator {
+  fn from(op: BinaryOperator) -> Self {
+    Self::Binary(op)
+  }
+}
+
+impl From<UnaryOperator> for Operator {
+  fn from(op: UnaryOperator) -> Self {
+    Self::Unary(op)
+  }
+}
+
+impl From<UpdateOperator> for Operator {
+  fn from(op: UpdateOperator) -> Self {
+    Self::Update(op)
+  }
+}

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/options.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/options.rs
@@ -1,0 +1,168 @@
+use oxc_data_structures::code_buffer::{DEFAULT_INDENT_WIDTH, IndentChar};
+
+/// Codegen Options.
+#[derive(Debug, Clone)]
+pub struct CodegenOptions {
+  /// Use single quotes instead of double quotes.
+  ///
+  /// Default is `false`.
+  pub single_quote: bool,
+
+  /// Remove whitespace.
+  ///
+  /// Default is `false`.
+  pub minify: bool,
+
+  /// Print comments?
+  ///
+  /// At present, only some leading comments are preserved.
+  ///
+  /// Default is [CommentOptions::default].
+  pub comments: CommentOptions,
+
+  /// Indentation character.
+  ///
+  /// Default is [`IndentChar::Tab`].
+  pub indent_char: IndentChar,
+
+  /// Number of characters per indentation level.
+  ///
+  /// Default is `1`.
+  pub indent_width: usize,
+
+  /// Initial indentation level for generated code.
+  ///
+  /// Default is `0`.
+  pub initial_indent: u32,
+}
+
+impl Default for CodegenOptions {
+  fn default() -> Self {
+    Self {
+      single_quote: false,
+      minify: false,
+      comments: CommentOptions::default(),
+      indent_char: IndentChar::default(),
+      indent_width: DEFAULT_INDENT_WIDTH,
+      initial_indent: 0,
+    }
+  }
+}
+
+impl CodegenOptions {
+  /// Minify whitespace and remove comments.
+  pub fn minify() -> Self {
+    Self {
+      single_quote: false,
+      minify: true,
+      comments: CommentOptions::disabled(),
+      indent_char: IndentChar::default(),
+      indent_width: DEFAULT_INDENT_WIDTH,
+      initial_indent: 0,
+    }
+  }
+
+  #[inline]
+  pub(crate) fn print_normal_comment(&self) -> bool {
+    self.comments.normal
+  }
+
+  #[inline]
+  pub(crate) fn print_legal_comment(&self) -> bool {
+    self.comments.legal.is_inline()
+  }
+
+  #[inline]
+  pub(crate) fn print_jsdoc_comment(&self) -> bool {
+    self.comments.jsdoc
+  }
+
+  #[inline]
+  pub(crate) fn print_annotation_comment(&self) -> bool {
+    self.comments.annotation
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Comment Options
+pub struct CommentOptions {
+  /// Print normal comments that do not have special meanings.
+  ///
+  /// At present only statement level comments are printed.
+  ///
+  /// Default is `true`.
+  pub normal: bool,
+
+  /// Print jsdoc comments.
+  ///
+  /// * jsdoc: `/** jsdoc */`
+  ///
+  /// Default is `true`.
+  pub jsdoc: bool,
+
+  /// Print annotation comments.
+  ///
+  /// * pure: `/* #__PURE__ */` and `/* #__NO_SIDE_EFFECTS__ */`
+  /// * webpack: `/* webpackChunkName */`
+  /// * vite: `/* @vite-ignore */`
+  /// * coverage: `v8 ignore`, `c8 ignore`, `node:coverage`, `istanbul ignore`
+  ///
+  /// Default is `true`.
+  pub annotation: bool,
+
+  /// Print legal comments.
+  ///
+  /// * starts with `//!` or `/*!`.
+  /// * contains `/* @license */` or `/* @preserve */`
+  ///
+  /// Default is [`LegalComment::Inline`].
+  pub legal: LegalComment,
+}
+
+impl Default for CommentOptions {
+  fn default() -> Self {
+    Self { normal: true, jsdoc: true, annotation: true, legal: LegalComment::default() }
+  }
+}
+
+impl CommentOptions {
+  /// Disable Comments.
+  pub fn disabled() -> Self {
+    Self { normal: false, jsdoc: false, annotation: false, legal: LegalComment::None }
+  }
+}
+
+/// Legal comment
+///
+/// <https://esbuild.github.io/api/#legal-comments>
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub enum LegalComment {
+  /// Do not preserve any legal comments.
+  None,
+  /// Preserve all legal comments (default).
+  #[default]
+  Inline,
+  /// Move all legal comments to the end of the file.
+  Eof,
+  /// Return all legal comments and link then to them with a comment to the provided string.
+  Linked(String),
+  /// Move all legal comments to a .LEGAL.txt file but to not link to them.
+  External,
+}
+
+impl LegalComment {
+  /// Is None.
+  pub fn is_none(&self) -> bool {
+    *self == Self::None
+  }
+
+  /// Is inline mode.
+  pub fn is_inline(&self) -> bool {
+    *self == Self::Inline
+  }
+
+  /// Is EOF mode.
+  pub fn is_eof(&self) -> bool {
+    *self == Self::Eof
+  }
+}

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/str.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/str.rs
@@ -1,0 +1,728 @@
+use std::slice;
+
+use oxc_ast::ast::StringLiteral;
+use oxc_data_structures::{assert_unchecked, slice_iter::SliceIter};
+use oxc_syntax::{
+  identifier::NBSP,
+  line_terminator::{LS_LAST_2_BYTES, PS_LAST_2_BYTES},
+};
+
+use super::Codegen;
+
+/// Quote character.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Quote {
+  Single = b'\'',
+  Double = b'"',
+  Backtick = b'`',
+}
+
+impl Quote {
+  #[inline]
+  pub fn print(self, codegen: &mut Codegen<'_>) {
+    // SAFETY: All variants of `Quote` are ASCII bytes
+    unsafe { codegen.code.print_byte_unchecked(self as u8) };
+  }
+}
+
+impl Codegen<'_> {
+  /// Print a [`StringLiteral`].
+  pub(crate) fn print_string_literal(&mut self, s: &StringLiteral<'_>, allow_backtick: bool) {
+    self.add_source_mapping(s.span);
+
+    // If `minify` option enabled, quote will be chosen depending on what produces shortest output.
+    // What is the best quote to use will be determined when first character needing escape is found.
+    // This avoids iterating through the string twice if it contains no quotes (common case).
+    // Don't print opening quote now, because we don't know what it is yet.
+    //
+    // If not in `minify` mode, print the quote requested in options.
+    let quote = if self.options.minify {
+      None
+    } else {
+      let quote = self.quote;
+      quote.print(self);
+      Some(quote)
+    };
+
+    // Loop through bytes, looking for any which need to be escaped.
+    // String is written to buffer in chunks.
+    let bytes = s.value.as_bytes().iter();
+    let mut state = PrintStringState {
+      chunk_start: bytes.ptr(),
+      bytes,
+      quote,
+      lone_surrogates: s.lone_surrogates,
+      allow_backtick,
+    };
+
+    // Loop through bytes.
+    while let Some(b) = state.peek() {
+      // Look up whether byte needs escaping
+      let escape = ESCAPES.0[b as usize];
+      if escape == Escape::__ {
+        // No escape required.
+        // SAFETY: We just checked there's a byte to consume.
+        // If byte is not ASCII, this will temporarily leave `bytes` iterator not on a UTF-8
+        // character boundary, but if so next turns of the loop will consume the rest of
+        // the Unicode character.
+        // All bytes which produce an `Escape` which isn't `Escape::__` are 1st byte
+        // of a UTF-8 character sequence.
+        unsafe { state.consume_byte_unchecked() };
+      } else {
+        // Escape may be required. Execute byte handler.
+        // Characters requiring escape are relatively rare, so cold branch.
+        cold_branch(|| {
+          // SAFETY: We just peeked a byte, so there is a byte ready to consume.
+          // `escape` corresponds to that byte.
+          // Checked that `escape != Escape::__` above.
+          unsafe { handle_escape(escape, self, &mut state) };
+        });
+      }
+    }
+
+    // Flush any remaining bytes
+    state.flush(self);
+
+    // Print closing quote.
+    // SAFETY: `flush` calls `calculate_quote` which ensures `state.quote` is `Some`.
+    let quote = unsafe { state.quote.unwrap_unchecked() };
+    quote.print(self);
+  }
+}
+
+/// String printer state.
+///
+/// Main purpose is to contain `bytes` iterator.
+/// This iterator must always be positioned on a UTF-8 character boundary.
+struct PrintStringState<'s> {
+  chunk_start: *const u8,
+  bytes: slice::Iter<'s, u8>,
+  quote: Option<Quote>,
+  lone_surrogates: bool,
+  allow_backtick: bool,
+}
+
+impl PrintStringState<'_> {
+  /// Peek next byte in `bytes` iterator.
+  #[inline]
+  fn peek(&self) -> Option<u8> {
+    self.bytes.peek_copy()
+  }
+
+  /// Advance the `bytes` iterator by 1 byte.
+  ///
+  /// # SAFETY
+  ///
+  /// * There must be at least 1 more byte in the `bytes` iterator.
+  /// * After this call, `bytes` iterator must be left on a UTF-8 character boundary
+  ///   (i.e. the current byte is ASCII), or if byte is not ASCII, then further calls to
+  ///   `consume_byte_unchecked` / `consume_bytes_unchecked` consume the rest of the Unicode character
+  ///   before calling other methods e.g. `flush`.
+  #[inline]
+  unsafe fn consume_byte_unchecked(&mut self) {
+    // SAFETY: Caller guarantees there is a byte to consume in `bytes` iterator,
+    // and that consuming it leaves the iterator on a UTF-8 char boundary
+    unsafe { self.bytes.next_unchecked() };
+  }
+
+  /// Advance the `bytes` iterator by `count` bytes.
+  ///
+  /// # SAFETY
+  ///
+  /// * There must be at least `count` more bytes in the `bytes` iterator.
+  /// * After this call, `bytes` iterator must be left on a UTF-8 character boundary.
+  #[inline]
+  unsafe fn consume_bytes_unchecked(&mut self, count: usize) {
+    // SAFETY: Caller guarantees there are `count` bytes to consume in `bytes` iterator,
+    // and that consuming them leaves the iterator on a UTF-8 char boundary.
+    unsafe { self.bytes.advance_unchecked(count) };
+  }
+
+  /// Set the start of next chunk to be current position of `bytes` iterator.
+  #[inline]
+  fn start_chunk(&mut self) {
+    self.chunk_start = self.bytes.ptr();
+  }
+
+  /// Flush current chunk to buffer, consume 1 byte, and start next chunk after that byte.
+  ///
+  /// # SAFETY
+  ///
+  /// * There must be at least 1 more byte in the `bytes` iterator.
+  /// * After this call, `bytes` iterator must be left on a UTF-8 character boundary.
+  ///   i.e. the current byte is ASCII.
+  #[inline]
+  unsafe fn flush_and_consume_byte(&mut self, codegen: &mut Codegen) {
+    // SAFETY: Caller guarantees `flush_and_consume_bytes`'s requirements are met
+    unsafe { self.flush_and_consume_bytes(codegen, 1) };
+  }
+
+  /// Flush current chunk to buffer, consume `count` bytes, and start next chunk after those bytes.
+  ///
+  /// # SAFETY
+  ///
+  /// * There must be at least `count` more bytes in the `bytes` iterator.
+  /// * After this call, `bytes` iterator must be left on a UTF-8 character boundary.
+  #[inline]
+  unsafe fn flush_and_consume_bytes(&mut self, codegen: &mut Codegen, count: usize) {
+    self.flush(codegen);
+
+    // SAFETY: Caller guarantees there are `count` bytes to consume in `bytes` iterator,
+    // and that consuming them leaves the iterator on a UTF-8 char boundary
+    unsafe { self.consume_bytes_unchecked(count) };
+
+    self.start_chunk();
+  }
+
+  /// Flush all bytes from `chunk_start` up to current position of `bytes` iterator into buffer.
+  ///
+  /// If what quote character to use has not been decided yet, calculate the best quote character,
+  /// and print it before flushing.
+  fn flush(&mut self, codegen: &mut Codegen) {
+    // If which quote character to use is not already known, calculate it and print opening quote
+    self.calculate_quote(codegen);
+
+    // SAFETY: `chunk_start` is pointer to current position of `bytes` iterator at some point,
+    // and the iterator only advances, so current position of `bytes` must be on or after `chunk_start`
+    let len = unsafe {
+      let bytes_ptr = self.bytes.ptr();
+      bytes_ptr.offset_from_unsigned(self.chunk_start)
+    };
+
+    // SAFETY: `chunk_start` is within bounds of original `&str`.
+    // `bytes` iter cannot go past end of `&str` either.
+    // So a slice of `len` bytes starting at `chunk_start` must be within bounds of the `&str`.
+    // `bytes` iterator is always positioned on a UTF-8 character boundary, as is `chunk_start`.
+    // Therefore the slice between these two must be a valid UTF-8 string.
+    unsafe {
+      let slice = slice::from_raw_parts(self.chunk_start, len);
+      codegen.code.print_bytes_unchecked(slice);
+    }
+  }
+
+  /// Calculate optimum quote character to use, and print that quote (as opening quote).
+  ///
+  /// Actual logic in separate `calculate_quote_impl` method, so that `calculate_quote` itself
+  /// is inlined, to create a fast path for when `quote` is `Some`.
+  #[inline]
+  fn calculate_quote(&mut self, codegen: &mut Codegen) -> Quote {
+    if let Some(quote) = self.quote { quote } else { self.calculate_quote_impl(codegen) }
+  }
+
+  fn calculate_quote_impl(&mut self, codegen: &mut Codegen) -> Quote {
+    let quote = if self.allow_backtick {
+      self.calculate_quote_maybe_backtick()
+    } else {
+      self.calculate_quote_no_backtick()
+    };
+
+    quote.print(codegen);
+
+    self.quote = Some(quote);
+
+    quote
+  }
+
+  /// Calculate optimum quote character to use, when backtick (`) is an option.
+  fn calculate_quote_maybe_backtick(&self) -> Quote {
+    // Max string length is:
+    // * 64-bit platforms: `u32::MAX`.
+    // * 32-bit platforms: `i32::MAX`.
+    // In either case, `isize` is sufficient to make overflow impossible.
+    let mut single_cost: isize = 0;
+    let mut double_cost: isize = 0;
+    let mut backtick_cost: isize = 0;
+    let mut bytes = self.bytes.clone();
+    while let Some(b) = bytes.next() {
+      match b {
+        b'\n' => backtick_cost -= 1,
+        b'\'' => single_cost += 1,
+        b'"' => double_cost += 1,
+        b'`' => backtick_cost += 1,
+        b'$' if bytes.peek() == Some(&b'{') => {
+          backtick_cost += 1;
+        }
+        _ => {}
+      }
+    }
+
+    // If equal cost for different quotes prefer, in order:
+    // 1. Backtick
+    // 2. Double quote
+    // 3. Single quote
+    #[rustfmt::skip]
+        let quote = if backtick_cost <= double_cost {
+            if backtick_cost <= single_cost {
+                Quote::Backtick
+            } else {
+                Quote::Single
+            }
+        } else if double_cost <= single_cost {
+            Quote::Double
+        } else {
+            Quote::Single
+        };
+    quote
+  }
+
+  /// Calculate optimum quote character to use, when backtick (`) is not an option.
+  fn calculate_quote_no_backtick(&self) -> Quote {
+    // Max string length is:
+    // * 64-bit platforms: `u32::MAX`.
+    // * 32-bit platforms: `i32::MAX`.
+    // In either case, `isize` is sufficient to make overflow impossible.
+    let mut single_cost: isize = 0;
+    for &b in self.bytes.clone() {
+      match b {
+        b'\'' => single_cost += 1,
+        b'"' => single_cost -= 1,
+        _ => {}
+      }
+    }
+
+    // Prefer double quote over single quote if cost is the same
+    if single_cost < 0 { Quote::Single } else { Quote::Double }
+  }
+}
+
+/// Convert `char` to UTF-8 bytes array.
+const fn to_bytes<const N: usize>(ch: char) -> [u8; N] {
+  assert!(ch.len_utf8() == N);
+  let mut bytes = [0u8; N];
+  ch.encode_utf8(&mut bytes);
+  bytes
+}
+
+/// `NBSP` character as UTF-8 bytes.
+const NBSP_BYTES: [u8; 2] = to_bytes(NBSP);
+const _: () = assert!(NBSP_BYTES[0] == 0xC2);
+const NBSP_LAST_BYTE: u8 = NBSP_BYTES[1];
+
+/// Lossy replacement character (U+FFFD) as UTF-8 bytes.
+const LOSSY_REPLACEMENT_CHAR_BYTES: [u8; 3] = to_bytes('\u{FFFD}');
+const _: () = assert!(LOSSY_REPLACEMENT_CHAR_BYTES[0] == 0xEF);
+const LOSSY_REPLACEMENT_CHAR_LAST_2_BYTES: [u8; 2] =
+  [LOSSY_REPLACEMENT_CHAR_BYTES[1], LOSSY_REPLACEMENT_CHAR_BYTES[2]];
+
+/// Escape codes.
+///
+/// Discriminant - 1 is used as index into `BYTE_HANDLERS` (except for `__` variant).
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Escape {
+  __ = 0,  // No escape required
+  NU = 1,  // \x00  - Null byte
+  BE = 2,  // \x07  - Bell
+  BK = 3,  // \b    - Backspace
+  VT = 4,  // \v    - Vertical tab
+  FF = 5,  // \f    - Form feed
+  NL = 6,  // \n    - New line
+  CR = 7,  // \r    - Carriage return
+  ES = 8,  // \x1B  - Escape
+  BS = 9,  // \\    - Backslash
+  SQ = 10, // '     - Single quote
+  DQ = 11, // "     - Double quote
+  BQ = 12, // `     - Backtick quote
+  DO = 13, // $     - Dollar sign
+  LT = 14, // <     - Less-than sign
+  LS = 15, // LS/PS - U+2028 LINE SEPARATOR or U+2029 PARAGRAPH SEPARATOR (first byte)
+  NB = 16, // NBSP  - Non-breaking space (first byte)
+  LO = 17, // �     - U+FFFD lossy replacement character (first byte)
+}
+
+/// Struct which ensures content is aligned on 128.
+#[repr(C, align(128))]
+struct Aligned128<T>(T);
+
+/// Table mapping bytes to `Escape`s.
+///
+/// Aligned on 128, so top half (ASCII chars) occupies a pair of L1 cache lines.
+/// Bottom half (non-ASCII chars) also occupies a pair of L1 cache lines,
+/// but will not be accessed for strings which only contain ASCII (common case).
+static ESCAPES: Aligned128<[Escape; 256]> = {
+  #[allow(clippy::enum_glob_use, clippy::allow_attributes)]
+  use Escape::*;
+  Aligned128([
+    //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+    NU, __, __, __, __, __, __, BE, BK, __, NL, VT, FF, CR, __, __, // 0
+    __, __, __, __, __, __, __, __, __, __, __, ES, __, __, __, __, // 1
+    __, __, DQ, __, DO, __, __, SQ, __, __, __, __, __, __, __, __, // 2
+    __, __, __, __, __, __, __, __, __, __, __, __, LT, __, __, __, // 3
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
+    __, __, __, __, __, __, __, __, __, __, __, __, BS, __, __, __, // 5
+    BQ, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 8
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 9
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // A
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
+    __, __, NB, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
+    __, __, LS, __, __, __, __, __, __, __, __, __, __, __, __, LO, // E
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
+  ])
+};
+
+type ByteHandler = unsafe fn(&mut Codegen, &mut PrintStringState);
+
+/// Byte handlers.
+///
+/// Indexed by `escape as usize - 1` (where `escape` is not `Escape::__`).
+/// Must be in same order as discriminants in `Escape`.
+///
+/// Function pointers are 8 bytes each, so `BYTE_HANDLERS` is 136 bytes in total.
+/// Aligned on 128, so first 16 occupy a pair of L1 cache lines.
+/// The last will be in separate cache line, but it should be vanishingly rare that it's accessed.
+static BYTE_HANDLERS: Aligned128<[ByteHandler; 17]> = Aligned128([
+  print_null,
+  print_bell,
+  print_backspace,
+  print_vertical_tab,
+  print_form_field,
+  print_new_line,
+  print_carriage_return,
+  print_escape,
+  print_backslash,
+  print_single_quote,
+  print_double_quote,
+  print_backtick,
+  print_dollar,
+  print_less_than,
+  print_ls_or_ps,
+  print_non_breaking_space,
+  print_lossy_replacement,
+]);
+
+/// Call byte handler for byte which needs escaping.
+///
+/// # SAFETY
+///
+/// * There must be another byte to consume in `bytes` iterator.
+/// * `escape` must correspond to the next byte.
+/// * `escape` must not be `Escape::__`.
+unsafe fn handle_escape(escape: Escape, codegen: &mut Codegen, state: &mut PrintStringState) {
+  // Inform compiler that `escape` is not `Escape::__`.
+  // This removes the bounds check from `BYTE_HANDLERS.0[escape as usize - 1]`.
+  // SAFETY: Caller guarantees `escape` is not `Escape::__`.
+  unsafe { assert_unchecked!(escape != Escape::__) };
+
+  let byte_handler = BYTE_HANDLERS.0[escape as usize - 1];
+  // SAFETY: Caller guarantees there is a byte to consume in `bytes` iterator,
+  // and that `escape` corresponds to the next byte, so we are calling the correct byte handler
+  unsafe { byte_handler(codegen, state) };
+}
+
+// Byte handlers for bytes which need escaping.
+//
+// # SAFETY
+//
+// All byte handlers have safety invariants:
+// * There must be at least 1 byte remaining in `bytes` iterator.
+// * The byte handler is only called for the byte it expects.
+
+// \x00
+unsafe fn print_null(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(0x00));
+
+  // SAFETY: Next byte is `\x00`, which is ASCII
+  unsafe { state.flush_and_consume_byte(codegen) };
+  if state.peek().is_some_and(|b| b.is_ascii_digit()) {
+    codegen.print_str("\\x00");
+  } else {
+    codegen.print_str("\\0");
+  }
+}
+
+// \x07
+unsafe fn print_bell(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(0x07));
+  // SAFETY: Next byte is `\x07`, which is ASCII
+  unsafe { state.flush_and_consume_byte(codegen) };
+  codegen.print_str("\\x07");
+}
+
+// \b
+unsafe fn print_backspace(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(0x08));
+  // SAFETY: Next byte is `\b`, which is ASCII
+  unsafe { state.flush_and_consume_byte(codegen) };
+  codegen.print_str("\\b");
+}
+
+// \v
+unsafe fn print_vertical_tab(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(0x0B));
+  // SAFETY: Next byte is `\v`, which is ASCII
+  unsafe { state.flush_and_consume_byte(codegen) };
+  codegen.print_str("\\v");
+}
+
+// \f
+unsafe fn print_form_field(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(0x0C));
+  // SAFETY: Next byte is `\f`, which is ASCII
+  unsafe { state.flush_and_consume_byte(codegen) };
+  codegen.print_str("\\f");
+}
+
+// \n
+unsafe fn print_new_line(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(b'\n'));
+
+  if state.calculate_quote(codegen) == Quote::Backtick {
+    // No need to escape.
+    // SAFETY: Next byte is `\n`, which is ASCII.
+    unsafe { state.consume_byte_unchecked() };
+  } else {
+    // SAFETY: Next byte is `\n`, which is ASCII
+    unsafe { state.flush_and_consume_byte(codegen) };
+    codegen.print_str("\\n");
+  }
+}
+
+// \r
+unsafe fn print_carriage_return(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(b'\r'));
+  // SAFETY: Next byte is `\r`, which is ASCII
+  unsafe { state.flush_and_consume_byte(codegen) };
+  codegen.print_str("\\r");
+}
+
+// \x1B
+unsafe fn print_escape(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(0x1B));
+  // SAFETY: Next byte is `\x1B`, which is ASCII
+  unsafe { state.flush_and_consume_byte(codegen) };
+  codegen.print_str("\\x1B");
+}
+
+// \
+unsafe fn print_backslash(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(b'\\'));
+  // SAFETY: Next byte is `\`, which is ASCII
+  unsafe { state.flush_and_consume_byte(codegen) };
+  codegen.print_str("\\\\");
+}
+
+// '
+unsafe fn print_single_quote(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(b'\''));
+
+  if state.calculate_quote(codegen) == Quote::Single {
+    // SAFETY: Next byte is `'`, which is ASCII
+    unsafe { state.flush_and_consume_byte(codegen) };
+    codegen.print_str("\\'");
+  } else {
+    // No need to escape.
+    // SAFETY: Next byte is `'`, which is ASCII.
+    unsafe { state.consume_byte_unchecked() };
+  }
+}
+
+// "
+unsafe fn print_double_quote(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(b'"'));
+
+  if state.calculate_quote(codegen) == Quote::Double {
+    // SAFETY: Next byte is `"`, which is ASCII
+    unsafe { state.flush_and_consume_byte(codegen) };
+    codegen.print_str("\\\"");
+  } else {
+    // No need to escape.
+    // SAFETY: Next byte is `"`, which is ASCII.
+    unsafe { state.consume_byte_unchecked() };
+  }
+}
+
+// `
+unsafe fn print_backtick(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(b'`'));
+
+  if state.calculate_quote(codegen) == Quote::Backtick {
+    // SAFETY: Next byte is `, which is ASCII
+    unsafe { state.flush_and_consume_byte(codegen) };
+    codegen.print_str("\\`");
+  } else {
+    // No need to escape.
+    // SAFETY: Next byte is `, which is ASCII.
+    unsafe { state.consume_byte_unchecked() };
+  }
+}
+
+// $
+unsafe fn print_dollar(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(b'$'));
+
+  // Note: Check next byte is `{` first, to avoid calculating quote unless have to
+  let next = state.bytes.as_slice().get(1);
+  if next == Some(&b'{') && state.calculate_quote(codegen) == Quote::Backtick {
+    // SAFETY: Next byte is `$`, which is ASCII
+    unsafe { state.flush_and_consume_byte(codegen) };
+    codegen.print_str("\\$");
+  } else {
+    // No need to escape.
+    // SAFETY: Next byte is `$`, which is ASCII.
+    unsafe { state.consume_byte_unchecked() };
+  }
+}
+
+// <
+unsafe fn print_less_than(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(b'<'));
+
+  // Get slice of remaining bytes, including leading `<`
+  let slice = state.bytes.as_slice();
+
+  // SAFETY: Next byte is `<`, which is ASCII
+  unsafe { state.consume_byte_unchecked() };
+
+  if slice.len() >= 8 && is_script_close_tag(&slice[0..8]) {
+    // Flush up to and including `<`. Skip `/`. Write `\/` instead. Then skip over `script`.
+    // Next chunk starts with `script`.
+    // SAFETY: We already consumed `<`. Next byte is `/`, which is ASCII.
+    unsafe { state.flush_and_consume_byte(codegen) };
+    codegen.print_str("\\/");
+    // SAFETY: The check above ensures there are 6 bytes left, after consuming 2 already.
+    // `script` / `SCRIPT` is all ASCII bytes, so skipping them leaves `bytes` iterator
+    // positioned on UTF-8 char boundary.
+    unsafe { state.consume_bytes_unchecked(6) };
+  }
+}
+
+// 0xE2 - first byte of <LS> or <PS>
+unsafe fn print_ls_or_ps(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(0xE2));
+
+  let next2: [u8; 2] = {
+    // SAFETY: 0xE2 is always the start of a 3-byte Unicode character,
+    // so there must be 2 more bytes available to consume
+    let next2 = unsafe { state.bytes.as_slice().get_unchecked(1..3) };
+    next2.try_into().unwrap()
+  };
+
+  let replacement = match next2 {
+    LS_LAST_2_BYTES => "\\u2028",
+    PS_LAST_2_BYTES => "\\u2029",
+    _ => {
+      // Some other character starting with 0xE2. Advance past it.
+      // SAFETY: 0xE2 is always the start of a 3-byte Unicode character
+      unsafe { state.consume_bytes_unchecked(3) };
+      return;
+    }
+  };
+
+  // SAFETY: 0xE2 is always the start of a 3-byte Unicode character
+  unsafe { state.flush_and_consume_bytes(codegen, 3) };
+  codegen.print_str(replacement);
+}
+
+// 0xC2 - first byte of <NBSP>
+unsafe fn print_non_breaking_space(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(0xC2));
+
+  // SAFETY: 0xC2 is always the start of a 2-byte Unicode character,
+  // so there must be 1 more byte available to consume
+  let next = unsafe { *state.bytes.as_slice().get_unchecked(1) };
+  if next == NBSP_LAST_BYTE {
+    // Character is NBSP.
+    // SAFETY: 0xC2 is always the start of a 2-byte Unicode character.
+    unsafe { state.flush_and_consume_bytes(codegen, 2) };
+    codegen.print_str("\\xA0");
+  } else {
+    // Some other character starting with 0xC2. Advance past it.
+    // SAFETY: 0xC2 is always the start of a 2-byte Unicode character.
+    unsafe { state.consume_bytes_unchecked(2) };
+  }
+}
+
+// 0xEF - first byte of lossy replacement character (U+FFFD)
+unsafe fn print_lossy_replacement(codegen: &mut Codegen, state: &mut PrintStringState) {
+  debug_assert_eq!(state.peek(), Some(0xEF));
+
+  if state.lone_surrogates {
+    // String contains lone surrogates which use the lossy replacement character (U+FFFD)
+    // as an escape marker.
+    // The lone surrogate is encoded as `\u{FFFD}XXXX` where `XXXX` is the code point as hex.
+    let next2: [u8; 2] = {
+      // SAFETY: 0xEF is always the start of a 3-byte Unicode character,
+      // so there must be 2 more bytes available to consume
+      let next2 = unsafe { state.bytes.as_slice().get_unchecked(1..3) };
+      next2.try_into().unwrap()
+    };
+
+    if next2 == LOSSY_REPLACEMENT_CHAR_LAST_2_BYTES {
+      // Get the 4 hex bytes
+      let bytes = &mut state.bytes;
+      let hex: [u8; 4] = bytes.as_slice()[3..7].try_into().unwrap();
+
+      if hex == *b"fffd" {
+        // Actual lossy replacement character.
+        // Flush up to and including the lossy replacement character, then skip the 4 hex bytes.
+        // SAFETY: 0xEF is always the start of a 3-byte Unicode character
+        unsafe { state.consume_bytes_unchecked(3) };
+        state.flush(codegen);
+        // SAFETY: 0xEF is always the start of a 3-byte Unicode character.
+        // `bytes.as_slice()[3..7]` would have panicked if there weren't 4 more bytes after it.
+        // All those bytes are ASCII, so this leaves `bytes` on a UTF-8 char boundary.
+        unsafe { state.consume_bytes_unchecked(4) };
+        // Start next chunk after the 4 hex bytes
+        state.start_chunk();
+        return;
+      }
+
+      // Flush text before the lossy replacement character
+      state.flush(codegen);
+
+      // Check all 4 hex bytes are ASCII
+      assert_eq!(u32::from_ne_bytes(hex) & 0x8080_8080, 0);
+
+      // SAFETY: `bytes.as_slice()[3..7]` would have panicked if there weren't at least 7 bytes
+      // remaining. First 3 bytes are lossy replacement character, and we just checked that
+      // next 4 bytes are ASCII, so this leaves `bytes` on a UTF-8 char boundary.
+      unsafe { state.consume_bytes_unchecked(7) };
+
+      // Start next chunk after the 4 hex bytes
+      state.start_chunk();
+
+      codegen.print_str("\\u");
+      // SAFETY: Just checked all 4 hex bytes are ASCII
+      unsafe { codegen.code.print_bytes_unchecked(&hex) };
+
+      return;
+    }
+  }
+
+  // `lone_surrogates` is `false` or character is some other character starting with 0xEF.
+  // Advance past the character.
+  // SAFETY: 0xEF is always the start of a 3-byte Unicode character
+  unsafe { state.consume_bytes_unchecked(3) };
+}
+
+/// Call a closure while hinting to compiler that this branch is rarely taken.
+///
+/// "Cold trampoline function", suggested in:
+/// <https://users.rust-lang.org/t/is-cold-the-only-reliable-way-to-hint-to-branch-predictor/106509/2>
+#[cold]
+pub fn cold_branch<F: FnOnce() -> T, T>(f: F) -> T {
+  f()
+}
+
+/// Check if `slice` is `</script`, regardless of case.
+///
+/// `slice.len()` must be 8.
+//
+// `#[inline(always)]` so that compiler can see from caller that `slice.len() == 8`
+// and so `slice.try_into().unwrap()` cannot fail. This function is only 4 instructions.
+#[expect(clippy::inline_always)]
+#[inline(always)]
+pub fn is_script_close_tag(slice: &[u8]) -> bool {
+  // Compiler condenses these operations to an 8-byte read, u64 AND, and u64 compare.
+  // https://godbolt.org/z/K8q68WGn6
+  let mut bytes: [u8; 8] = slice.try_into().unwrap();
+  for byte in bytes.iter_mut().skip(2) {
+    // `| 32` converts ASCII upper case letters to lower case.
+    *byte |= 32;
+  }
+  bytes == *b"</script"
+}

--- a/crates/vue_oxlint_jsx/src/test/mod.rs
+++ b/crates/vue_oxlint_jsx/src/test/mod.rs
@@ -16,7 +16,7 @@ macro_rules! test_ast {
   }};
   ($file_path:expr, $should_errors:expr, $should_panic:expr) => {{
     $crate::test::run_test($file_path, "ast", |ret| {
-      use oxc_codegen::Codegen;
+      use $crate::codegen::Codegen;
       let js = Codegen::new().build(&ret.program);
       let source_text = $crate::test::read_file($file_path);
       let node_locations = $crate::test::format_node_locations(&ret.program, &source_text);


### PR DESCRIPTION
## Summary
- vendor a local fork of `oxc_codegen` into `crates/vue_oxlint_jsx/src/codegen/oxc`
- switch `vue_oxlint_jsx` to use the vendored codegen and add the required upstream support dependencies
- keep the local fork narrower than upstream by omitting sourcemap support and documenting the new layout in `AGENTS.md`

## Why
`vue_oxlint_jsx` needs to customize code generation behavior locally without depending on upstream `oxc_codegen` release timing. Vendoring the codegen crate into the Vue crate gives the project a controlled fork point while preserving the existing `VueJsxCodegen` API.

## Validation
- `just lint`
- `just test`
- `just ready`
