### PR TITLE
fix: preserve parenthesized expressions in codegen

### DIFF
--- a/crates/vue_oxlint_jsx/src/codegen/oxc/gen.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/gen.rs
@@ -1167,8 +1167,10 @@ impl GenExpr for Expression<'_> {
 }
 
 impl GenExpr for ParenthesizedExpression<'_> {
-  fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
-    self.expression.print_expr(p, precedence, ctx);
+  fn gen_expr(&self, p: &mut Codegen, _: Precedence, ctx: Context) {
+    p.wrap(true, |p| {
+      self.expression.print_expr(p, Precedence::Lowest, ctx.and_forbid_call(false));
+    });
   }
 }
 

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for_vue.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/vue_oxlint_jsx/src/test/mod.rs
+source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 27
 expression: "&codegen"
 ---
-async()=>{<><template>{source(item=><div v-for:__v___={undefined}/>)}{source1(item1=><div v-for:__v___={undefined}/>)}{source2((item2,index2)=><div v-for:__v___={undefined}/>)}{source3((item3=`1`,index3=99)=><div v-for:__v___={undefined}/>)}{users4(({id4,name4})=><div v-for:__v___={undefined}/>)}{users5(({id5,name5},index)=><div v-for:__v___={undefined}/>)}{users6(({id6=1,name6=`Liang`},index)=><div v-for:__v___={undefined}/>)}{someObj7((key7,value7,index7)=><div v-for:__v___={undefined}/>)}{someIter8(([item8,index8])=><div v-for:__v___={undefined}/>)}{someIter9(([item9=`hi`,index9])=><div v-for:__v___={undefined}/>)}</template></>};
+async()=>{<><template>{(source)(item=>(<div v-for:__v___={undefined}/>))}{(source1)(item1=>(<div v-for:__v___={undefined}/>))}{(source2)((item2,index2)=>(<div v-for:__v___={undefined}/>))}{(source3)((item3=`1`,index3=99)=>(<div v-for:__v___={undefined}/>))}{(users4)(({id4,name4})=>(<div v-for:__v___={undefined}/>))}{(users5)(({id5,name5},index)=>(<div v-for:__v___={undefined}/>))}{(users6)(({id6=1,name6=`Liang`},index)=>(<div v-for:__v___={undefined}/>))}{(someObj7)((key7,value7,index7)=>(<div v-for:__v___={undefined}/>))}{(someIter8)(([item8,index8])=>(<div v-for:__v___={undefined}/>))}{(someIter9)(([item9=`hi`,index9])=>(<div v-for:__v___={undefined}/>))}</template></>};


### PR DESCRIPTION
## Summary

Preserve `ParenthesizedExpression` nodes when generating code from the vendored OXC codegen fork instead of forwarding directly to the inner expression.

This keeps Vue-generated constructs such as `v-for` source wrappers and arrow JSX bodies parenthesized in the emitted code, improving AST roundtrip compatibility for the current codegen path.

## Validation

- `cargo test --all-features --workspace`
- `just lint`
- `just ready`

## Notes

The broader codegen roundtrip tests still intentionally use the existing `#[should_panic]` marker because removing it exposes other unrelated compatibility gaps. This PR scopes the first compatibility improvement to preserving parenthesized expressions.