### PR TITLE
refactor: split test_ast macro tests

### DIFF
--- a/crates/vue_oxlint_jsx/src/parser/elements/directive.rs
+++ b/crates/vue_oxlint_jsx/src/parser/elements/directive.rs
@@ -73,8 +73,5 @@ impl<'a> ParserImpl<'a> {
 mod tests {
   use crate::test_ast;
 
-  #[test]
-  fn test_parse_directive_name() {
-    test_ast!("directive/basic.vue");
-  }
+  test_ast!(directive_basic_vue, "directive/basic.vue");
 }

--- a/crates/vue_oxlint_jsx/src/parser/elements/v_for.rs
+++ b/crates/vue_oxlint_jsx/src/parser/elements/v_for.rs
@@ -141,13 +141,6 @@ impl<'b> VForWrapper<'_, 'b> {
 mod tests {
   use crate::test_ast;
 
-  #[test]
-  fn v_for() {
-    test_ast!("directive/v-for.vue");
-  }
-
-  #[test]
-  fn v_for_error() {
-    test_ast!("directive/v-for-error.vue", true, false);
-  }
+  test_ast!(v_for_vue, "directive/v-for.vue");
+  test_ast!(v_for_error_vue, "directive/v-for-error.vue", true, false);
 }

--- a/crates/vue_oxlint_jsx/src/parser/elements/v_if.rs
+++ b/crates/vue_oxlint_jsx/src/parser/elements/v_if.rs
@@ -114,9 +114,6 @@ impl<'a, 'b> VIfManager<'a, 'b> {
 mod tests {
   use crate::test_ast;
 
-  #[test]
-  fn v_if() {
-    test_ast!("directive/v-if.vue");
-    test_ast!("directive/v-if-error.vue", true, false);
-  }
+  test_ast!(v_if_vue, "directive/v-if.vue");
+  test_ast!(v_if_error_vue, "directive/v-if-error.vue", true, false);
 }

--- a/crates/vue_oxlint_jsx/src/parser/elements/v_slot.rs
+++ b/crates/vue_oxlint_jsx/src/parser/elements/v_slot.rs
@@ -170,8 +170,5 @@ impl<'b> VSlotWrapper<'_, 'b> {
 mod tests {
   use crate::test_ast;
 
-  #[test]
-  fn v_slot() {
-    test_ast!("directive/v-slot.vue");
-  }
+  test_ast!(v_slot_vue, "directive/v-slot.vue");
 }

--- a/crates/vue_oxlint_jsx/src/parser/parse.rs
+++ b/crates/vue_oxlint_jsx/src/parser/parse.rs
@@ -221,40 +221,23 @@ impl SourceLocatonSpan for SourceLocation {
 mod tests {
   use crate::test_ast;
 
-  #[test]
-  fn basic_vue() {
-    test_ast!("basic.vue");
-    test_ast!("typescript.vue");
-    test_ast!("void.vue", true, false);
-    test_ast!("tags.vue");
-    test_ast!("root_texts.vue");
-    test_ast!("components.vue");
-  }
-
-  #[test]
-  fn comments() {
-    test_ast!("comments.vue");
-  }
-
-  #[test]
-  fn errors() {
-    test_ast!("error/template.vue", true, true);
-    test_ast!("error/interpolation.vue", true, true);
-    test_ast!("error/script.vue", true, false);
-    test_ast!("error/directive.vue", true, false);
-    test_ast!("error/script.vue", true, false);
-    test_ast!("error/directive.vue", true, false);
-    test_ast!("error/multiple_langs.vue", true, true);
-    test_ast!("error/multiple_scripts.vue", true, true);
-    test_ast!("error/empty_multiple_scripts.vue");
-  }
-
-  #[test]
-  fn scripts() {
-    test_ast!("scripts/basic.vue");
-    test_ast!("scripts/setup.vue");
-    test_ast!("scripts/both.vue");
-    test_ast!("scripts/empty.vue");
-    test_ast!("scripts/directives.vue");
-  }
+  test_ast!(basic_vue, "basic.vue");
+  test_ast!(typescript_vue, "typescript.vue");
+  test_ast!(void_vue, "void.vue", true, false);
+  test_ast!(tags_vue, "tags.vue");
+  test_ast!(root_texts_vue, "root_texts.vue");
+  test_ast!(components_vue, "components.vue");
+  test_ast!(comments_vue, "comments.vue");
+  test_ast!(error_template_vue, "error/template.vue", true, true);
+  test_ast!(error_interpolation_vue, "error/interpolation.vue", true, true);
+  test_ast!(error_script_vue, "error/script.vue", true, false);
+  test_ast!(error_directive_vue, "error/directive.vue", true, false);
+  test_ast!(error_multiple_langs_vue, "error/multiple_langs.vue", true, true);
+  test_ast!(error_multiple_scripts_vue, "error/multiple_scripts.vue", true, true);
+  test_ast!(error_empty_multiple_scripts_vue, "error/empty_multiple_scripts.vue");
+  test_ast!(scripts_basic_vue, "scripts/basic.vue");
+  test_ast!(scripts_setup_vue, "scripts/setup.vue");
+  test_ast!(scripts_both_vue, "scripts/both.vue");
+  test_ast!(scripts_empty_vue, "scripts/empty.vue");
+  test_ast!(scripts_directives_vue, "scripts/directives.vue");
 }

--- a/crates/vue_oxlint_jsx/src/test/codegen.rs
+++ b/crates/vue_oxlint_jsx/src/test/codegen.rs
@@ -55,11 +55,8 @@ fn assert_reparsed_codegen_ast(
   .parse();
 
   assert!(!ret.fatal, "Codegen parser unexpectedly panicked for {file_path}");
-  #[allow(clippy::overly_complex_bool_expr)]
-  // Now it is always true, will remove after fix all snapshot
-  let is_eq = ret.program.content_eq(reparsed_program) || true;
   assert!(
-    is_eq,
+    ret.program.content_eq(reparsed_program),
     "Reparsed codegen AST differs from original codegen AST for {file_path}. \nCodegen snapshot: {}",
     codegen_snapshot_path(file_path),
   );

--- a/crates/vue_oxlint_jsx/src/test/mod.rs
+++ b/crates/vue_oxlint_jsx/src/test/mod.rs
@@ -15,38 +15,28 @@ pub use codegen::run_codegen_test;
 
 #[macro_export]
 macro_rules! test_ast {
-  ($file_path:expr) => {{
-    test_ast!($file_path, false, false);
-    $crate::test::run_codegen_test($file_path);
-  }};
-  ($file_path:expr, $should_errors:expr, $should_panic:expr) => {{
-    $crate::test::run_test($file_path, "ast", |ret| {
-      let codegen = $crate::test::format_program_codegen(&ret.program);
-      let source_text = $crate::test::read_file($file_path);
-      let node_locations = $crate::test::format_node_locations(&ret.program, &source_text);
-      assert_eq!(
-        !ret.errors.is_empty(),
-        $should_errors,
-        "Error expectation mismatch for {}. Expected has_errors: {}, but got {}",
-        $file_path,
-        $should_errors,
-        ret.errors.len()
-      );
-      assert_eq!(
-        ret.fatal, $should_panic,
-        "Fatal error expectation mismatch for {}. Expected fatal: {}, but got fatal: {}",
-        $file_path, $should_panic, ret.fatal
-      );
+  ($test_name:ident, $file_path:expr) => {
+    mod $test_name {
+      #[test]
+      fn ast() {
+        $crate::test::run_ast_test($file_path, false, false);
+      }
 
-      let result = $crate::test::TestResult {
-        program: &ret.program,
-        errors: &ret.errors,
-        codegen,
-        spans: node_locations,
-      };
-      format!("{result:#?}")
-    });
-  }};
+      #[test]
+      #[should_panic(expected = "Reparsed codegen AST differs from original codegen AST")]
+      fn codegen() {
+        $crate::test::run_codegen_test($file_path);
+      }
+    }
+  };
+  ($test_name:ident, $file_path:expr, $should_errors:expr, $allow_panic:expr) => {
+    mod $test_name {
+      #[test]
+      fn ast() {
+        $crate::test::run_ast_test($file_path, $should_errors, $allow_panic);
+      }
+    }
+  };
 }
 
 #[macro_export]
@@ -63,6 +53,29 @@ pub struct TestResult<'a> {
   pub errors: &'a Vec<OxcDiagnostic>,
   pub codegen: String,
   pub spans: String,
+}
+
+pub fn run_ast_test(file_path: &str, should_errors: bool, allow_panic: bool) {
+  run_test(file_path, "ast", |ret| {
+    let codegen = format_program_codegen(&ret.program);
+    let source_text = read_file(file_path);
+    let node_locations = format_node_locations(&ret.program, &source_text);
+    assert_eq!(
+      !ret.errors.is_empty(),
+      should_errors,
+      "Error expectation mismatch for {file_path}. Expected has_errors: {should_errors}, but got {}",
+      ret.errors.len()
+    );
+    assert_eq!(
+      ret.fatal, allow_panic,
+      "Fatal error expectation mismatch for {file_path}. Expected fatal: {allow_panic}, but got fatal: {}",
+      ret.fatal
+    );
+
+    let result =
+      TestResult { program: &ret.program, errors: &ret.errors, codegen, spans: node_locations };
+    format!("{result:#?}")
+  });
 }
 
 impl std::fmt::Debug for TestResult<'_> {


### PR DESCRIPTION
## Summary

- Refactor `test_ast!` so each fixture declaration expands into generated test items instead of being called inside grouped `#[test]` functions.
- Split normal AST assertions from codegen checks for default fixtures, keeping known strict codegen AST-equivalence failures as expected-panic tests for now.
- Remove the temporary `|| true` guard from the codegen AST equality assertion.

## Validation

- `cargo test -p vue_oxlint_jsx --all-features`
- `just lint`
- `just test`
- `just ready`