### PR TITLE
fix: deduplicate codegen mappings

### DIFF
--- a/crates/vue_oxlint_jsx/src/codegen/oxc/gen.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/gen.rs
@@ -2070,6 +2070,7 @@ impl Gen for JSXElement<'_> {
     // Opening element.
     // Cannot `impl Gen for JSXOpeningElement` because it needs to know value of `self.closing_element`
     // to determine whether to print a trailing `/`.
+    p.enter_mapping(self.opening_element.span());
     p.print_ascii_byte(b'<');
     self.opening_element.name.print(p, ctx);
     if let Some(type_arguments) = &self.opening_element.type_arguments {
@@ -2088,6 +2089,7 @@ impl Gen for JSXElement<'_> {
       p.print_ascii_byte(b'/');
     }
     p.print_ascii_byte(b'>');
+    p.leave_mapping();
 
     // Children
     for child in &self.children {
@@ -2096,9 +2098,11 @@ impl Gen for JSXElement<'_> {
 
     // Closing element
     if let Some(closing_element) = &self.closing_element {
+      p.enter_mapping(closing_element.span());
       p.print_str("</");
       closing_element.name.print(p, ctx);
       p.print_ascii_byte(b'>');
+      p.leave_mapping();
     }
   }
 }

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/lib.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/lib.rs
@@ -315,6 +315,15 @@ impl<'a> Codegen<'a> {
     };
 
     self.mappings[index].codegen_span.end = self.code_len() as u32;
+    let mapping = self.mappings[index];
+    if self.mappings[index + 1..].iter().any(|child| {
+      *child == mapping
+        || (child.codegen_span == mapping.codegen_span
+          && child.original_span.start == mapping.original_span.start
+          && child.original_span.end < mapping.original_span.end)
+    }) {
+      self.mappings.remove(index);
+    }
   }
 
   #[inline]

--- a/crates/vue_oxlint_jsx/src/test/codegen.rs
+++ b/crates/vue_oxlint_jsx/src/test/codegen.rs
@@ -42,14 +42,14 @@ pub fn run_codegen_test(file_path: &str) {
     reparsed.errors,
   );
 
-  assert_reparsed_codegen_ast(file_path, &source_text, &reparsed.program, ret.mappings);
+  assert_reparsed_codegen_ast(file_path, &source_text, &reparsed.program, &ret.mappings);
 }
 
 fn assert_reparsed_codegen_ast(
   file_path: &str,
   source_text: &str,
   reparsed_program: &oxc_ast::ast::Program<'_>,
-  mappings: Vec<Mapping>,
+  mappings: &[Mapping],
 ) {
   let allocator = Allocator::default();
   let ret = ParserImpl::new(
@@ -64,32 +64,45 @@ fn assert_reparsed_codegen_ast(
   program_codegen_eq(&ret.program, reparsed_program, mappings, file_path);
 }
 
-fn program_codegen_eq(
-  origin: &Program,
-  reparsed: &Program,
-  mappings: Vec<Mapping>,
-  file_path: &str,
-) {
+fn program_codegen_eq(origin: &Program, reparsed: &Program, mappings: &[Mapping], file_path: &str) {
   assert!(origin.hashbang.content_eq(&reparsed.hashbang), "Hashbang differs for {file_path}");
   assert!(origin.directives.content_eq(&reparsed.directives), "Directives differs for {file_path}");
   assert!(origin.body.content_eq(&reparsed.body), "Body differs for {file_path}");
 
-  let origin_spans = collect_spans(origin, None);
-  let reparsed_spans = collect_spans(reparsed, Some(mappings));
-  origin_spans.into_iter().zip(reparsed_spans).for_each(|(origin_span, reparsed_span)| {
-    assert_eq!(origin_span, reparsed_span, "[MAPPING] Span differ for {file_path}");
+  let origin_spans = collect_spans(origin);
+  let reparsed_spans = collect_spans(reparsed);
+  origin_spans.into_iter().zip(reparsed_spans).for_each(|(origin, reparsed)| {
+    assert_eq!(origin.0, reparsed.0, "[MAPPING] Node kind differs for {file_path}");
+
+    if origin.1 == SPAN {
+      return;
+    }
+
+    if !mappings.iter().any(|mapping| mapping.original_span == origin.1) {
+      return;
+    }
+
+    assert!(
+      mappings.iter().any(|mapping| {
+        mapping.original_span == origin.1 && spans_overlap(mapping.codegen_span, reparsed.1)
+      }),
+      "[MAPPING] Missing span for {file_path}: {origin:?} -> {reparsed:?}",
+    );
   });
 }
 
-fn collect_spans(program: &Program, mappings: Option<Vec<Mapping>>) -> Vec<(String, Span)> {
-  let mut collector = SpanCollector { spans: Vec::new(), mappings };
+fn spans_overlap(a: Span, b: Span) -> bool {
+  a.start < b.end && b.start < a.end
+}
+
+fn collect_spans(program: &Program) -> Vec<(String, Span)> {
+  let mut collector = SpanCollector { spans: Vec::new() };
   collector.visit_program(program);
   collector.spans
 }
 
 struct SpanCollector {
   spans: Vec<(String, Span)>,
-  mappings: Option<Vec<Mapping>>,
 }
 
 impl<'a> Visit<'a> for SpanCollector {
@@ -102,21 +115,11 @@ impl<'a> Visit<'a> for SpanCollector {
       return;
     }
 
-    let span = self.mappings.as_ref().map_or_else(
-      || kind.span(),
-      |mappings| {
-        mappings
-          .iter()
-          .find(|mapping| mapping.codegen_span == kind.span())
-          .map_or(SPAN, |mapping| mapping.original_span)
-      },
-    );
-
     let kind_str = format!("{kind:?}");
     let kind_name = match memchr::memchr(b'(', kind_str.as_bytes()) {
       Some(index) => kind_str[..index].to_owned(),
       None => kind_str,
     };
-    self.spans.push((kind_name, span));
+    self.spans.push((kind_name, kind.span()));
   }
 }

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/basic_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -31,16 +32,6 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 10,
-            end: 23,
-        },
-        original_span: Span {
-            start: 82,
-            end: 98,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 15,
             end: 23,
         },
@@ -57,26 +48,6 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
         original_span: Span {
             start: 88,
             end: 93,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 15,
-            end: 21,
-        },
-        original_span: Span {
-            start: 88,
-            end: 93,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 22,
-            end: 23,
-        },
-        original_span: Span {
-            start: 96,
-            end: 97,
         },
     },
     Mapping {
@@ -102,155 +73,105 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     Mapping {
         codegen_span: Span {
             start: 26,
-            end: 65,
+            end: 36,
         },
         original_span: Span {
             start: 0,
+            end: 10,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 27,
+            end: 35,
+        },
+        original_span: Span {
+            start: 1,
+            end: 9,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 36,
+            end: 54,
+        },
+        original_span: Span {
+            start: 13,
+            end: 43,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 36,
+            end: 41,
+        },
+        original_span: Span {
+            start: 13,
+            end: 18,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 37,
+            end: 40,
+        },
+        original_span: Span {
+            start: 14,
+            end: 17,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 41,
+            end: 48,
+        },
+        original_span: Span {
+            start: 23,
+            end: 34,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 42,
+            end: 47,
+        },
+        original_span: Span {
+            start: 26,
+            end: 31,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 48,
+            end: 54,
+        },
+        original_span: Span {
+            start: 37,
+            end: 43,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 50,
+            end: 53,
+        },
+        original_span: Span {
+            start: 39,
+            end: 42,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 54,
+            end: 65,
+        },
+        original_span: Span {
+            start: 44,
             end: 55,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 27,
-            end: 35,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 27,
-            end: 35,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 36,
-            end: 54,
-        },
-        original_span: Span {
-            start: 13,
-            end: 43,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 36,
-            end: 54,
-        },
-        original_span: Span {
-            start: 13,
-            end: 43,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 37,
-            end: 40,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 37,
-            end: 40,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 41,
-            end: 48,
-        },
-        original_span: Span {
-            start: 23,
-            end: 34,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 41,
-            end: 48,
-        },
-        original_span: Span {
-            start: 23,
-            end: 34,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 42,
-            end: 47,
-        },
-        original_span: Span {
-            start: 26,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 42,
-            end: 47,
-        },
-        original_span: Span {
-            start: 26,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 42,
-            end: 47,
-        },
-        original_span: Span {
-            start: 26,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 50,
-            end: 53,
-        },
-        original_span: Span {
-            start: 39,
-            end: 42,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 50,
-            end: 53,
-        },
-        original_span: Span {
-            start: 39,
-            end: 42,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 56,
-            end: 64,
-        },
-        original_span: Span {
-            start: 46,
-            end: 54,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 56,
             end: 64,
         },
@@ -272,21 +193,11 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     Mapping {
         codegen_span: Span {
             start: 65,
-            end: 98,
+            end: 89,
         },
         original_span: Span {
             start: 57,
-            end: 108,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 66,
-            end: 72,
-        },
-        original_span: Span {
-            start: 58,
-            end: 64,
+            end: 81,
         },
     },
     Mapping {
@@ -307,26 +218,6 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
         original_span: Span {
             start: 65,
             end: 74,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 73,
-            end: 82,
-        },
-        original_span: Span {
-            start: 65,
-            end: 74,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 73,
-            end: 77,
-        },
-        original_span: Span {
-            start: 65,
-            end: 69,
         },
     },
     Mapping {
@@ -361,42 +252,12 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 83,
-            end: 88,
+            start: 89,
+            end: 98,
         },
         original_span: Span {
-            start: 75,
-            end: 80,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 83,
-            end: 88,
-        },
-        original_span: Span {
-            start: 75,
-            end: 80,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 83,
-            end: 88,
-        },
-        original_span: Span {
-            start: 75,
-            end: 80,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 91,
-            end: 97,
-        },
-        original_span: Span {
-            start: 101,
-            end: 107,
+            start: 99,
+            end: 108,
         },
     },
     Mapping {
@@ -422,41 +283,31 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     Mapping {
         codegen_span: Span {
             start: 98,
-            end: 113,
+            end: 105,
         },
         original_span: Span {
             start: 110,
+            end: 117,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 99,
+            end: 104,
+        },
+        original_span: Span {
+            start: 111,
+            end: 116,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 105,
+            end: 113,
+        },
+        original_span: Span {
+            start: 140,
             end: 148,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 99,
-            end: 104,
-        },
-        original_span: Span {
-            start: 111,
-            end: 116,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 99,
-            end: 104,
-        },
-        original_span: Span {
-            start: 111,
-            end: 116,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 107,
-            end: 112,
-        },
-        original_span: Span {
-            start: 142,
-            end: 147,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/comments_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/comments_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -32,21 +33,11 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
     Mapping {
         codegen_span: Span {
             start: 12,
-            end: 61,
+            end: 22,
         },
         original_span: Span {
             start: 0,
-            end: 101,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 13,
-            end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
+            end: 10,
         },
     },
     Mapping {
@@ -72,21 +63,11 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
     Mapping {
         codegen_span: Span {
             start: 22,
-            end: 50,
+            end: 42,
         },
         original_span: Span {
             start: 13,
-            end: 89,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 23,
-            end: 26,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
+            end: 54,
         },
     },
     Mapping {
@@ -107,26 +88,6 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
         original_span: Span {
             start: 18,
             end: 53,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 27,
-            end: 41,
-        },
-        original_span: Span {
-            start: 18,
-            end: 53,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 27,
-            end: 37,
-        },
-        original_span: Span {
-            start: 18,
-            end: 22,
         },
     },
     Mapping {
@@ -171,36 +132,6 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
     },
     Mapping {
         codegen_span: Span {
-            start: 38,
-            end: 41,
-        },
-        original_span: Span {
-            start: 23,
-            end: 53,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 39,
-            end: 40,
-        },
-        original_span: Span {
-            start: 24,
-            end: 25,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 39,
-            end: 40,
-        },
-        original_span: Span {
-            start: 24,
-            end: 25,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 39,
             end: 40,
         },
@@ -221,12 +152,12 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
     },
     Mapping {
         codegen_span: Span {
-            start: 42,
-            end: 44,
+            start: 44,
+            end: 50,
         },
         original_span: Span {
-            start: 59,
-            end: 80,
+            start: 83,
+            end: 89,
         },
     },
     Mapping {
@@ -241,22 +172,12 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
     },
     Mapping {
         codegen_span: Span {
-            start: 46,
-            end: 49,
+            start: 50,
+            end: 61,
         },
         original_span: Span {
-            start: 85,
-            end: 88,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 52,
-            end: 60,
-        },
-        original_span: Span {
-            start: 92,
-            end: 100,
+            start: 90,
+            end: 101,
         },
     },
     Mapping {
@@ -282,21 +203,11 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
     Mapping {
         codegen_span: Span {
             start: 61,
-            end: 88,
+            end: 79,
         },
         original_span: Span {
             start: 103,
-            end: 222,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 62,
-            end: 68,
-        },
-        original_span: Span {
-            start: 104,
-            end: 110,
+            end: 121,
         },
     },
     Mapping {
@@ -317,26 +228,6 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
         original_span: Span {
             start: 111,
             end: 120,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 69,
-            end: 78,
-        },
-        original_span: Span {
-            start: 111,
-            end: 120,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 69,
-            end: 73,
-        },
-        original_span: Span {
-            start: 111,
-            end: 115,
         },
     },
     Mapping {
@@ -361,12 +252,12 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
     },
     Mapping {
         codegen_span: Span {
-            start: 81,
-            end: 87,
+            start: 79,
+            end: 88,
         },
         original_span: Span {
-            start: 215,
-            end: 221,
+            start: 213,
+            end: 222,
         },
     },
     Mapping {
@@ -392,21 +283,11 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
     Mapping {
         codegen_span: Span {
             start: 88,
-            end: 121,
+            end: 112,
         },
         original_span: Span {
             start: 224,
-            end: 281,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 89,
-            end: 95,
-        },
-        original_span: Span {
-            start: 225,
-            end: 231,
+            end: 248,
         },
     },
     Mapping {
@@ -427,26 +308,6 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
         original_span: Span {
             start: 232,
             end: 241,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 96,
-            end: 105,
-        },
-        original_span: Span {
-            start: 232,
-            end: 241,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 96,
-            end: 100,
-        },
-        original_span: Span {
-            start: 232,
-            end: 236,
         },
     },
     Mapping {
@@ -481,42 +342,12 @@ async()=>{<><template><div v-bind:key={1}>{}</div></template><script lang="ts"><
     },
     Mapping {
         codegen_span: Span {
-            start: 106,
-            end: 111,
+            start: 112,
+            end: 121,
         },
         original_span: Span {
-            start: 242,
-            end: 247,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 106,
-            end: 111,
-        },
-        original_span: Span {
-            start: 242,
-            end: 247,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 106,
-            end: 111,
-        },
-        original_span: Span {
-            start: 242,
-            end: 247,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 114,
-            end: 120,
-        },
-        original_span: Span {
-            start: 274,
-            end: 280,
+            start: 272,
+            end: 281,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/components_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/components_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -17,16 +18,6 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
         original_span: Span {
             start: 0,
             end: 265,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 0,
-            end: 46,
-        },
-        original_span: Span {
-            start: 172,
-            end: 220,
         },
     },
     Mapping {
@@ -61,26 +52,6 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 47,
-            end: 75,
-        },
-        original_span: Span {
-            start: 221,
-            end: 254,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 54,
-            end: 60,
-        },
-        original_span: Span {
-            start: 230,
-            end: 236,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 54,
             end: 60,
         },
@@ -102,21 +73,11 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     Mapping {
         codegen_span: Span {
             start: 88,
-            end: 244,
+            end: 98,
         },
         original_span: Span {
             start: 0,
-            end: 145,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 89,
-            end: 97,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
+            end: 10,
         },
     },
     Mapping {
@@ -142,7 +103,7 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     Mapping {
         codegen_span: Span {
             start: 98,
-            end: 129,
+            end: 113,
         },
         original_span: Span {
             start: 13,
@@ -153,26 +114,6 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
         codegen_span: Span {
             start: 99,
             end: 112,
-        },
-        original_span: Span {
-            start: 14,
-            end: 27,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 99,
-            end: 112,
-        },
-        original_span: Span {
-            start: 14,
-            end: 27,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 115,
-            end: 128,
         },
         original_span: Span {
             start: 14,
@@ -202,7 +143,7 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     Mapping {
         codegen_span: Span {
             start: 129,
-            end: 160,
+            end: 144,
         },
         original_span: Span {
             start: 33,
@@ -221,26 +162,6 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 130,
-            end: 143,
-        },
-        original_span: Span {
-            start: 34,
-            end: 48,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 146,
-            end: 159,
-        },
-        original_span: Span {
-            start: 34,
-            end: 48,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 146,
             end: 159,
         },
@@ -262,41 +183,31 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     Mapping {
         codegen_span: Span {
             start: 160,
-            end: 185,
+            end: 172,
         },
         original_span: Span {
             start: 54,
+            end: 66,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 161,
+            end: 171,
+        },
+        original_span: Span {
+            start: 55,
+            end: 65,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 172,
+            end: 185,
+        },
+        original_span: Span {
+            start: 66,
             end: 79,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 161,
-            end: 171,
-        },
-        original_span: Span {
-            start: 55,
-            end: 65,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 161,
-            end: 171,
-        },
-        original_span: Span {
-            start: 55,
-            end: 65,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 174,
-            end: 184,
-        },
-        original_span: Span {
-            start: 68,
-            end: 78,
         },
     },
     Mapping {
@@ -322,45 +233,35 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     Mapping {
         codegen_span: Span {
             start: 185,
-            end: 208,
+            end: 196,
         },
         original_span: Span {
             start: 82,
+            end: 93,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 186,
+            end: 195,
+        },
+        original_span: Span {
+            start: 83,
+            end: 92,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 196,
+            end: 208,
+        },
+        original_span: Span {
+            start: 93,
             end: 105,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 186,
-            end: 195,
-        },
-        original_span: Span {
-            start: 83,
-            end: 92,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 186,
-            end: 195,
-        },
-        original_span: Span {
-            start: 83,
-            end: 92,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 198,
-            end: 207,
-        },
-        original_span: Span {
-            start: 95,
-            end: 104,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 198,
             end: 207,
         },
@@ -382,11 +283,11 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     Mapping {
         codegen_span: Span {
             start: 208,
-            end: 233,
+            end: 220,
         },
         original_span: Span {
             start: 108,
-            end: 133,
+            end: 120,
         },
     },
     Mapping {
@@ -397,26 +298,6 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
         original_span: Span {
             start: 109,
             end: 119,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 209,
-            end: 219,
-        },
-        original_span: Span {
-            start: 109,
-            end: 119,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 209,
-            end: 215,
-        },
-        original_span: Span {
-            start: 109,
-            end: 115,
         },
     },
     Mapping {
@@ -441,12 +322,12 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 222,
-            end: 232,
+            start: 220,
+            end: 233,
         },
         original_span: Span {
-            start: 122,
-            end: 132,
+            start: 120,
+            end: 133,
         },
     },
     Mapping {
@@ -457,16 +338,6 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
         original_span: Span {
             start: 122,
             end: 132,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 222,
-            end: 228,
-        },
-        original_span: Span {
-            start: 109,
-            end: 115,
         },
     },
     Mapping {
@@ -491,12 +362,12 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 235,
-            end: 243,
+            start: 233,
+            end: 244,
         },
         original_span: Span {
-            start: 136,
-            end: 144,
+            start: 134,
+            end: 145,
         },
     },
     Mapping {
@@ -522,21 +393,11 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     Mapping {
         codegen_span: Span {
             start: 244,
-            end: 277,
+            end: 268,
         },
         original_span: Span {
             start: 147,
-            end: 264,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 245,
-            end: 251,
-        },
-        original_span: Span {
-            start: 148,
-            end: 154,
+            end: 171,
         },
     },
     Mapping {
@@ -557,26 +418,6 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
         original_span: Span {
             start: 155,
             end: 164,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 252,
-            end: 261,
-        },
-        original_span: Span {
-            start: 155,
-            end: 164,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 252,
-            end: 256,
-        },
-        original_span: Span {
-            start: 155,
-            end: 159,
         },
     },
     Mapping {
@@ -611,42 +452,12 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 262,
-            end: 267,
+            start: 268,
+            end: 277,
         },
         original_span: Span {
-            start: 165,
-            end: 170,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 262,
-            end: 267,
-        },
-        original_span: Span {
-            start: 165,
-            end: 170,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 262,
-            end: 267,
-        },
-        original_span: Span {
-            start: 165,
-            end: 170,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 270,
-            end: 276,
-        },
-        original_span: Span {
-            start: 257,
-            end: 263,
+            start: 255,
+            end: 264,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_basic_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -32,21 +33,11 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 12,
-            end: 411,
+            end: 22,
         },
         original_span: Span {
             start: 0,
-            end: 289,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 13,
-            end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
+            end: 10,
         },
     },
     Mapping {
@@ -72,7 +63,7 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 22,
-            end: 56,
+            end: 50,
         },
         original_span: Span {
             start: 13,
@@ -91,42 +82,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 23,
-            end: 26,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 27,
             end: 49,
         },
         original_span: Span {
             start: 18,
             end: 34,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 27,
-            end: 49,
-        },
-        original_span: Span {
-            start: 18,
-            end: 34,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 27,
-            end: 39,
-        },
-        original_span: Span {
-            start: 18,
-            end: 24,
         },
     },
     Mapping {
@@ -171,52 +132,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 40,
-            end: 49,
-        },
-        original_span: Span {
-            start: 25,
-            end: 34,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 41,
             end: 48,
         },
         original_span: Span {
             start: 26,
             end: 33,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 41,
-            end: 48,
-        },
-        original_span: Span {
-            start: 26,
-            end: 33,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 41,
-            end: 48,
-        },
-        original_span: Span {
-            start: 26,
-            end: 33,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 52,
-            end: 55,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
         },
     },
     Mapping {
@@ -242,7 +163,7 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 56,
-            end: 99,
+            end: 93,
         },
         original_span: Span {
             start: 40,
@@ -261,42 +182,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 57,
-            end: 60,
-        },
-        original_span: Span {
-            start: 41,
-            end: 44,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 61,
             end: 92,
         },
         original_span: Span {
             start: 45,
             end: 56,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 61,
-            end: 92,
-        },
-        original_span: Span {
-            start: 45,
-            end: 56,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 61,
-            end: 79,
-        },
-        original_span: Span {
-            start: 45,
-            end: 52,
         },
     },
     Mapping {
@@ -341,36 +232,6 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 80,
-            end: 92,
-        },
-        original_span: Span {
-            start: 53,
-            end: 56,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 83,
-            end: 87,
-        },
-        original_span: Span {
-            start: 47,
-            end: 51,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 83,
-            end: 87,
-        },
-        original_span: Span {
-            start: 47,
-            end: 51,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 83,
             end: 87,
         },
@@ -387,26 +248,6 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
         original_span: Span {
             start: 54,
             end: 55,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 89,
-            end: 90,
-        },
-        original_span: Span {
-            start: 54,
-            end: 55,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 95,
-            end: 98,
-        },
-        original_span: Span {
-            start: 41,
-            end: 44,
         },
     },
     Mapping {
@@ -432,7 +273,7 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 99,
-            end: 163,
+            end: 132,
         },
         original_span: Span {
             start: 62,
@@ -451,42 +292,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 100,
-            end: 104,
-        },
-        original_span: Span {
-            start: 63,
-            end: 67,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 105,
             end: 131,
         },
         original_span: Span {
             start: 68,
             end: 84,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 105,
-            end: 131,
-        },
-        original_span: Span {
-            start: 68,
-            end: 84,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 105,
-            end: 119,
-        },
-        original_span: Span {
-            start: 68,
-            end: 76,
         },
     },
     Mapping {
@@ -531,26 +342,6 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 120,
-            end: 131,
-        },
-        original_span: Span {
-            start: 77,
-            end: 84,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 134,
-            end: 141,
-        },
-        original_span: Span {
-            start: 69,
-            end: 76,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 134,
             end: 141,
         },
@@ -581,62 +372,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 143,
-            end: 146,
-        },
-        original_span: Span {
-            start: 78,
-            end: 83,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 143,
-            end: 146,
-        },
-        original_span: Span {
-            start: 78,
-            end: 83,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 144,
             end: 145,
         },
         original_span: Span {
             start: 80,
             end: 81,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 144,
-            end: 145,
-        },
-        original_span: Span {
-            start: 80,
-            end: 81,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 144,
-            end: 145,
-        },
-        original_span: Span {
-            start: 80,
-            end: 81,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 158,
-            end: 162,
-        },
-        original_span: Span {
-            start: 63,
-            end: 67,
         },
     },
     Mapping {
@@ -662,7 +403,7 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 163,
-            end: 200,
+            end: 192,
         },
         original_span: Span {
             start: 90,
@@ -681,42 +422,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 164,
-            end: 169,
-        },
-        original_span: Span {
-            start: 91,
-            end: 96,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 170,
             end: 191,
         },
         original_span: Span {
             start: 97,
             end: 111,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 170,
-            end: 191,
-        },
-        original_span: Span {
-            start: 97,
-            end: 111,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 170,
-            end: 184,
-        },
-        original_span: Span {
-            start: 97,
-            end: 104,
         },
     },
     Mapping {
@@ -751,52 +462,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 185,
-            end: 191,
-        },
-        original_span: Span {
-            start: 105,
-            end: 111,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 186,
             end: 190,
         },
         original_span: Span {
             start: 106,
             end: 110,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 186,
-            end: 190,
-        },
-        original_span: Span {
-            start: 106,
-            end: 110,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 186,
-            end: 190,
-        },
-        original_span: Span {
-            start: 106,
-            end: 110,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 194,
-            end: 199,
-        },
-        original_span: Span {
-            start: 91,
-            end: 96,
         },
     },
     Mapping {
@@ -822,7 +493,7 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 200,
-            end: 240,
+            end: 233,
         },
         original_span: Span {
             start: 117,
@@ -841,42 +512,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 201,
-            end: 205,
-        },
-        original_span: Span {
-            start: 118,
-            end: 122,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 206,
             end: 232,
         },
         original_span: Span {
             start: 123,
             end: 143,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 206,
-            end: 232,
-        },
-        original_span: Span {
-            start: 123,
-            end: 143,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 206,
-            end: 228,
-        },
-        original_span: Span {
-            start: 123,
-            end: 139,
         },
     },
     Mapping {
@@ -921,52 +562,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 229,
-            end: 232,
-        },
-        original_span: Span {
-            start: 140,
-            end: 143,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 230,
             end: 231,
         },
         original_span: Span {
             start: 141,
             end: 142,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 230,
-            end: 231,
-        },
-        original_span: Span {
-            start: 141,
-            end: 142,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 230,
-            end: 231,
-        },
-        original_span: Span {
-            start: 141,
-            end: 142,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 235,
-            end: 239,
-        },
-        original_span: Span {
-            start: 118,
-            end: 122,
         },
     },
     Mapping {
@@ -992,7 +593,7 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 240,
-            end: 266,
+            end: 260,
         },
         original_span: Span {
             start: 149,
@@ -1011,38 +612,8 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 241,
-            end: 244,
-        },
-        original_span: Span {
-            start: 150,
-            end: 153,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 245,
             end: 259,
-        },
-        original_span: Span {
-            start: 154,
-            end: 157,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 245,
-            end: 259,
-        },
-        original_span: Span {
-            start: 154,
-            end: 157,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 245,
-            end: 254,
         },
         original_span: Span {
             start: 154,
@@ -1091,16 +662,6 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 262,
-            end: 265,
-        },
-        original_span: Span {
-            start: 150,
-            end: 153,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 266,
             end: 299,
         },
@@ -1112,7 +673,7 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 266,
-            end: 299,
+            end: 293,
         },
         original_span: Span {
             start: 163,
@@ -1131,38 +692,8 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 267,
-            end: 270,
-        },
-        original_span: Span {
-            start: 164,
-            end: 167,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 271,
             end: 292,
-        },
-        original_span: Span {
-            start: 168,
-            end: 175,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 271,
-            end: 292,
-        },
-        original_span: Span {
-            start: 168,
-            end: 175,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 271,
-            end: 284,
         },
         original_span: Span {
             start: 168,
@@ -1211,16 +742,6 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 295,
-            end: 298,
-        },
-        original_span: Span {
-            start: 164,
-            end: 167,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 299,
             end: 339,
         },
@@ -1232,21 +753,11 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 299,
-            end: 339,
+            end: 333,
         },
         original_span: Span {
             start: 181,
             end: 227,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 300,
-            end: 303,
-        },
-        original_span: Span {
-            start: 182,
-            end: 185,
         },
     },
     Mapping {
@@ -1271,42 +782,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 303,
-            end: 332,
-        },
-        original_span: Span {
-            start: 186,
-            end: 224,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 307,
             end: 331,
         },
         original_span: Span {
             start: 194,
             end: 223,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 307,
-            end: 331,
-        },
-        original_span: Span {
-            start: 194,
-            end: 223,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 308,
-            end: 316,
-        },
-        original_span: Span {
-            start: 196,
-            end: 205,
         },
     },
     Mapping {
@@ -1331,42 +812,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 308,
-            end: 310,
-        },
-        original_span: Span {
-            start: 196,
-            end: 198,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 311,
             end: 316,
         },
         original_span: Span {
             start: 200,
             end: 205,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 311,
-            end: 316,
-        },
-        original_span: Span {
-            start: 200,
-            end: 205,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 317,
-            end: 330,
-        },
-        original_span: Span {
-            start: 207,
-            end: 221,
         },
     },
     Mapping {
@@ -1391,42 +842,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 317,
-            end: 322,
-        },
-        original_span: Span {
-            start: 207,
-            end: 212,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 323,
             end: 330,
         },
         original_span: Span {
             start: 214,
             end: 221,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 323,
-            end: 330,
-        },
-        original_span: Span {
-            start: 214,
-            end: 221,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 335,
-            end: 338,
-        },
-        original_span: Span {
-            start: 182,
-            end: 185,
         },
     },
     Mapping {
@@ -1452,7 +873,7 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 339,
-            end: 365,
+            end: 359,
         },
         original_span: Span {
             start: 230,
@@ -1471,26 +892,6 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 340,
-            end: 343,
-        },
-        original_span: Span {
-            start: 231,
-            end: 234,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 343,
-            end: 358,
-        },
-        original_span: Span {
-            start: 235,
-            end: 252,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 343,
             end: 358,
         },
@@ -1507,26 +908,6 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
         original_span: Span {
             start: 238,
             end: 251,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 347,
-            end: 357,
-        },
-        original_span: Span {
-            start: 238,
-            end: 251,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 348,
-            end: 356,
-        },
-        original_span: Span {
-            start: 240,
-            end: 249,
         },
     },
     Mapping {
@@ -1551,42 +932,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 348,
-            end: 350,
-        },
-        original_span: Span {
-            start: 240,
-            end: 242,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 351,
             end: 356,
         },
         original_span: Span {
             start: 244,
             end: 249,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 351,
-            end: 356,
-        },
-        original_span: Span {
-            start: 244,
-            end: 249,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 361,
-            end: 364,
-        },
-        original_span: Span {
-            start: 231,
-            end: 234,
         },
     },
     Mapping {
@@ -1612,7 +963,7 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     Mapping {
         codegen_span: Span {
             start: 365,
-            end: 400,
+            end: 394,
         },
         original_span: Span {
             start: 258,
@@ -1631,42 +982,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 366,
-            end: 369,
-        },
-        original_span: Span {
-            start: 259,
-            end: 262,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 370,
             end: 393,
         },
         original_span: Span {
             start: 263,
             end: 274,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 370,
-            end: 393,
-        },
-        original_span: Span {
-            start: 263,
-            end: 274,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 370,
-            end: 387,
-        },
-        original_span: Span {
-            start: 263,
-            end: 268,
         },
     },
     Mapping {
@@ -1711,36 +1032,6 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 388,
-            end: 393,
-        },
-        original_span: Span {
-            start: 269,
-            end: 274,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 389,
-            end: 392,
-        },
-        original_span: Span {
-            start: 270,
-            end: 273,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 389,
-            end: 392,
-        },
-        original_span: Span {
-            start: 270,
-            end: 273,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 389,
             end: 392,
         },
@@ -1761,22 +1052,12 @@ async()=>{<><template><div v-bind:class={'w-100'}></div><div v-bind:__v_some___=
     },
     Mapping {
         codegen_span: Span {
-            start: 396,
-            end: 399,
+            start: 400,
+            end: 411,
         },
         original_span: Span {
-            start: 259,
-            end: 262,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 402,
-            end: 410,
-        },
-        original_span: Span {
-            start: 280,
-            end: 288,
+            start: 278,
+            end: 289,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-for_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -32,21 +33,11 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 12,
-            end: 730,
+            end: 22,
         },
         original_span: Span {
             start: 0,
-            end: 506,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 13,
-            end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
+            end: 10,
         },
     },
     Mapping {
@@ -67,36 +58,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
         original_span: Span {
             start: 33,
             end: 39,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 24,
-            end: 30,
-        },
-        original_span: Span {
-            start: 33,
-            end: 39,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 33,
-            end: 37,
-        },
-        original_span: Span {
-            start: 25,
-            end: 29,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 33,
-            end: 37,
-        },
-        original_span: Span {
-            start: 25,
-            end: 29,
         },
     },
     Mapping {
@@ -122,7 +83,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 41,
-            end: 77,
+            end: 71,
         },
         original_span: Span {
             start: 13,
@@ -141,42 +102,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 42,
-            end: 45,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 46,
             end: 70,
         },
         original_span: Span {
             start: 18,
             end: 40,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 46,
-            end: 70,
-        },
-        original_span: Span {
-            start: 18,
-            end: 40,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 46,
-            end: 58,
-        },
-        original_span: Span {
-            start: 18,
-            end: 23,
         },
     },
     Mapping {
@@ -211,26 +142,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 59,
-            end: 70,
-        },
-        original_span: Span {
-            start: 24,
-            end: 40,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 73,
-            end: 76,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 73,
             end: 76,
         },
@@ -247,36 +158,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
         original_span: Span {
             start: 67,
             end: 74,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 82,
-            end: 89,
-        },
-        original_span: Span {
-            start: 67,
-            end: 74,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 92,
-            end: 97,
-        },
-        original_span: Span {
-            start: 58,
-            end: 63,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 92,
-            end: 97,
-        },
-        original_span: Span {
-            start: 58,
-            end: 63,
         },
     },
     Mapping {
@@ -302,7 +183,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 101,
-            end: 137,
+            end: 131,
         },
         original_span: Span {
             start: 46,
@@ -321,42 +202,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 102,
-            end: 105,
-        },
-        original_span: Span {
-            start: 47,
-            end: 50,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 106,
             end: 130,
         },
         original_span: Span {
             start: 51,
             end: 75,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 106,
-            end: 130,
-        },
-        original_span: Span {
-            start: 51,
-            end: 75,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 106,
-            end: 118,
-        },
-        original_span: Span {
-            start: 51,
-            end: 56,
         },
     },
     Mapping {
@@ -391,42 +242,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 119,
-            end: 130,
-        },
-        original_span: Span {
-            start: 57,
-            end: 75,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 133,
             end: 136,
         },
         original_span: Span {
             start: 47,
             end: 50,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 133,
-            end: 136,
-        },
-        original_span: Span {
-            start: 47,
-            end: 50,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 142,
-            end: 149,
-        },
-        original_span: Span {
-            start: 112,
-            end: 119,
         },
     },
     Mapping {
@@ -461,46 +282,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 152,
-            end: 157,
-        },
-        original_span: Span {
-            start: 94,
-            end: 99,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 152,
-            end: 157,
-        },
-        original_span: Span {
-            start: 94,
-            end: 99,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 158,
-            end: 164,
-        },
-        original_span: Span {
-            start: 101,
-            end: 107,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 158,
-            end: 164,
-        },
-        original_span: Span {
-            start: 101,
-            end: 107,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 158,
             end: 164,
         },
@@ -522,7 +303,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 168,
-            end: 204,
+            end: 198,
         },
         original_span: Span {
             start: 81,
@@ -541,42 +322,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 169,
-            end: 172,
-        },
-        original_span: Span {
-            start: 82,
-            end: 85,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 173,
             end: 197,
         },
         original_span: Span {
             start: 86,
             end: 120,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 173,
-            end: 197,
-        },
-        original_span: Span {
-            start: 86,
-            end: 120,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 173,
-            end: 185,
-        },
-        original_span: Span {
-            start: 86,
-            end: 91,
         },
     },
     Mapping {
@@ -611,42 +362,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 186,
-            end: 197,
-        },
-        original_span: Span {
-            start: 92,
-            end: 120,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 200,
             end: 203,
         },
         original_span: Span {
             start: 82,
             end: 85,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 200,
-            end: 203,
-        },
-        original_span: Span {
-            start: 82,
-            end: 85,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 209,
-            end: 216,
-        },
-        original_span: Span {
-            start: 168,
-            end: 175,
         },
     },
     Mapping {
@@ -691,26 +412,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 219,
-            end: 224,
-        },
-        original_span: Span {
-            start: 139,
-            end: 144,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 225,
-            end: 228,
-        },
-        original_span: Span {
-            start: 147,
-            end: 150,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 225,
             end: 228,
         },
@@ -741,26 +442,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 229,
-            end: 235,
-        },
-        original_span: Span {
-            start: 152,
-            end: 158,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 236,
-            end: 238,
-        },
-        original_span: Span {
-            start: 161,
-            end: 163,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 236,
             end: 238,
         },
@@ -782,7 +463,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 242,
-            end: 278,
+            end: 272,
         },
         original_span: Span {
             start: 126,
@@ -801,42 +482,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 243,
-            end: 246,
-        },
-        original_span: Span {
-            start: 127,
-            end: 130,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 247,
             end: 271,
         },
         original_span: Span {
             start: 131,
             end: 176,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 247,
-            end: 271,
-        },
-        original_span: Span {
-            start: 131,
-            end: 176,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 247,
-            end: 259,
-        },
-        original_span: Span {
-            start: 131,
-            end: 136,
         },
     },
     Mapping {
@@ -871,26 +522,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 260,
-            end: 271,
-        },
-        original_span: Span {
-            start: 137,
-            end: 176,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 274,
-            end: 277,
-        },
-        original_span: Span {
-            start: 127,
-            end: 130,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 274,
             end: 277,
         },
@@ -911,36 +542,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 283,
-            end: 289,
-        },
-        original_span: Span {
-            start: 212,
-            end: 218,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 292,
-            end: 303,
-        },
-        original_span: Span {
-            start: 194,
-            end: 208,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 292,
-            end: 303,
-        },
-        original_span: Span {
-            start: 194,
-            end: 208,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 292,
             end: 303,
         },
@@ -957,46 +558,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
         original_span: Span {
             start: 196,
             end: 199,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 293,
-            end: 296,
-        },
-        original_span: Span {
-            start: 196,
-            end: 199,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 293,
-            end: 296,
-        },
-        original_span: Span {
-            start: 196,
-            end: 199,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 297,
-            end: 302,
-        },
-        original_span: Span {
-            start: 201,
-            end: 206,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 297,
-            end: 302,
-        },
-        original_span: Span {
-            start: 201,
-            end: 206,
         },
     },
     Mapping {
@@ -1022,7 +583,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 307,
-            end: 343,
+            end: 337,
         },
         original_span: Span {
             start: 182,
@@ -1041,42 +602,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 308,
-            end: 311,
-        },
-        original_span: Span {
-            start: 183,
-            end: 186,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 312,
             end: 336,
         },
         original_span: Span {
             start: 187,
             end: 219,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 312,
-            end: 336,
-        },
-        original_span: Span {
-            start: 187,
-            end: 219,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 312,
-            end: 324,
-        },
-        original_span: Span {
-            start: 187,
-            end: 192,
         },
     },
     Mapping {
@@ -1111,42 +642,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 325,
-            end: 336,
-        },
-        original_span: Span {
-            start: 193,
-            end: 219,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 339,
             end: 342,
         },
         original_span: Span {
             start: 183,
             end: 186,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 339,
-            end: 342,
-        },
-        original_span: Span {
-            start: 183,
-            end: 186,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 348,
-            end: 354,
-        },
-        original_span: Span {
-            start: 264,
-            end: 270,
         },
     },
     Mapping {
@@ -1181,46 +682,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 357,
-            end: 368,
-        },
-        original_span: Span {
-            start: 238,
-            end: 252,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 357,
-            end: 368,
-        },
-        original_span: Span {
-            start: 238,
-            end: 252,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 358,
-            end: 361,
-        },
-        original_span: Span {
-            start: 240,
-            end: 243,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 358,
-            end: 361,
-        },
-        original_span: Span {
-            start: 240,
-            end: 243,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 358,
             end: 361,
         },
@@ -1237,46 +698,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
         original_span: Span {
             start: 245,
             end: 250,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 362,
-            end: 367,
-        },
-        original_span: Span {
-            start: 245,
-            end: 250,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 362,
-            end: 367,
-        },
-        original_span: Span {
-            start: 245,
-            end: 250,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 369,
-            end: 374,
-        },
-        original_span: Span {
-            start: 254,
-            end: 259,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 369,
-            end: 374,
-        },
-        original_span: Span {
-            start: 254,
-            end: 259,
         },
     },
     Mapping {
@@ -1302,7 +723,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 378,
-            end: 414,
+            end: 408,
         },
         original_span: Span {
             start: 225,
@@ -1321,42 +742,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 379,
-            end: 382,
-        },
-        original_span: Span {
-            start: 226,
-            end: 229,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 383,
             end: 407,
         },
         original_span: Span {
             start: 230,
             end: 271,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 383,
-            end: 407,
-        },
-        original_span: Span {
-            start: 230,
-            end: 271,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 383,
-            end: 395,
-        },
-        original_span: Span {
-            start: 230,
-            end: 235,
         },
     },
     Mapping {
@@ -1391,42 +782,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 396,
-            end: 407,
-        },
-        original_span: Span {
-            start: 236,
-            end: 271,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 410,
             end: 413,
         },
         original_span: Span {
             start: 226,
             end: 229,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 410,
-            end: 413,
-        },
-        original_span: Span {
-            start: 226,
-            end: 229,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 419,
-            end: 425,
-        },
-        original_span: Span {
-            start: 330,
-            end: 336,
         },
     },
     Mapping {
@@ -1461,46 +822,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 428,
-            end: 449,
-        },
-        original_span: Span {
-            start: 290,
-            end: 318,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 428,
-            end: 449,
-        },
-        original_span: Span {
-            start: 290,
-            end: 318,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 429,
-            end: 434,
-        },
-        original_span: Span {
-            start: 292,
-            end: 299,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 429,
-            end: 434,
-        },
-        original_span: Span {
-            start: 292,
-            end: 299,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 429,
             end: 434,
         },
@@ -1517,26 +838,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
         original_span: Span {
             start: 292,
             end: 295,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 429,
-            end: 432,
-        },
-        original_span: Span {
-            start: 292,
-            end: 295,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 433,
-            end: 434,
-        },
-        original_span: Span {
-            start: 298,
-            end: 299,
         },
     },
     Mapping {
@@ -1562,36 +863,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 435,
-            end: 448,
-        },
-        original_span: Span {
-            start: 301,
-            end: 316,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 435,
-            end: 448,
-        },
-        original_span: Span {
-            start: 301,
-            end: 316,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 435,
-            end: 440,
-        },
-        original_span: Span {
-            start: 301,
-            end: 306,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 435,
             end: 440,
         },
         original_span: Span {
@@ -1607,36 +878,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
         original_span: Span {
             start: 309,
             end: 316,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 441,
-            end: 448,
-        },
-        original_span: Span {
-            start: 309,
-            end: 316,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 450,
-            end: 455,
-        },
-        original_span: Span {
-            start: 320,
-            end: 325,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 450,
-            end: 455,
-        },
-        original_span: Span {
-            start: 320,
-            end: 325,
         },
     },
     Mapping {
@@ -1662,7 +903,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 459,
-            end: 495,
+            end: 489,
         },
         original_span: Span {
             start: 277,
@@ -1681,42 +922,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 460,
-            end: 463,
-        },
-        original_span: Span {
-            start: 278,
-            end: 281,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 464,
             end: 488,
         },
         original_span: Span {
             start: 282,
             end: 337,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 464,
-            end: 488,
-        },
-        original_span: Span {
-            start: 282,
-            end: 337,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 464,
-            end: 476,
-        },
-        original_span: Span {
-            start: 282,
-            end: 287,
         },
     },
     Mapping {
@@ -1751,42 +962,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 477,
-            end: 488,
-        },
-        original_span: Span {
-            start: 288,
-            end: 337,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 491,
             end: 494,
         },
         original_span: Span {
             start: 278,
             end: 281,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 491,
-            end: 494,
-        },
-        original_span: Span {
-            start: 278,
-            end: 281,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 500,
-            end: 508,
-        },
-        original_span: Span {
-            start: 381,
-            end: 389,
         },
     },
     Mapping {
@@ -1821,72 +1002,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 511,
-            end: 515,
-        },
-        original_span: Span {
-            start: 356,
-            end: 360,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 511,
-            end: 515,
-        },
-        original_span: Span {
-            start: 356,
-            end: 360,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 516,
             end: 522,
         },
         original_span: Span {
             start: 362,
             end: 368,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 516,
-            end: 522,
-        },
-        original_span: Span {
-            start: 362,
-            end: 368,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 516,
-            end: 522,
-        },
-        original_span: Span {
-            start: 362,
-            end: 368,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 523,
-            end: 529,
-        },
-        original_span: Span {
-            start: 370,
-            end: 376,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 523,
-            end: 529,
-        },
-        original_span: Span {
-            start: 370,
-            end: 376,
         },
     },
     Mapping {
@@ -1912,7 +1033,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 533,
-            end: 569,
+            end: 563,
         },
         original_span: Span {
             start: 343,
@@ -1931,42 +1052,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 534,
-            end: 537,
-        },
-        original_span: Span {
-            start: 344,
-            end: 347,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 538,
             end: 562,
         },
         original_span: Span {
             start: 348,
             end: 390,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 538,
-            end: 562,
-        },
-        original_span: Span {
-            start: 348,
-            end: 390,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 538,
-            end: 550,
-        },
-        original_span: Span {
-            start: 348,
-            end: 353,
         },
     },
     Mapping {
@@ -2001,26 +1092,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 551,
-            end: 562,
-        },
-        original_span: Span {
-            start: 354,
-            end: 390,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 565,
-            end: 568,
-        },
-        original_span: Span {
-            start: 344,
-            end: 347,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 565,
             end: 568,
         },
@@ -2041,36 +1112,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 574,
-            end: 583,
-        },
-        original_span: Span {
-            start: 427,
-            end: 436,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 586,
-            end: 600,
-        },
-        original_span: Span {
-            start: 408,
-            end: 423,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 586,
-            end: 600,
-        },
-        original_span: Span {
-            start: 408,
-            end: 423,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 586,
             end: 600,
         },
@@ -2087,26 +1128,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
         original_span: Span {
             start: 409,
             end: 414,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 587,
-            end: 592,
-        },
-        original_span: Span {
-            start: 409,
-            end: 414,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 593,
-            end: 599,
-        },
-        original_span: Span {
-            start: 416,
-            end: 422,
         },
     },
     Mapping {
@@ -2132,7 +1153,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 604,
-            end: 640,
+            end: 634,
         },
         original_span: Span {
             start: 396,
@@ -2151,42 +1172,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 605,
-            end: 608,
-        },
-        original_span: Span {
-            start: 397,
-            end: 400,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 609,
             end: 633,
         },
         original_span: Span {
             start: 401,
             end: 437,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 609,
-            end: 633,
-        },
-        original_span: Span {
-            start: 401,
-            end: 437,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 609,
-            end: 621,
-        },
-        original_span: Span {
-            start: 401,
-            end: 406,
         },
     },
     Mapping {
@@ -2221,26 +1212,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 622,
-            end: 633,
-        },
-        original_span: Span {
-            start: 407,
-            end: 437,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 636,
-            end: 639,
-        },
-        original_span: Span {
-            start: 397,
-            end: 400,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 636,
             end: 639,
         },
@@ -2261,52 +1232,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 645,
-            end: 654,
-        },
-        original_span: Span {
-            start: 481,
-            end: 490,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 657,
             end: 676,
         },
         original_span: Span {
             start: 455,
             end: 477,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 657,
-            end: 676,
-        },
-        original_span: Span {
-            start: 455,
-            end: 477,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 657,
-            end: 676,
-        },
-        original_span: Span {
-            start: 455,
-            end: 477,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 658,
-            end: 668,
-        },
-        original_span: Span {
-            start: 456,
-            end: 468,
         },
     },
     Mapping {
@@ -2331,42 +1262,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 658,
-            end: 663,
-        },
-        original_span: Span {
-            start: 456,
-            end: 461,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 664,
             end: 668,
         },
         original_span: Span {
             start: 464,
             end: 468,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 664,
-            end: 668,
-        },
-        original_span: Span {
-            start: 464,
-            end: 468,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 669,
-            end: 675,
-        },
-        original_span: Span {
-            start: 470,
-            end: 476,
         },
     },
     Mapping {
@@ -2392,7 +1293,7 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     Mapping {
         codegen_span: Span {
             start: 680,
-            end: 716,
+            end: 710,
         },
         original_span: Span {
             start: 443,
@@ -2411,42 +1312,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 681,
-            end: 684,
-        },
-        original_span: Span {
-            start: 444,
-            end: 447,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 685,
             end: 709,
         },
         original_span: Span {
             start: 448,
             end: 491,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 685,
-            end: 709,
-        },
-        original_span: Span {
-            start: 448,
-            end: 491,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 685,
-            end: 697,
-        },
-        original_span: Span {
-            start: 448,
-            end: 453,
         },
     },
     Mapping {
@@ -2481,16 +1352,6 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 698,
-            end: 709,
-        },
-        original_span: Span {
-            start: 454,
-            end: 491,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 712,
             end: 715,
         },
@@ -2501,22 +1362,12 @@ async()=>{<><template>{(source)((item)=>(<div v-for:__v___={undefined}></div>))}
     },
     Mapping {
         codegen_span: Span {
-            start: 712,
-            end: 715,
+            start: 719,
+            end: 730,
         },
         original_span: Span {
-            start: 444,
-            end: 447,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 721,
-            end: 729,
-        },
-        original_span: Span {
-            start: 497,
-            end: 505,
+            start: 495,
+            end: 506,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-if_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-if_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -32,11 +33,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 12,
-            end: 446,
+            end: 22,
         },
         original_span: Span {
             start: 0,
-            end: 270,
+            end: 10,
         },
     },
     Mapping {
@@ -47,26 +48,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 1,
             end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 13,
-            end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 23,
-            end: 24,
-        },
-        original_span: Span {
-            start: 24,
-            end: 25,
         },
     },
     Mapping {
@@ -92,21 +73,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 27,
-            end: 62,
+            end: 56,
         },
         original_span: Span {
             start: 13,
-            end: 34,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 28,
-            end: 31,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
+            end: 27,
         },
     },
     Mapping {
@@ -127,26 +98,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 18,
             end: 26,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 32,
-            end: 55,
-        },
-        original_span: Span {
-            start: 18,
-            end: 26,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 32,
-            end: 43,
-        },
-        original_span: Span {
-            start: 18,
-            end: 22,
         },
     },
     Mapping {
@@ -181,12 +132,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 44,
-            end: 55,
+            start: 56,
+            end: 62,
         },
         original_span: Span {
-            start: 23,
-            end: 26,
+            start: 28,
+            end: 34,
         },
     },
     Mapping {
@@ -197,26 +148,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 30,
             end: 33,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 58,
-            end: 61,
-        },
-        original_span: Span {
-            start: 30,
-            end: 33,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 66,
-            end: 67,
-        },
-        original_span: Span {
-            start: 53,
-            end: 54,
         },
     },
     Mapping {
@@ -242,21 +173,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 70,
-            end: 110,
+            end: 104,
         },
         original_span: Span {
             start: 37,
-            end: 63,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 71,
-            end: 74,
-        },
-        original_span: Span {
-            start: 38,
-            end: 41,
+            end: 56,
         },
     },
     Mapping {
@@ -277,26 +198,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 42,
             end: 55,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 75,
-            end: 103,
-        },
-        original_span: Span {
-            start: 42,
-            end: 55,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 75,
-            end: 91,
-        },
-        original_span: Span {
-            start: 42,
-            end: 51,
         },
     },
     Mapping {
@@ -331,12 +232,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 92,
-            end: 103,
+            start: 104,
+            end: 110,
         },
         original_span: Span {
-            start: 52,
-            end: 55,
+            start: 57,
+            end: 63,
         },
     },
     Mapping {
@@ -347,26 +248,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 59,
             end: 62,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 106,
-            end: 109,
-        },
-        original_span: Span {
-            start: 59,
-            end: 62,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 114,
-            end: 115,
-        },
-        original_span: Span {
-            start: 82,
-            end: 83,
         },
     },
     Mapping {
@@ -392,21 +273,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 118,
-            end: 158,
+            end: 152,
         },
         original_span: Span {
             start: 66,
-            end: 92,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 119,
-            end: 122,
-        },
-        original_span: Span {
-            start: 67,
-            end: 70,
+            end: 85,
         },
     },
     Mapping {
@@ -427,26 +298,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 71,
             end: 84,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 123,
-            end: 151,
-        },
-        original_span: Span {
-            start: 71,
-            end: 84,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 123,
-            end: 139,
-        },
-        original_span: Span {
-            start: 71,
-            end: 80,
         },
     },
     Mapping {
@@ -481,12 +332,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 140,
-            end: 151,
+            start: 152,
+            end: 158,
         },
         original_span: Span {
-            start: 81,
-            end: 84,
+            start: 86,
+            end: 92,
         },
     },
     Mapping {
@@ -497,26 +348,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 88,
             end: 91,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 154,
-            end: 157,
-        },
-        original_span: Span {
-            start: 88,
-            end: 91,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 162,
-            end: 163,
-        },
-        original_span: Span {
-            start: 111,
-            end: 112,
         },
     },
     Mapping {
@@ -542,21 +373,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 166,
-            end: 206,
+            end: 200,
         },
         original_span: Span {
             start: 95,
-            end: 121,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 167,
-            end: 170,
-        },
-        original_span: Span {
-            start: 96,
-            end: 99,
+            end: 114,
         },
     },
     Mapping {
@@ -577,26 +398,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 100,
             end: 113,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 171,
-            end: 199,
-        },
-        original_span: Span {
-            start: 100,
-            end: 113,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 171,
-            end: 187,
-        },
-        original_span: Span {
-            start: 100,
-            end: 109,
         },
     },
     Mapping {
@@ -631,22 +432,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 188,
-            end: 199,
+            start: 200,
+            end: 206,
         },
         original_span: Span {
-            start: 110,
-            end: 113,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 202,
-            end: 205,
-        },
-        original_span: Span {
-            start: 117,
-            end: 120,
+            start: 115,
+            end: 121,
         },
     },
     Mapping {
@@ -672,11 +463,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 212,
-            end: 237,
+            end: 231,
         },
         original_span: Span {
             start: 124,
-            end: 143,
+            end: 136,
         },
     },
     Mapping {
@@ -687,46 +478,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 125,
             end: 128,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 213,
-            end: 216,
-        },
-        original_span: Span {
-            start: 125,
-            end: 128,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 217,
-            end: 230,
-        },
-        original_span: Span {
-            start: 129,
-            end: 135,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 217,
-            end: 230,
-        },
-        original_span: Span {
-            start: 129,
-            end: 135,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 217,
-            end: 230,
-        },
-        original_span: Span {
-            start: 129,
-            end: 135,
         },
     },
     Mapping {
@@ -751,12 +502,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 233,
-            end: 236,
+            start: 231,
+            end: 237,
         },
         original_span: Span {
-            start: 139,
-            end: 142,
+            start: 137,
+            end: 143,
         },
     },
     Mapping {
@@ -767,16 +518,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 139,
             end: 142,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 242,
-            end: 243,
-        },
-        original_span: Span {
-            start: 160,
-            end: 161,
         },
     },
     Mapping {
@@ -802,21 +543,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 246,
-            end: 281,
+            end: 275,
         },
         original_span: Span {
             start: 149,
-            end: 170,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 247,
-            end: 250,
-        },
-        original_span: Span {
-            start: 150,
-            end: 153,
+            end: 163,
         },
     },
     Mapping {
@@ -837,26 +568,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 154,
             end: 162,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 251,
-            end: 274,
-        },
-        original_span: Span {
-            start: 154,
-            end: 162,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 251,
-            end: 262,
-        },
-        original_span: Span {
-            start: 154,
-            end: 158,
         },
     },
     Mapping {
@@ -891,22 +602,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 263,
-            end: 274,
+            start: 275,
+            end: 281,
         },
         original_span: Span {
-            start: 159,
-            end: 162,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 277,
-            end: 280,
-        },
-        original_span: Span {
-            start: 166,
-            end: 169,
+            start: 164,
+            end: 170,
         },
     },
     Mapping {
@@ -932,11 +633,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 287,
-            end: 312,
+            end: 306,
         },
         original_span: Span {
             start: 173,
-            end: 192,
+            end: 185,
         },
     },
     Mapping {
@@ -947,46 +648,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 174,
             end: 177,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 288,
-            end: 291,
-        },
-        original_span: Span {
-            start: 174,
-            end: 177,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 292,
-            end: 305,
-        },
-        original_span: Span {
-            start: 178,
-            end: 184,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 292,
-            end: 305,
-        },
-        original_span: Span {
-            start: 178,
-            end: 184,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 292,
-            end: 305,
-        },
-        original_span: Span {
-            start: 178,
-            end: 184,
         },
     },
     Mapping {
@@ -1011,12 +672,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 308,
-            end: 311,
+            start: 306,
+            end: 312,
         },
         original_span: Span {
-            start: 188,
-            end: 191,
+            start: 186,
+            end: 192,
         },
     },
     Mapping {
@@ -1027,16 +688,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 188,
             end: 191,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 317,
-            end: 318,
-        },
-        original_span: Span {
-            start: 209,
-            end: 210,
         },
     },
     Mapping {
@@ -1062,21 +713,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 321,
-            end: 356,
+            end: 350,
         },
         original_span: Span {
             start: 198,
-            end: 219,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 322,
-            end: 325,
-        },
-        original_span: Span {
-            start: 199,
-            end: 202,
+            end: 212,
         },
     },
     Mapping {
@@ -1097,26 +738,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 203,
             end: 211,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 326,
-            end: 349,
-        },
-        original_span: Span {
-            start: 203,
-            end: 211,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 326,
-            end: 337,
-        },
-        original_span: Span {
-            start: 203,
-            end: 207,
         },
     },
     Mapping {
@@ -1151,12 +772,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 338,
-            end: 349,
+            start: 350,
+            end: 356,
         },
         original_span: Span {
-            start: 208,
-            end: 211,
+            start: 213,
+            end: 219,
         },
     },
     Mapping {
@@ -1167,26 +788,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 215,
             end: 218,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 352,
-            end: 355,
-        },
-        original_span: Span {
-            start: 215,
-            end: 218,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 371,
-            end: 372,
-        },
-        original_span: Span {
-            start: 233,
-            end: 234,
         },
     },
     Mapping {
@@ -1212,21 +813,11 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 375,
-            end: 410,
+            end: 404,
         },
         original_span: Span {
             start: 222,
-            end: 243,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 376,
-            end: 379,
-        },
-        original_span: Span {
-            start: 223,
-            end: 226,
+            end: 236,
         },
     },
     Mapping {
@@ -1247,26 +838,6 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
         original_span: Span {
             start: 227,
             end: 235,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 380,
-            end: 403,
-        },
-        original_span: Span {
-            start: 227,
-            end: 235,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 380,
-            end: 391,
-        },
-        original_span: Span {
-            start: 227,
-            end: 231,
         },
     },
     Mapping {
@@ -1301,22 +872,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 392,
-            end: 403,
+            start: 404,
+            end: 410,
         },
         original_span: Span {
-            start: 232,
-            end: 235,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 406,
-            end: 409,
-        },
-        original_span: Span {
-            start: 239,
-            end: 242,
+            start: 237,
+            end: 243,
         },
     },
     Mapping {
@@ -1342,35 +903,35 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     Mapping {
         codegen_span: Span {
             start: 424,
-            end: 435,
+            end: 429,
         },
         original_span: Span {
             start: 246,
+            end: 251,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 425,
+            end: 428,
+        },
+        original_span: Span {
+            start: 247,
+            end: 250,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 429,
+            end: 435,
+        },
+        original_span: Span {
+            start: 252,
             end: 258,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 425,
-            end: 428,
-        },
-        original_span: Span {
-            start: 247,
-            end: 250,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 425,
-            end: 428,
-        },
-        original_span: Span {
-            start: 247,
-            end: 250,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 431,
             end: 434,
         },
@@ -1381,22 +942,12 @@ async()=>{<><template>{a?<><div v-if:__v___={undefined}></div></>:b?<><div v-els
     },
     Mapping {
         codegen_span: Span {
-            start: 431,
-            end: 434,
+            start: 435,
+            end: 446,
         },
         original_span: Span {
-            start: 254,
-            end: 257,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 437,
-            end: 445,
-        },
-        original_span: Span {
-            start: 261,
-            end: 269,
+            start: 259,
+            end: 270,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-slot_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/directive_v-slot_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -32,21 +33,11 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     Mapping {
         codegen_span: Span {
             start: 12,
-            end: 577,
+            end: 22,
         },
         original_span: Span {
             start: 0,
-            end: 411,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 13,
-            end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
+            end: 10,
         },
     },
     Mapping {
@@ -72,21 +63,11 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     Mapping {
         codegen_span: Span {
             start: 22,
-            end: 91,
+            end: 54,
         },
         original_span: Span {
             start: 13,
-            end: 42,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 23,
-            end: 27,
-        },
-        original_span: Span {
-            start: 14,
-            end: 18,
+            end: 35,
         },
     },
     Mapping {
@@ -107,26 +88,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 19,
             end: 34,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 28,
-            end: 53,
-        },
-        original_span: Span {
-            start: 19,
-            end: 34,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 28,
-            end: 41,
-        },
-        original_span: Span {
-            start: 19,
-            end: 20,
         },
     },
     Mapping {
@@ -171,16 +132,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 42,
-            end: 53,
-        },
-        original_span: Span {
-            start: 21,
-            end: 34,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 65,
             end: 74,
         },
@@ -201,26 +152,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 65,
-            end: 74,
-        },
-        original_span: Span {
-            start: 22,
-            end: 33,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 65,
-            end: 74,
-        },
-        original_span: Span {
-            start: 22,
-            end: 33,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 66,
             end: 73,
         },
@@ -231,32 +162,12 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 66,
-            end: 73,
+            start: 84,
+            end: 91,
         },
         original_span: Span {
-            start: 24,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 66,
-            end: 73,
-        },
-        original_span: Span {
-            start: 24,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 86,
-            end: 90,
-        },
-        original_span: Span {
-            start: 37,
-            end: 41,
+            start: 35,
+            end: 42,
         },
     },
     Mapping {
@@ -282,21 +193,11 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     Mapping {
         codegen_span: Span {
             start: 91,
-            end: 168,
+            end: 123,
         },
         original_span: Span {
             start: 45,
-            end: 101,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 92,
-            end: 96,
-        },
-        original_span: Span {
-            start: 46,
-            end: 50,
+            end: 73,
         },
     },
     Mapping {
@@ -317,26 +218,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 51,
             end: 72,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 97,
-            end: 122,
-        },
-        original_span: Span {
-            start: 51,
-            end: 72,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 97,
-            end: 110,
-        },
-        original_span: Span {
-            start: 51,
-            end: 58,
         },
     },
     Mapping {
@@ -381,26 +262,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 111,
-            end: 122,
-        },
-        original_span: Span {
-            start: 59,
-            end: 72,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 125,
-            end: 131,
-        },
-        original_span: Span {
-            start: 52,
-            end: 58,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 125,
             end: 131,
         },
@@ -431,46 +292,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 133,
-            end: 142,
-        },
-        original_span: Span {
-            start: 60,
-            end: 71,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 133,
-            end: 142,
-        },
-        original_span: Span {
-            start: 60,
-            end: 71,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 134,
-            end: 141,
-        },
-        original_span: Span {
-            start: 62,
-            end: 69,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 134,
-            end: 141,
-        },
-        original_span: Span {
-            start: 62,
-            end: 69,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 134,
             end: 141,
         },
@@ -491,16 +312,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 147,
-            end: 156,
-        },
-        original_span: Span {
-            start: 78,
-            end: 91,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 148,
             end: 155,
         },
@@ -511,32 +322,12 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 148,
-            end: 155,
+            start: 161,
+            end: 168,
         },
         original_span: Span {
-            start: 81,
-            end: 88,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 148,
-            end: 155,
-        },
-        original_span: Span {
-            start: 81,
-            end: 88,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 163,
-            end: 167,
-        },
-        original_span: Span {
-            start: 96,
-            end: 100,
+            start: 94,
+            end: 101,
         },
     },
     Mapping {
@@ -562,11 +353,11 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     Mapping {
         codegen_span: Span {
             start: 168,
-            end: 209,
+            end: 185,
         },
         original_span: Span {
             start: 104,
-            end: 133,
+            end: 121,
         },
     },
     Mapping {
@@ -577,46 +368,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 105,
             end: 109,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 169,
-            end: 173,
-        },
-        original_span: Span {
-            start: 105,
-            end: 109,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 174,
-            end: 184,
-        },
-        original_span: Span {
-            start: 110,
-            end: 120,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 174,
-            end: 184,
-        },
-        original_span: Span {
-            start: 110,
-            end: 120,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 174,
-            end: 184,
-        },
-        original_span: Span {
-            start: 110,
-            end: 120,
         },
     },
     Mapping {
@@ -661,22 +412,12 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 187,
-            end: 190,
+            start: 202,
+            end: 209,
         },
         original_span: Span {
-            start: 117,
-            end: 120,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 204,
-            end: 208,
-        },
-        original_span: Span {
-            start: 128,
-            end: 132,
+            start: 126,
+            end: 133,
         },
     },
     Mapping {
@@ -702,7 +443,7 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     Mapping {
         codegen_span: Span {
             start: 209,
-            end: 257,
+            end: 229,
         },
         original_span: Span {
             start: 136,
@@ -717,46 +458,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 137,
             end: 141,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 210,
-            end: 214,
-        },
-        original_span: Span {
-            start: 137,
-            end: 141,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 215,
-            end: 228,
-        },
-        original_span: Span {
-            start: 142,
-            end: 148,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 215,
-            end: 228,
-        },
-        original_span: Span {
-            start: 142,
-            end: 148,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 215,
-            end: 228,
-        },
-        original_span: Span {
-            start: 142,
-            end: 148,
         },
     },
     Mapping {
@@ -791,16 +492,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 252,
-            end: 256,
-        },
-        original_span: Span {
-            start: 137,
-            end: 141,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 257,
             end: 334,
         },
@@ -812,21 +503,11 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     Mapping {
         codegen_span: Span {
             start: 257,
-            end: 334,
+            end: 289,
         },
         original_span: Span {
             start: 154,
-            end: 216,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 258,
-            end: 262,
-        },
-        original_span: Span {
-            start: 155,
-            end: 159,
+            end: 188,
         },
     },
     Mapping {
@@ -847,26 +528,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 160,
             end: 187,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 263,
-            end: 288,
-        },
-        original_span: Span {
-            start: 160,
-            end: 187,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 263,
-            end: 276,
-        },
-        original_span: Span {
-            start: 160,
-            end: 173,
         },
     },
     Mapping {
@@ -911,26 +572,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 277,
-            end: 288,
-        },
-        original_span: Span {
-            start: 174,
-            end: 187,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 291,
-            end: 297,
-        },
-        original_span: Span {
-            start: 167,
-            end: 173,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 291,
             end: 297,
         },
@@ -961,46 +602,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 299,
-            end: 308,
-        },
-        original_span: Span {
-            start: 175,
-            end: 186,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 299,
-            end: 308,
-        },
-        original_span: Span {
-            start: 175,
-            end: 186,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 300,
-            end: 307,
-        },
-        original_span: Span {
-            start: 177,
-            end: 184,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 300,
-            end: 307,
-        },
-        original_span: Span {
-            start: 177,
-            end: 184,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 300,
             end: 307,
         },
@@ -1021,16 +622,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 313,
-            end: 322,
-        },
-        original_span: Span {
-            start: 193,
-            end: 206,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 314,
             end: 321,
         },
@@ -1041,32 +632,12 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 314,
-            end: 321,
+            start: 327,
+            end: 334,
         },
         original_span: Span {
-            start: 196,
-            end: 203,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 314,
-            end: 321,
-        },
-        original_span: Span {
-            start: 196,
-            end: 203,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 329,
-            end: 333,
-        },
-        original_span: Span {
-            start: 211,
-            end: 215,
+            start: 209,
+            end: 216,
         },
     },
     Mapping {
@@ -1092,21 +663,11 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     Mapping {
         codegen_span: Span {
             start: 334,
-            end: 412,
+            end: 366,
         },
         original_span: Span {
             start: 219,
-            end: 275,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 335,
-            end: 339,
-        },
-        original_span: Span {
-            start: 220,
-            end: 224,
+            end: 247,
         },
     },
     Mapping {
@@ -1127,26 +688,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 225,
             end: 246,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 340,
-            end: 365,
-        },
-        original_span: Span {
-            start: 225,
-            end: 246,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 340,
-            end: 353,
-        },
-        original_span: Span {
-            start: 225,
-            end: 232,
         },
     },
     Mapping {
@@ -1191,16 +732,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 354,
-            end: 365,
-        },
-        original_span: Span {
-            start: 233,
-            end: 246,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 377,
             end: 386,
         },
@@ -1217,46 +748,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 234,
             end: 245,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 377,
-            end: 386,
-        },
-        original_span: Span {
-            start: 234,
-            end: 245,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 377,
-            end: 386,
-        },
-        original_span: Span {
-            start: 234,
-            end: 245,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 378,
-            end: 385,
-        },
-        original_span: Span {
-            start: 236,
-            end: 243,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 378,
-            end: 385,
-        },
-        original_span: Span {
-            start: 236,
-            end: 243,
         },
     },
     Mapping {
@@ -1281,16 +772,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 391,
-            end: 400,
-        },
-        original_span: Span {
-            start: 252,
-            end: 265,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 392,
             end: 399,
         },
@@ -1301,32 +782,12 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 392,
-            end: 399,
+            start: 405,
+            end: 412,
         },
         original_span: Span {
-            start: 255,
-            end: 262,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 392,
-            end: 399,
-        },
-        original_span: Span {
-            start: 255,
-            end: 262,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 407,
-            end: 411,
-        },
-        original_span: Span {
-            start: 270,
-            end: 274,
+            start: 268,
+            end: 275,
         },
     },
     Mapping {
@@ -1352,21 +813,11 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     Mapping {
         codegen_span: Span {
             start: 412,
-            end: 492,
+            end: 448,
         },
         original_span: Span {
             start: 278,
-            end: 339,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 413,
-            end: 417,
-        },
-        original_span: Span {
-            start: 279,
-            end: 283,
+            end: 311,
         },
     },
     Mapping {
@@ -1387,26 +838,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 284,
             end: 310,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 418,
-            end: 447,
-        },
-        original_span: Span {
-            start: 284,
-            end: 310,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 418,
-            end: 435,
-        },
-        original_span: Span {
-            start: 284,
-            end: 296,
         },
     },
     Mapping {
@@ -1451,36 +882,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 436,
-            end: 447,
-        },
-        original_span: Span {
-            start: 297,
-            end: 310,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 451,
-            end: 454,
-        },
-        original_span: Span {
-            start: 292,
-            end: 295,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 451,
-            end: 454,
-        },
-        original_span: Span {
-            start: 292,
-            end: 295,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 451,
             end: 454,
         },
@@ -1511,46 +912,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 457,
-            end: 466,
-        },
-        original_span: Span {
-            start: 298,
-            end: 309,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 457,
-            end: 466,
-        },
-        original_span: Span {
-            start: 298,
-            end: 309,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 458,
-            end: 465,
-        },
-        original_span: Span {
-            start: 300,
-            end: 307,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 458,
-            end: 465,
-        },
-        original_span: Span {
-            start: 300,
-            end: 307,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 458,
             end: 465,
         },
@@ -1571,16 +932,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 471,
-            end: 480,
-        },
-        original_span: Span {
-            start: 316,
-            end: 329,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 472,
             end: 479,
         },
@@ -1591,32 +942,12 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 472,
-            end: 479,
+            start: 485,
+            end: 492,
         },
         original_span: Span {
-            start: 319,
-            end: 326,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 472,
-            end: 479,
-        },
-        original_span: Span {
-            start: 319,
-            end: 326,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 487,
-            end: 491,
-        },
-        original_span: Span {
-            start: 334,
-            end: 338,
+            start: 332,
+            end: 339,
         },
     },
     Mapping {
@@ -1642,21 +973,11 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     Mapping {
         codegen_span: Span {
             start: 492,
-            end: 566,
+            end: 524,
         },
         original_span: Span {
             start: 342,
-            end: 399,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 493,
-            end: 497,
-        },
-        original_span: Span {
-            start: 343,
-            end: 347,
+            end: 369,
         },
     },
     Mapping {
@@ -1677,26 +998,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 348,
             end: 368,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 498,
-            end: 523,
-        },
-        original_span: Span {
-            start: 348,
-            end: 368,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 498,
-            end: 511,
-        },
-        original_span: Span {
-            start: 348,
-            end: 361,
         },
     },
     Mapping {
@@ -1741,26 +1042,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 512,
-            end: 523,
-        },
-        original_span: Span {
-            start: 362,
-            end: 368,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 526,
-            end: 532,
-        },
-        original_span: Span {
-            start: 355,
-            end: 361,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 526,
             end: 532,
         },
@@ -1791,36 +1072,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 534,
-            end: 538,
-        },
-        original_span: Span {
-            start: 363,
-            end: 367,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 534,
-            end: 538,
-        },
-        original_span: Span {
-            start: 363,
-            end: 367,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 543,
-            end: 554,
-        },
-        original_span: Span {
-            start: 374,
-            end: 389,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 543,
             end: 554,
         },
@@ -1837,36 +1088,6 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
         original_span: Span {
             start: 377,
             end: 386,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 544,
-            end: 553,
-        },
-        original_span: Span {
-            start: 377,
-            end: 386,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 544,
-            end: 553,
-        },
-        original_span: Span {
-            start: 377,
-            end: 386,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 544,
-            end: 548,
-        },
-        original_span: Span {
-            start: 377,
-            end: 381,
         },
     },
     Mapping {
@@ -1891,12 +1112,12 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 561,
-            end: 565,
+            start: 559,
+            end: 566,
         },
         original_span: Span {
-            start: 394,
-            end: 398,
+            start: 392,
+            end: 399,
         },
     },
     Mapping {
@@ -1911,12 +1132,12 @@ async()=>{<><template><Comp v-slot:__v___={undefined}>{{default:({message})=><><
     },
     Mapping {
         codegen_span: Span {
-            start: 568,
-            end: 576,
+            start: 566,
+            end: 577,
         },
         original_span: Span {
-            start: 402,
-            end: 410,
+            start: 400,
+            end: 411,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/error_empty_multiple_scripts_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/error_empty_multiple_scripts_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -31,16 +32,6 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 0,
-            end: 9,
-        },
-        original_span: Span {
-            start: 9,
-            end: 21,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 5,
             end: 9,
         },
@@ -57,26 +48,6 @@ const a=1;async()=>{<><script></script><script></script></>};
         original_span: Span {
             start: 15,
             end: 16,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 5,
-            end: 7,
-        },
-        original_span: Span {
-            start: 15,
-            end: 16,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 8,
-            end: 9,
-        },
-        original_span: Span {
-            start: 19,
-            end: 20,
         },
     },
     Mapping {
@@ -102,45 +73,35 @@ const a=1;async()=>{<><script></script><script></script></>};
     Mapping {
         codegen_span: Span {
             start: 22,
-            end: 39,
+            end: 30,
         },
         original_span: Span {
             start: 0,
+            end: 8,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 23,
+            end: 29,
+        },
+        original_span: Span {
+            start: 1,
+            end: 7,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 30,
+            end: 39,
+        },
+        original_span: Span {
+            start: 22,
             end: 31,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 23,
-            end: 29,
-        },
-        original_span: Span {
-            start: 1,
-            end: 7,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 23,
-            end: 29,
-        },
-        original_span: Span {
-            start: 1,
-            end: 7,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 32,
-            end: 38,
-        },
-        original_span: Span {
-            start: 24,
-            end: 30,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 32,
             end: 38,
         },
@@ -162,41 +123,31 @@ const a=1;async()=>{<><script></script><script></script></>};
     Mapping {
         codegen_span: Span {
             start: 39,
-            end: 56,
+            end: 47,
         },
         original_span: Span {
             start: 33,
+            end: 41,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 40,
+            end: 46,
+        },
+        original_span: Span {
+            start: 34,
+            end: 40,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 47,
+            end: 56,
+        },
+        original_span: Span {
+            start: 43,
             end: 52,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 40,
-            end: 46,
-        },
-        original_span: Span {
-            start: 34,
-            end: 40,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 40,
-            end: 46,
-        },
-        original_span: Span {
-            start: 34,
-            end: 40,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 49,
-            end: 55,
-        },
-        original_span: Span {
-            start: 45,
-            end: 51,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/root_texts_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/root_texts_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -32,11 +33,11 @@ async()=>{<><template></template><script></script><script></script><style></styl
     Mapping {
         codegen_span: Span {
             start: 12,
-            end: 33,
+            end: 22,
         },
         original_span: Span {
             start: 0,
-            end: 21,
+            end: 10,
         },
     },
     Mapping {
@@ -51,22 +52,12 @@ async()=>{<><template></template><script></script><script></script><style></styl
     },
     Mapping {
         codegen_span: Span {
-            start: 13,
+            start: 22,
+            end: 33,
+        },
+        original_span: Span {
+            start: 10,
             end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 24,
-            end: 32,
-        },
-        original_span: Span {
-            start: 12,
-            end: 20,
         },
     },
     Mapping {
@@ -92,45 +83,35 @@ async()=>{<><template></template><script></script><script></script><style></styl
     Mapping {
         codegen_span: Span {
             start: 33,
-            end: 50,
+            end: 41,
         },
         original_span: Span {
             start: 21,
+            end: 29,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 34,
+            end: 40,
+        },
+        original_span: Span {
+            start: 22,
+            end: 28,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 41,
+            end: 50,
+        },
+        original_span: Span {
+            start: 29,
             end: 38,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 34,
-            end: 40,
-        },
-        original_span: Span {
-            start: 22,
-            end: 28,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 34,
-            end: 40,
-        },
-        original_span: Span {
-            start: 22,
-            end: 28,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 43,
-            end: 49,
-        },
-        original_span: Span {
-            start: 31,
-            end: 37,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 43,
             end: 49,
         },
@@ -152,41 +133,31 @@ async()=>{<><template></template><script></script><script></script><style></styl
     Mapping {
         codegen_span: Span {
             start: 50,
-            end: 67,
+            end: 58,
         },
         original_span: Span {
             start: 54,
+            end: 62,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 51,
+            end: 57,
+        },
+        original_span: Span {
+            start: 55,
+            end: 61,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 58,
+            end: 67,
+        },
+        original_span: Span {
+            start: 62,
             end: 71,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 57,
-        },
-        original_span: Span {
-            start: 55,
-            end: 61,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 57,
-        },
-        original_span: Span {
-            start: 55,
-            end: 61,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 60,
-            end: 66,
-        },
-        original_span: Span {
-            start: 64,
-            end: 70,
         },
     },
     Mapping {
@@ -212,41 +183,31 @@ async()=>{<><template></template><script></script><script></script><style></styl
     Mapping {
         codegen_span: Span {
             start: 67,
-            end: 82,
+            end: 74,
         },
         original_span: Span {
             start: 102,
+            end: 109,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 68,
+            end: 73,
+        },
+        original_span: Span {
+            start: 103,
+            end: 108,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 74,
+            end: 82,
+        },
+        original_span: Span {
+            start: 109,
             end: 117,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 68,
-            end: 73,
-        },
-        original_span: Span {
-            start: 103,
-            end: 108,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 68,
-            end: 73,
-        },
-        original_span: Span {
-            start: 103,
-            end: 108,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 76,
-            end: 81,
-        },
-        original_span: Span {
-            start: 111,
-            end: 116,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_basic_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -31,32 +32,12 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 0,
-            end: 13,
-        },
-        original_span: Span {
-            start: 55,
-            end: 70,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 5,
             end: 13,
         },
         original_span: Span {
             start: 61,
             end: 70,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 5,
-            end: 11,
-        },
-        original_span: Span {
-            start: 61,
-            end: 66,
         },
     },
     Mapping {
@@ -81,51 +62,11 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 12,
-            end: 13,
-        },
-        original_span: Span {
-            start: 69,
-            end: 70,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 14,
             end: 52,
         },
         original_span: Span {
             start: 72,
-            end: 136,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 14,
-            end: 52,
-        },
-        original_span: Span {
-            start: 72,
-            end: 136,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 29,
-            end: 52,
-        },
-        original_span: Span {
-            start: 87,
-            end: 136,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 29,
-            end: 52,
-        },
-        original_span: Span {
-            start: 87,
             end: 136,
         },
     },
@@ -147,26 +88,6 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
         original_span: Span {
             start: 91,
             end: 134,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 30,
-            end: 51,
-        },
-        original_span: Span {
-            start: 91,
-            end: 134,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 30,
-            end: 34,
-        },
-        original_span: Span {
-            start: 91,
-            end: 95,
         },
     },
     Mapping {
@@ -211,62 +132,12 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 37,
-            end: 50,
-        },
-        original_span: Span {
-            start: 104,
-            end: 130,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 43,
             end: 50,
         },
         original_span: Span {
             start: 111,
             end: 130,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 43,
-            end: 50,
-        },
-        original_span: Span {
-            start: 111,
-            end: 130,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 44,
-            end: 49,
-        },
-        original_span: Span {
-            start: 119,
-            end: 124,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 44,
-            end: 49,
-        },
-        original_span: Span {
-            start: 119,
-            end: 124,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 44,
-            end: 49,
-        },
-        original_span: Span {
-            start: 119,
-            end: 124,
         },
     },
     Mapping {
@@ -292,105 +163,85 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     Mapping {
         codegen_span: Span {
             start: 65,
-            end: 97,
+            end: 75,
         },
         original_span: Span {
             start: 0,
+            end: 10,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 66,
+            end: 74,
+        },
+        original_span: Span {
+            start: 1,
+            end: 9,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 75,
+            end: 86,
+        },
+        original_span: Span {
+            start: 13,
+            end: 32,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 75,
+            end: 80,
+        },
+        original_span: Span {
+            start: 13,
+            end: 18,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 76,
+            end: 79,
+        },
+        original_span: Span {
+            start: 14,
+            end: 17,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 80,
+            end: 86,
+        },
+        original_span: Span {
+            start: 26,
+            end: 32,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 82,
+            end: 85,
+        },
+        original_span: Span {
+            start: 28,
+            end: 31,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 86,
+            end: 97,
+        },
+        original_span: Span {
+            start: 33,
             end: 44,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 66,
-            end: 74,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 66,
-            end: 74,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 75,
-            end: 86,
-        },
-        original_span: Span {
-            start: 13,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 75,
-            end: 86,
-        },
-        original_span: Span {
-            start: 13,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 76,
-            end: 79,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 76,
-            end: 79,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 82,
-            end: 85,
-        },
-        original_span: Span {
-            start: 28,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 82,
-            end: 85,
-        },
-        original_span: Span {
-            start: 28,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 88,
-            end: 96,
-        },
-        original_span: Span {
-            start: 35,
-            end: 43,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 88,
             end: 96,
         },
@@ -412,41 +263,31 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     Mapping {
         codegen_span: Span {
             start: 97,
-            end: 114,
+            end: 105,
         },
         original_span: Span {
             start: 46,
+            end: 54,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 98,
+            end: 104,
+        },
+        original_span: Span {
+            start: 47,
+            end: 53,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 105,
+            end: 114,
+        },
+        original_span: Span {
+            start: 137,
             end: 146,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 98,
-            end: 104,
-        },
-        original_span: Span {
-            start: 47,
-            end: 53,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 98,
-            end: 104,
-        },
-        original_span: Span {
-            start: 47,
-            end: 53,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 107,
-            end: 113,
-        },
-        original_span: Span {
-            start: 139,
-            end: 145,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_both_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_both_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -31,42 +32,12 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 0,
-            end: 20,
-        },
-        original_span: Span {
-            start: 61,
-            end: 87,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 7,
             end: 10,
         },
         original_span: Span {
             start: 70,
             end: 73,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 7,
-            end: 10,
-        },
-        original_span: Span {
-            start: 70,
-            end: 73,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 21,
-            end: 34,
-        },
-        original_span: Span {
-            start: 133,
-            end: 149,
         },
     },
     Mapping {
@@ -101,26 +72,6 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 26,
-            end: 32,
-        },
-        original_span: Span {
-            start: 139,
-            end: 144,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 33,
-            end: 34,
-        },
-        original_span: Span {
-            start: 147,
-            end: 148,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 33,
             end: 34,
         },
@@ -136,36 +87,6 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
         },
         original_span: Span {
             start: 151,
-            end: 216,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 35,
-            end: 73,
-        },
-        original_span: Span {
-            start: 151,
-            end: 216,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 50,
-            end: 73,
-        },
-        original_span: Span {
-            start: 166,
-            end: 216,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 50,
-            end: 73,
-        },
-        original_span: Span {
-            start: 166,
             end: 216,
         },
     },
@@ -187,26 +108,6 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
         original_span: Span {
             start: 170,
             end: 214,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 72,
-        },
-        original_span: Span {
-            start: 170,
-            end: 214,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 55,
-        },
-        original_span: Span {
-            start: 170,
-            end: 174,
         },
     },
     Mapping {
@@ -251,26 +152,6 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 58,
-            end: 71,
-        },
-        original_span: Span {
-            start: 183,
-            end: 210,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 64,
-            end: 71,
-        },
-        original_span: Span {
-            start: 190,
-            end: 210,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 64,
             end: 71,
         },
@@ -287,46 +168,6 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
         original_span: Span {
             start: 198,
             end: 203,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 65,
-            end: 70,
-        },
-        original_span: Span {
-            start: 198,
-            end: 203,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 65,
-            end: 70,
-        },
-        original_span: Span {
-            start: 198,
-            end: 203,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 65,
-            end: 70,
-        },
-        original_span: Span {
-            start: 198,
-            end: 203,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 84,
-            end: 104,
-        },
-        original_span: Span {
-            start: 89,
-            end: 112,
         },
     },
     Mapping {
@@ -361,26 +202,6 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 89,
-            end: 96,
-        },
-        original_span: Span {
-            start: 95,
-            end: 101,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 97,
-            end: 104,
-        },
-        original_span: Span {
-            start: 104,
-            end: 111,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 97,
             end: 104,
         },
@@ -401,51 +222,11 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 97,
-            end: 100,
-        },
-        original_span: Span {
-            start: 104,
-            end: 107,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 101,
             end: 103,
         },
         original_span: Span {
             start: 108,
-            end: 110,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 101,
-            end: 103,
-        },
-        original_span: Span {
-            start: 108,
-            end: 110,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 101,
-            end: 103,
-        },
-        original_span: Span {
-            start: 108,
-            end: 110,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 102,
-            end: 103,
-        },
-        original_span: Span {
-            start: 109,
             end: 110,
         },
     },
@@ -472,105 +253,85 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     Mapping {
         codegen_span: Span {
             start: 107,
-            end: 139,
+            end: 117,
         },
         original_span: Span {
             start: 0,
+            end: 10,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 108,
+            end: 116,
+        },
+        original_span: Span {
+            start: 1,
+            end: 9,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 117,
+            end: 128,
+        },
+        original_span: Span {
+            start: 13,
+            end: 32,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 117,
+            end: 122,
+        },
+        original_span: Span {
+            start: 13,
+            end: 18,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 118,
+            end: 121,
+        },
+        original_span: Span {
+            start: 14,
+            end: 17,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 122,
+            end: 128,
+        },
+        original_span: Span {
+            start: 26,
+            end: 32,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 124,
+            end: 127,
+        },
+        original_span: Span {
+            start: 28,
+            end: 31,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 128,
+            end: 139,
+        },
+        original_span: Span {
+            start: 33,
             end: 44,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 108,
-            end: 116,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 108,
-            end: 116,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 117,
-            end: 128,
-        },
-        original_span: Span {
-            start: 13,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 117,
-            end: 128,
-        },
-        original_span: Span {
-            start: 13,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 118,
-            end: 121,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 118,
-            end: 121,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 124,
-            end: 127,
-        },
-        original_span: Span {
-            start: 28,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 124,
-            end: 127,
-        },
-        original_span: Span {
-            start: 28,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 130,
-            end: 138,
-        },
-        original_span: Span {
-            start: 35,
-            end: 43,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 130,
             end: 138,
         },
@@ -592,21 +353,11 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     Mapping {
         codegen_span: Span {
             start: 139,
-            end: 162,
+            end: 153,
         },
         original_span: Span {
             start: 46,
-            end: 122,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 140,
-            end: 146,
-        },
-        original_span: Span {
-            start: 47,
-            end: 53,
+            end: 60,
         },
     },
     Mapping {
@@ -631,42 +382,12 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 147,
-            end: 152,
+            start: 153,
+            end: 162,
         },
         original_span: Span {
-            start: 54,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 147,
-            end: 152,
-        },
-        original_span: Span {
-            start: 54,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 147,
-            end: 152,
-        },
-        original_span: Span {
-            start: 54,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 155,
-            end: 161,
-        },
-        original_span: Span {
-            start: 115,
-            end: 121,
+            start: 113,
+            end: 122,
         },
     },
     Mapping {
@@ -692,41 +413,31 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     Mapping {
         codegen_span: Span {
             start: 162,
-            end: 179,
+            end: 170,
         },
         original_span: Span {
             start: 124,
+            end: 132,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 163,
+            end: 169,
+        },
+        original_span: Span {
+            start: 125,
+            end: 131,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 170,
+            end: 179,
+        },
+        original_span: Span {
+            start: 217,
             end: 226,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 163,
-            end: 169,
-        },
-        original_span: Span {
-            start: 125,
-            end: 131,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 163,
-            end: 169,
-        },
-        original_span: Span {
-            start: 125,
-            end: 131,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 172,
-            end: 178,
-        },
-        original_span: Span {
-            start: 219,
-            end: 225,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_codegen_fidelity_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_codegen_fidelity_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -27,26 +28,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
         original_span: Span {
             start: 20,
             end: 66,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 0,
-            end: 40,
-        },
-        original_span: Span {
-            start: 20,
-            end: 66,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 7,
-            end: 10,
-        },
-        original_span: Span {
-            start: 29,
-            end: 32,
         },
     },
     Mapping {
@@ -81,16 +62,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 18,
-            end: 21,
-        },
-        original_span: Span {
-            start: 41,
-            end: 44,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 25,
             end: 28,
         },
@@ -111,16 +82,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 41,
-            end: 59,
-        },
-        original_span: Span {
-            start: 67,
-            end: 88,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 48,
             end: 58,
         },
@@ -141,42 +102,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 48,
-            end: 51,
-        },
-        original_span: Span {
-            start: 76,
-            end: 79,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 55,
             end: 58,
         },
         original_span: Span {
             start: 83,
             end: 86,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 55,
-            end: 58,
-        },
-        original_span: Span {
-            start: 83,
-            end: 86,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 60,
-            end: 77,
-        },
-        original_span: Span {
-            start: 90,
-            end: 109,
         },
     },
     Mapping {
@@ -211,42 +142,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 65,
-            end: 73,
-        },
-        original_span: Span {
-            start: 96,
-            end: 103,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 74,
             end: 77,
         },
         original_span: Span {
             start: 106,
             end: 109,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 74,
-            end: 77,
-        },
-        original_span: Span {
-            start: 106,
-            end: 109,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 78,
-            end: 103,
-        },
-        original_span: Span {
-            start: 110,
-            end: 137,
         },
     },
     Mapping {
@@ -281,42 +182,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 83,
-            end: 93,
-        },
-        original_span: Span {
-            start: 116,
-            end: 125,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 94,
             end: 103,
         },
         original_span: Span {
             start: 128,
             end: 137,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 94,
-            end: 103,
-        },
-        original_span: Span {
-            start: 128,
-            end: 137,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 104,
-            end: 118,
-        },
-        original_span: Span {
-            start: 138,
-            end: 154,
         },
     },
     Mapping {
@@ -351,42 +222,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 109,
-            end: 113,
-        },
-        original_span: Span {
-            start: 144,
-            end: 147,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 114,
             end: 118,
         },
         original_span: Span {
             start: 150,
             end: 154,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 114,
-            end: 118,
-        },
-        original_span: Span {
-            start: 150,
-            end: 154,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 119,
-            end: 138,
-        },
-        original_span: Span {
-            start: 155,
-            end: 176,
         },
     },
     Mapping {
@@ -421,42 +262,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 124,
-            end: 131,
-        },
-        original_span: Span {
-            start: 161,
-            end: 167,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 132,
             end: 138,
         },
         original_span: Span {
             start: 170,
             end: 176,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 132,
-            end: 138,
-        },
-        original_span: Span {
-            start: 170,
-            end: 176,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 139,
-            end: 157,
-        },
-        original_span: Span {
-            start: 177,
-            end: 197,
         },
     },
     Mapping {
@@ -491,42 +302,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 144,
-            end: 151,
-        },
-        original_span: Span {
-            start: 183,
-            end: 189,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 152,
             end: 157,
         },
         original_span: Span {
             start: 192,
             end: 197,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 152,
-            end: 157,
-        },
-        original_span: Span {
-            start: 192,
-            end: 197,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 158,
-            end: 178,
-        },
-        original_span: Span {
-            start: 198,
-            end: 220,
         },
     },
     Mapping {
@@ -561,42 +342,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 163,
-            end: 171,
-        },
-        original_span: Span {
-            start: 204,
-            end: 211,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 172,
             end: 178,
         },
         original_span: Span {
             start: 214,
             end: 220,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 172,
-            end: 178,
-        },
-        original_span: Span {
-            start: 214,
-            end: 220,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 179,
-            end: 223,
-        },
-        original_span: Span {
-            start: 221,
-            end: 268,
         },
     },
     Mapping {
@@ -631,26 +382,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 184,
-            end: 190,
-        },
-        original_span: Span {
-            start: 227,
-            end: 232,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 191,
-            end: 223,
-        },
-        original_span: Span {
-            start: 235,
-            end: 268,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 191,
             end: 223,
         },
@@ -667,26 +398,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
         original_span: Span {
             start: 236,
             end: 239,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 192,
-            end: 195,
-        },
-        original_span: Span {
-            start: 236,
-            end: 239,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 196,
-            end: 210,
-        },
-        original_span: Span {
-            start: 240,
-            end: 254,
         },
     },
     Mapping {
@@ -711,26 +422,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 196,
-            end: 201,
-        },
-        original_span: Span {
-            start: 240,
-            end: 245,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 202,
-            end: 210,
-        },
-        original_span: Span {
-            start: 246,
-            end: 254,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 202,
             end: 210,
         },
@@ -751,52 +442,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 203,
-            end: 209,
-        },
-        original_span: Span {
-            start: 247,
-            end: 253,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 203,
-            end: 209,
-        },
-        original_span: Span {
-            start: 247,
-            end: 253,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 211,
             end: 221,
         },
         original_span: Span {
             start: 255,
             end: 265,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 211,
-            end: 221,
-        },
-        original_span: Span {
-            start: 255,
-            end: 265,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 211,
-            end: 214,
-        },
-        original_span: Span {
-            start: 255,
-            end: 258,
         },
     },
     Mapping {
@@ -831,16 +482,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 224,
-            end: 245,
-        },
-        original_span: Span {
-            start: 269,
-            end: 296,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 229,
             end: 245,
         },
@@ -861,42 +502,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 229,
-            end: 237,
-        },
-        original_span: Span {
-            start: 275,
-            end: 282,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 238,
             end: 245,
         },
         original_span: Span {
             start: 285,
             end: 296,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 238,
-            end: 245,
-        },
-        original_span: Span {
-            start: 285,
-            end: 296,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 238,
-            end: 243,
-        },
-        original_span: Span {
-            start: 285,
-            end: 292,
         },
     },
     Mapping {
@@ -922,41 +533,11 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     Mapping {
         codegen_span: Span {
             start: 239,
-            end: 242,
-        },
-        original_span: Span {
-            start: 286,
-            end: 291,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 239,
             end: 240,
         },
         original_span: Span {
             start: 286,
             end: 287,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 239,
-            end: 240,
-        },
-        original_span: Span {
-            start: 286,
-            end: 287,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 241,
-            end: 242,
-        },
-        original_span: Span {
-            start: 290,
-            end: 291,
         },
     },
     Mapping {
@@ -977,26 +558,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
         original_span: Span {
             start: 295,
             end: 296,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 244,
-            end: 245,
-        },
-        original_span: Span {
-            start: 295,
-            end: 296,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 246,
-            end: 282,
-        },
-        original_span: Span {
-            start: 297,
-            end: 340,
         },
     },
     Mapping {
@@ -1031,42 +592,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 251,
-            end: 258,
-        },
-        original_span: Span {
-            start: 303,
-            end: 309,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 259,
             end: 282,
         },
         original_span: Span {
             start: 312,
             end: 340,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 259,
-            end: 282,
-        },
-        original_span: Span {
-            start: 312,
-            end: 340,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 260,
-            end: 267,
-        },
-        original_span: Span {
-            start: 314,
-            end: 322,
         },
     },
     Mapping {
@@ -1091,42 +622,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 260,
-            end: 263,
-        },
-        original_span: Span {
-            start: 314,
-            end: 317,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 264,
             end: 267,
         },
         original_span: Span {
             start: 319,
             end: 322,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 264,
-            end: 267,
-        },
-        original_span: Span {
-            start: 319,
-            end: 322,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 268,
-            end: 281,
-        },
-        original_span: Span {
-            start: 324,
-            end: 338,
         },
     },
     Mapping {
@@ -1151,26 +652,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 268,
-            end: 275,
-        },
-        original_span: Span {
-            start: 324,
-            end: 331,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 276,
-            end: 281,
-        },
-        original_span: Span {
-            start: 333,
-            end: 338,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 276,
             end: 281,
         },
@@ -1187,26 +668,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
         original_span: Span {
             start: 334,
             end: 337,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 277,
-            end: 280,
-        },
-        original_span: Span {
-            start: 334,
-            end: 337,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 283,
-            end: 314,
-        },
-        original_span: Span {
-            start: 341,
-            end: 382,
         },
     },
     Mapping {
@@ -1241,16 +702,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 288,
-            end: 307,
-        },
-        original_span: Span {
-            start: 347,
-            end: 373,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 289,
             end: 296,
         },
@@ -1267,26 +718,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
         original_span: Span {
             start: 349,
             end: 352,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 289,
-            end: 292,
-        },
-        original_span: Span {
-            start: 349,
-            end: 352,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 293,
-            end: 296,
-        },
-        original_span: Span {
-            start: 354,
-            end: 357,
         },
     },
     Mapping {
@@ -1321,42 +752,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 297,
-            end: 300,
-        },
-        original_span: Span {
-            start: 359,
-            end: 362,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 301,
             end: 306,
         },
         original_span: Span {
             start: 364,
             end: 371,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 301,
-            end: 306,
-        },
-        original_span: Span {
-            start: 364,
-            end: 371,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 301,
-            end: 304,
-        },
-        original_span: Span {
-            start: 364,
-            end: 367,
         },
     },
     Mapping {
@@ -1381,42 +782,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 305,
-            end: 306,
-        },
-        original_span: Span {
-            start: 370,
-            end: 371,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 308,
             end: 314,
         },
         original_span: Span {
             start: 376,
             end: 382,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 308,
-            end: 314,
-        },
-        original_span: Span {
-            start: 376,
-            end: 382,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 315,
-            end: 333,
-        },
-        original_span: Span {
-            start: 383,
-            end: 405,
         },
     },
     Mapping {
@@ -1447,26 +818,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
         original_span: Span {
             start: 389,
             end: 394,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 320,
-            end: 326,
-        },
-        original_span: Span {
-            start: 389,
-            end: 394,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 327,
-            end: 333,
-        },
-        original_span: Span {
-            start: 397,
-            end: 405,
         },
     },
     Mapping {
@@ -1501,52 +852,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 328,
-            end: 329,
-        },
-        original_span: Span {
-            start: 398,
-            end: 399,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 328,
-            end: 329,
-        },
-        original_span: Span {
-            start: 398,
-            end: 399,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 332,
             end: 333,
         },
         original_span: Span {
             start: 404,
             end: 405,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 332,
-            end: 333,
-        },
-        original_span: Span {
-            start: 404,
-            end: 405,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 334,
-            end: 358,
-        },
-        original_span: Span {
-            start: 406,
-            end: 432,
         },
     },
     Mapping {
@@ -1581,42 +892,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 339,
-            end: 348,
-        },
-        original_span: Span {
-            start: 412,
-            end: 420,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 349,
             end: 358,
         },
         original_span: Span {
             start: 423,
             end: 432,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 349,
-            end: 358,
-        },
-        original_span: Span {
-            start: 423,
-            end: 432,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 352,
-            end: 356,
-        },
-        original_span: Span {
-            start: 427,
-            end: 430,
         },
     },
     Mapping {
@@ -1642,21 +923,11 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     Mapping {
         codegen_span: Span {
             start: 371,
-            end: 399,
+            end: 390,
         },
         original_span: Span {
             start: 0,
-            end: 442,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 372,
-            end: 378,
-        },
-        original_span: Span {
-            start: 1,
-            end: 7,
+            end: 19,
         },
     },
     Mapping {
@@ -1677,26 +948,6 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
         original_span: Span {
             start: 8,
             end: 18,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 379,
-            end: 389,
-        },
-        original_span: Span {
-            start: 8,
-            end: 18,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 379,
-            end: 383,
-        },
-        original_span: Span {
-            start: 8,
-            end: 12,
         },
     },
     Mapping {
@@ -1721,12 +972,12 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 392,
-            end: 398,
+            start: 390,
+            end: 399,
         },
         original_span: Span {
-            start: 435,
-            end: 441,
+            start: 433,
+            end: 442,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_directives_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_directives_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -52,45 +53,35 @@ expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n
     Mapping {
         codegen_span: Span {
             start: 38,
-            end: 55,
+            end: 46,
         },
         original_span: Span {
             start: 0,
+            end: 8,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 39,
+            end: 45,
+        },
+        original_span: Span {
+            start: 1,
+            end: 7,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 46,
+            end: 55,
+        },
+        original_span: Span {
+            start: 23,
             end: 32,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 39,
-            end: 45,
-        },
-        original_span: Span {
-            start: 1,
-            end: 7,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 39,
-            end: 45,
-        },
-        original_span: Span {
-            start: 1,
-            end: 7,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 48,
-            end: 54,
-        },
-        original_span: Span {
-            start: 25,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 48,
             end: 54,
         },
@@ -112,21 +103,11 @@ expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n
     Mapping {
         codegen_span: Span {
             start: 55,
-            end: 78,
+            end: 69,
         },
         original_span: Span {
             start: 34,
-            end: 72,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 56,
-            end: 62,
-        },
-        original_span: Span {
-            start: 35,
-            end: 41,
+            end: 48,
         },
     },
     Mapping {
@@ -151,42 +132,12 @@ expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n
     },
     Mapping {
         codegen_span: Span {
+            start: 69,
+            end: 78,
+        },
+        original_span: Span {
             start: 63,
-            end: 68,
-        },
-        original_span: Span {
-            start: 42,
-            end: 47,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 63,
-            end: 68,
-        },
-        original_span: Span {
-            start: 42,
-            end: 47,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 63,
-            end: 68,
-        },
-        original_span: Span {
-            start: 42,
-            end: 47,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 71,
-            end: 77,
-        },
-        original_span: Span {
-            start: 65,
-            end: 71,
+            end: 72,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_empty_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_empty_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -32,105 +33,85 @@ async()=>{<><template><div></div></template><script setup></script><script></scr
     Mapping {
         codegen_span: Span {
             start: 12,
-            end: 44,
+            end: 22,
         },
         original_span: Span {
             start: 0,
+            end: 10,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 13,
+            end: 21,
+        },
+        original_span: Span {
+            start: 1,
+            end: 9,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 22,
+            end: 33,
+        },
+        original_span: Span {
+            start: 13,
+            end: 32,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 22,
+            end: 27,
+        },
+        original_span: Span {
+            start: 13,
+            end: 18,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 23,
+            end: 26,
+        },
+        original_span: Span {
+            start: 14,
+            end: 17,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 27,
+            end: 33,
+        },
+        original_span: Span {
+            start: 26,
+            end: 32,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 29,
+            end: 32,
+        },
+        original_span: Span {
+            start: 28,
+            end: 31,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 33,
+            end: 44,
+        },
+        original_span: Span {
+            start: 33,
             end: 44,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 13,
-            end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 13,
-            end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 22,
-            end: 33,
-        },
-        original_span: Span {
-            start: 13,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 22,
-            end: 33,
-        },
-        original_span: Span {
-            start: 13,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 23,
-            end: 26,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 23,
-            end: 26,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 29,
-            end: 32,
-        },
-        original_span: Span {
-            start: 28,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 29,
-            end: 32,
-        },
-        original_span: Span {
-            start: 28,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 35,
-            end: 43,
-        },
-        original_span: Span {
-            start: 35,
-            end: 43,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 35,
             end: 43,
         },
@@ -152,21 +133,11 @@ async()=>{<><template><div></div></template><script setup></script><script></scr
     Mapping {
         codegen_span: Span {
             start: 44,
-            end: 67,
+            end: 58,
         },
         original_span: Span {
             start: 46,
-            end: 69,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 45,
-            end: 51,
-        },
-        original_span: Span {
-            start: 47,
-            end: 53,
+            end: 60,
         },
     },
     Mapping {
@@ -191,42 +162,12 @@ async()=>{<><template><div></div></template><script setup></script><script></scr
     },
     Mapping {
         codegen_span: Span {
-            start: 52,
-            end: 57,
+            start: 58,
+            end: 67,
         },
         original_span: Span {
-            start: 54,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 52,
-            end: 57,
-        },
-        original_span: Span {
-            start: 54,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 52,
-            end: 57,
-        },
-        original_span: Span {
-            start: 54,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 60,
-            end: 66,
-        },
-        original_span: Span {
-            start: 62,
-            end: 68,
+            end: 69,
         },
     },
     Mapping {
@@ -252,41 +193,31 @@ async()=>{<><template><div></div></template><script setup></script><script></scr
     Mapping {
         codegen_span: Span {
             start: 67,
-            end: 84,
+            end: 75,
         },
         original_span: Span {
             start: 71,
+            end: 79,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 68,
+            end: 74,
+        },
+        original_span: Span {
+            start: 72,
+            end: 78,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 75,
+            end: 84,
+        },
+        original_span: Span {
+            start: 79,
             end: 88,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 68,
-            end: 74,
-        },
-        original_span: Span {
-            start: 72,
-            end: 78,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 68,
-            end: 74,
-        },
-        original_span: Span {
-            start: 72,
-            end: 78,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 77,
-            end: 83,
-        },
-        original_span: Span {
-            start: 81,
-            end: 87,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_mapping_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_mapping_vue.snap
@@ -26,36 +26,6 @@ expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n
         },
         original_span: Span {
             start: 9,
-            end: 11,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 0,
-            end: 1,
-        },
-        original_span: Span {
-            start: 9,
-            end: 11,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 0,
-            end: 1,
-        },
-        original_span: Span {
-            start: 9,
-            end: 10,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 0,
-            end: 1,
-        },
-        original_span: Span {
-            start: 9,
             end: 10,
         },
     },
@@ -72,11 +42,11 @@ expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n
     Mapping {
         codegen_span: Span {
             start: 14,
-            end: 31,
+            end: 22,
         },
         original_span: Span {
             start: 0,
-            end: 21,
+            end: 8,
         },
     },
     Mapping {
@@ -91,22 +61,12 @@ expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n
     },
     Mapping {
         codegen_span: Span {
-            start: 15,
+            start: 22,
+            end: 31,
+        },
+        original_span: Span {
+            start: 12,
             end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 7,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 24,
-            end: 30,
-        },
-        original_span: Span {
-            start: 14,
-            end: 20,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_setup_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_setup_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -31,42 +32,12 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 0,
-            end: 20,
-        },
-        original_span: Span {
-            start: 61,
-            end: 86,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 7,
             end: 10,
         },
         original_span: Span {
             start: 70,
             end: 73,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 7,
-            end: 10,
-        },
-        original_span: Span {
-            start: 70,
-            end: 73,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 31,
-            end: 49,
-        },
-        original_span: Span {
-            start: 88,
-            end: 108,
         },
     },
     Mapping {
@@ -101,26 +72,6 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 36,
-            end: 42,
-        },
-        original_span: Span {
-            start: 94,
-            end: 99,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 43,
-            end: 49,
-        },
-        original_span: Span {
-            start: 102,
-            end: 108,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 43,
             end: 49,
         },
@@ -137,36 +88,6 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
         original_span: Span {
             start: 102,
             end: 105,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 43,
-            end: 46,
-        },
-        original_span: Span {
-            start: 102,
-            end: 105,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 47,
-            end: 48,
-        },
-        original_span: Span {
-            start: 106,
-            end: 107,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 47,
-            end: 48,
-        },
-        original_span: Span {
-            start: 106,
-            end: 107,
         },
     },
     Mapping {
@@ -192,105 +113,85 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     Mapping {
         codegen_span: Span {
             start: 52,
-            end: 84,
+            end: 62,
         },
         original_span: Span {
             start: 0,
+            end: 10,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 53,
+            end: 61,
+        },
+        original_span: Span {
+            start: 1,
+            end: 9,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 62,
+            end: 73,
+        },
+        original_span: Span {
+            start: 13,
+            end: 32,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 62,
+            end: 67,
+        },
+        original_span: Span {
+            start: 13,
+            end: 18,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 63,
+            end: 66,
+        },
+        original_span: Span {
+            start: 14,
+            end: 17,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 67,
+            end: 73,
+        },
+        original_span: Span {
+            start: 26,
+            end: 32,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 69,
+            end: 72,
+        },
+        original_span: Span {
+            start: 28,
+            end: 31,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 73,
+            end: 84,
+        },
+        original_span: Span {
+            start: 33,
             end: 44,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 53,
-            end: 61,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 53,
-            end: 61,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 62,
-            end: 73,
-        },
-        original_span: Span {
-            start: 13,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 62,
-            end: 73,
-        },
-        original_span: Span {
-            start: 13,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 63,
-            end: 66,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 63,
-            end: 66,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 69,
-            end: 72,
-        },
-        original_span: Span {
-            start: 28,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 69,
-            end: 72,
-        },
-        original_span: Span {
-            start: 28,
-            end: 31,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 75,
-            end: 83,
-        },
-        original_span: Span {
-            start: 35,
-            end: 43,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 75,
             end: 83,
         },
@@ -312,21 +213,11 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     Mapping {
         codegen_span: Span {
             start: 84,
-            end: 107,
+            end: 98,
         },
         original_span: Span {
             start: 46,
-            end: 118,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 85,
-            end: 91,
-        },
-        original_span: Span {
-            start: 47,
-            end: 53,
+            end: 60,
         },
     },
     Mapping {
@@ -351,42 +242,12 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 92,
-            end: 97,
+            start: 98,
+            end: 107,
         },
         original_span: Span {
-            start: 54,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 92,
-            end: 97,
-        },
-        original_span: Span {
-            start: 54,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 92,
-            end: 97,
-        },
-        original_span: Span {
-            start: 54,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 100,
-            end: 106,
-        },
-        original_span: Span {
-            start: 111,
-            end: 117,
+            start: 109,
+            end: 118,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/tags_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/tags_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -32,21 +33,11 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     Mapping {
         codegen_span: Span {
             start: 12,
-            end: 131,
+            end: 22,
         },
         original_span: Span {
             start: 0,
-            end: 140,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 13,
-            end: 21,
-        },
-        original_span: Span {
-            start: 1,
-            end: 9,
+            end: 10,
         },
     },
     Mapping {
@@ -72,61 +63,31 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     Mapping {
         codegen_span: Span {
             start: 22,
-            end: 43,
+            end: 37,
         },
         original_span: Span {
             start: 13,
-            end: 46,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 23,
-            end: 26,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 23,
-            end: 26,
-        },
-        original_span: Span {
-            start: 14,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 27,
-            end: 36,
-        },
-        original_span: Span {
-            start: 18,
-            end: 27,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 27,
-            end: 36,
-        },
-        original_span: Span {
-            start: 18,
-            end: 27,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 27,
             end: 32,
         },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 23,
+            end: 26,
+        },
+        original_span: Span {
+            start: 14,
+            end: 17,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 27,
+            end: 36,
+        },
         original_span: Span {
             start: 18,
-            end: 23,
+            end: 27,
         },
     },
     Mapping {
@@ -151,12 +112,12 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     },
     Mapping {
         codegen_span: Span {
-            start: 39,
-            end: 42,
+            start: 37,
+            end: 43,
         },
         original_span: Span {
-            start: 34,
-            end: 37,
+            start: 32,
+            end: 46,
         },
     },
     Mapping {
@@ -182,45 +143,35 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     Mapping {
         codegen_span: Span {
             start: 43,
-            end: 54,
+            end: 48,
         },
         original_span: Span {
             start: 49,
+            end: 60,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 44,
+            end: 47,
+        },
+        original_span: Span {
+            start: 50,
+            end: 53,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 48,
+            end: 54,
+        },
+        original_span: Span {
+            start: 60,
             end: 66,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 44,
-            end: 47,
-        },
-        original_span: Span {
-            start: 50,
-            end: 53,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 44,
-            end: 47,
-        },
-        original_span: Span {
-            start: 50,
-            end: 53,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 50,
-            end: 53,
-        },
-        original_span: Span {
-            start: 62,
-            end: 65,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 50,
             end: 53,
         },
@@ -242,7 +193,7 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     Mapping {
         codegen_span: Span {
             start: 54,
-            end: 77,
+            end: 71,
         },
         original_span: Span {
             start: 69,
@@ -261,42 +212,12 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     },
     Mapping {
         codegen_span: Span {
-            start: 55,
-            end: 58,
-        },
-        original_span: Span {
-            start: 70,
-            end: 73,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 59,
             end: 70,
         },
         original_span: Span {
             start: 74,
             end: 85,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 59,
-            end: 70,
-        },
-        original_span: Span {
-            start: 74,
-            end: 85,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 59,
-            end: 64,
-        },
-        original_span: Span {
-            start: 74,
-            end: 79,
         },
     },
     Mapping {
@@ -331,16 +252,6 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     },
     Mapping {
         codegen_span: Span {
-            start: 73,
-            end: 76,
-        },
-        original_span: Span {
-            start: 70,
-            end: 73,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 77,
             end: 100,
         },
@@ -352,21 +263,11 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     Mapping {
         codegen_span: Span {
             start: 77,
-            end: 100,
+            end: 93,
         },
         original_span: Span {
             start: 91,
             end: 109,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 78,
-            end: 82,
-        },
-        original_span: Span {
-            start: 92,
-            end: 96,
         },
     },
     Mapping {
@@ -387,26 +288,6 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
         original_span: Span {
             start: 97,
             end: 106,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 83,
-            end: 92,
-        },
-        original_span: Span {
-            start: 97,
-            end: 106,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 83,
-            end: 88,
-        },
-        original_span: Span {
-            start: 97,
-            end: 102,
         },
     },
     Mapping {
@@ -441,16 +322,6 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     },
     Mapping {
         codegen_span: Span {
-            start: 95,
-            end: 99,
-        },
-        original_span: Span {
-            start: 92,
-            end: 96,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 100,
             end: 111,
         },
@@ -462,7 +333,7 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     Mapping {
         codegen_span: Span {
             start: 100,
-            end: 111,
+            end: 105,
         },
         original_span: Span {
             start: 112,
@@ -473,26 +344,6 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
         codegen_span: Span {
             start: 101,
             end: 104,
-        },
-        original_span: Span {
-            start: 113,
-            end: 116,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 101,
-            end: 104,
-        },
-        original_span: Span {
-            start: 113,
-            end: 116,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 107,
-            end: 110,
         },
         original_span: Span {
             start: 113,
@@ -522,7 +373,7 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     Mapping {
         codegen_span: Span {
             start: 111,
-            end: 120,
+            end: 115,
         },
         original_span: Span {
             start: 122,
@@ -541,16 +392,6 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     },
     Mapping {
         codegen_span: Span {
-            start: 112,
-            end: 114,
-        },
-        original_span: Span {
-            start: 123,
-            end: 125,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 117,
             end: 119,
         },
@@ -561,22 +402,12 @@ async()=>{<><template><div class="1"></div><div></div><div class="w-1"></div><ma
     },
     Mapping {
         codegen_span: Span {
-            start: 117,
-            end: 119,
+            start: 120,
+            end: 131,
         },
         original_span: Span {
-            start: 123,
-            end: 125,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 122,
-            end: 130,
-        },
-        original_span: Span {
-            start: 131,
-            end: 139,
+            start: 129,
+            end: 140,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/typescript_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/typescript_vue.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
+assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
@@ -31,16 +32,6 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 10,
-            end: 42,
-        },
-        original_span: Span {
-            start: 25,
-            end: 61,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 15,
             end: 42,
         },
@@ -61,42 +52,12 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 15,
-            end: 17,
-        },
-        original_span: Span {
-            start: 31,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 18,
             end: 42,
         },
         original_span: Span {
             start: 35,
             end: 61,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 18,
-            end: 42,
-        },
-        original_span: Span {
-            start: 35,
-            end: 61,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 18,
-            end: 30,
-        },
-        original_span: Span {
-            start: 35,
-            end: 47,
         },
     },
     Mapping {
@@ -127,26 +88,6 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
         original_span: Span {
             start: 48,
             end: 58,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 31,
-            end: 39,
-        },
-        original_span: Span {
-            start: 48,
-            end: 58,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 32,
-            end: 37,
-        },
-        original_span: Span {
-            start: 50,
-            end: 56,
         },
     },
     Mapping {
@@ -191,36 +132,6 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 36,
-            end: 37,
-        },
-        original_span: Span {
-            start: 55,
-            end: 56,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 36,
-            end: 37,
-        },
-        original_span: Span {
-            start: 55,
-            end: 56,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 43,
-            end: 75,
-        },
-        original_span: Span {
-            start: 62,
-            end: 96,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 43,
             end: 75,
         },
@@ -251,42 +162,12 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 48,
-            end: 50,
-        },
-        original_span: Span {
-            start: 68,
-            end: 69,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 51,
             end: 75,
         },
         original_span: Span {
             start: 72,
             end: 96,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 75,
-        },
-        original_span: Span {
-            start: 72,
-            end: 96,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 63,
-        },
-        original_span: Span {
-            start: 72,
-            end: 84,
         },
     },
     Mapping {
@@ -321,36 +202,6 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 64,
-            end: 72,
-        },
-        original_span: Span {
-            start: 85,
-            end: 93,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 64,
-            end: 72,
-        },
-        original_span: Span {
-            start: 85,
-            end: 93,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 64,
-            end: 72,
-        },
-        original_span: Span {
-            start: 85,
-            end: 93,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 78,
             end: 111,
         },
@@ -362,21 +213,11 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     Mapping {
         codegen_span: Span {
             start: 78,
-            end: 111,
+            end: 102,
         },
         original_span: Span {
             start: 0,
-            end: 124,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 79,
-            end: 85,
-        },
-        original_span: Span {
-            start: 1,
-            end: 7,
+            end: 24,
         },
     },
     Mapping {
@@ -397,26 +238,6 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
         original_span: Span {
             start: 8,
             end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 86,
-            end: 95,
-        },
-        original_span: Span {
-            start: 8,
-            end: 17,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 86,
-            end: 90,
-        },
-        original_span: Span {
-            start: 8,
-            end: 12,
         },
     },
     Mapping {
@@ -451,42 +272,12 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 96,
-            end: 101,
+            start: 102,
+            end: 111,
         },
         original_span: Span {
-            start: 18,
-            end: 23,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 96,
-            end: 101,
-        },
-        original_span: Span {
-            start: 18,
-            end: 23,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 96,
-            end: 101,
-        },
-        original_span: Span {
-            start: 18,
-            end: 23,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 104,
-            end: 110,
-        },
-        original_span: Span {
-            start: 117,
-            end: 123,
+            start: 115,
+            end: 124,
         },
     },
     Mapping {
@@ -512,21 +303,11 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     Mapping {
         codegen_span: Span {
             start: 111,
-            end: 161,
+            end: 121,
         },
         original_span: Span {
             start: 126,
-            end: 213,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 112,
-            end: 120,
-        },
-        original_span: Span {
-            start: 127,
-            end: 135,
+            end: 136,
         },
     },
     Mapping {
@@ -552,21 +333,11 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     Mapping {
         codegen_span: Span {
             start: 121,
-            end: 139,
+            end: 126,
         },
         original_span: Span {
             start: 139,
-            end: 161,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 122,
-            end: 125,
-        },
-        original_span: Span {
-            start: 140,
-            end: 143,
+            end: 144,
         },
     },
     Mapping {
@@ -591,52 +362,12 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 126,
-            end: 133,
-        },
-        original_span: Span {
-            start: 144,
-            end: 155,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 127,
             end: 132,
         },
         original_span: Span {
             start: 147,
             end: 152,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 127,
-            end: 132,
-        },
-        original_span: Span {
-            start: 147,
-            end: 152,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 127,
-            end: 132,
-        },
-        original_span: Span {
-            start: 147,
-            end: 152,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 127,
-            end: 128,
-        },
-        original_span: Span {
-            start: 147,
-            end: 148,
         },
     },
     Mapping {
@@ -661,12 +392,12 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 135,
-            end: 138,
+            start: 133,
+            end: 139,
         },
         original_span: Span {
-            start: 157,
-            end: 160,
+            start: 155,
+            end: 161,
         },
     },
     Mapping {
@@ -692,35 +423,35 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     Mapping {
         codegen_span: Span {
             start: 139,
-            end: 150,
+            end: 144,
         },
         original_span: Span {
             start: 164,
+            end: 169,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 140,
+            end: 143,
+        },
+        original_span: Span {
+            start: 165,
+            end: 168,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 144,
+            end: 150,
+        },
+        original_span: Span {
+            start: 195,
             end: 201,
         },
     },
     Mapping {
         codegen_span: Span {
-            start: 140,
-            end: 143,
-        },
-        original_span: Span {
-            start: 165,
-            end: 168,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 140,
-            end: 143,
-        },
-        original_span: Span {
-            start: 165,
-            end: 168,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
             start: 146,
             end: 149,
         },
@@ -731,22 +462,12 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 146,
-            end: 149,
+            start: 150,
+            end: 161,
         },
         original_span: Span {
-            start: 197,
-            end: 200,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 152,
-            end: 160,
-        },
-        original_span: Span {
-            start: 204,
-            end: 212,
+            start: 202,
+            end: 213,
         },
     },
     Mapping {


### PR DESCRIPTION
## Summary

- Deduplicate generated mappings when an outer mapping is identical to, or only semicolon-wider than, a later child mapping for the same generated range.
- Add explicit JSX opening/closing element mappings so narrower element spans remain available after removing broad duplicates.
- Update codegen mapping assertions to validate emitted mappings by original span coverage instead of relying on the first generated-span match.
- Refresh codegen snapshots for the new mapping shape.

## Root Cause

`leave_mapping` kept wrapper mappings that shared the same generated range as their children. The snapshot fixture showed `0..1` mapping first to the expression statement span and then to the numeric literal span, so consumers using the first match could recover the wrong original range.

## Validation

- `cargo test -p vue_oxlint_jsx scripts_mapping_vue -- --nocapture`
- `just lint`
- `just test`
- `just ready`