### PR TITLE
test: ignore codegen program metadata

### DIFF
--- a/crates/vue_oxlint_jsx/src/test/codegen.rs
+++ b/crates/vue_oxlint_jsx/src/test/codegen.rs
@@ -56,10 +56,16 @@ fn assert_reparsed_codegen_ast(
 
   assert!(!ret.fatal, "Codegen parser unexpectedly panicked for {file_path}");
   assert!(
-    ret.program.content_eq(reparsed_program),
+    program_codegen_content_eq(&ret.program, reparsed_program),
     "Reparsed codegen AST differs from original codegen AST for {file_path}. \nCodegen snapshot: {}",
     codegen_snapshot_path(file_path),
   );
+}
+
+fn program_codegen_content_eq(left: &Program, right: &Program) -> bool {
+  left.hashbang.content_eq(&right.hashbang)
+    && left.directives.content_eq(&right.directives)
+    && left.body.content_eq(&right.body)
 }
 
 fn codegen_snapshot_path(file_path: &str) -> String {


### PR DESCRIPTION
## Summary

- Compare codegen round-trip program content without including `Program.source_type` or comments metadata.
- Preserve the existing macro-level `#[should_panic]` behavior for codegen tests.

## Root Cause

`Program::content_eq` includes `source_type`, so SFC codegen tests fail when the parser keeps `module_kind: Unambiguous` but reparsing generated TSX resolves it to `Module` or `Script`. That metadata difference is not part of the generated program body fidelity check.

## Validation

- `cargo test -p vue_oxlint_jsx scripts_codegen_fidelity_vue::codegen -- --nocapture` currently fails because the old blanket `#[should_panic]` expectation is still present and the codegen fidelity fixture no longer panics after ignoring program metadata.

## Caveat

Keeping the previous `#[should_panic]` logic and ignoring `source_type` are in tension for `scripts/codegen_fidelity.vue`: the body comparison now succeeds, so the should-panic attribute becomes the failing condition.