### PR TITLE
feat: implement clean-codegen-mapping for script nodes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Cargo workspace members live in `crates/*`, `packages/*`, and `benchmark/`.
 - A `ScriptBlock` is collected for the global `<script>` and the `<script setup>` block independently (`global` and `setup`); they're stitched into a single `Program` during parse.
 - Comments and irregular whitespaces are tracked separately because they're stripped/relocated during the SFC→JS rewrite but must be reported back with original-source spans.
 - The codegen entry point (`VueJsxCodegen`) drops the parser allocator before returning — only owned data is exposed. Use `VueJsxParser` instead if you need the AST itself.
+- **Clean-set mapping**: `ParserImpl` maintains a `clean_spans: FxHashSet<Span>` of spans that come directly from the original source (top-level statements and directives from each `<script>` block). `Codegen` receives this set via `with_clean_spans()` and, before printing any node, checks if its span is clean. Clean nodes are emitted verbatim from `program.source_text` with a single mapping entry; dirty nodes use the normal per-child traversal. This eliminates overlapping mapping entries for unchanged script content and preserves original whitespace/formatting.
 
 ## Vue/SFC parsing context
 

--- a/crates/vue_oxlint_jsx/fixtures/scripts/directive_prologue.vue
+++ b/crates/vue_oxlint_jsx/fixtures/scripts/directive_prologue.vue
@@ -1,0 +1,10 @@
+<script>
+"use strict"
+"use asm"
+semiFunctionCall();
+export const x = 1
+</script>
+
+<script setup>
+functionCallWithoutSemi()
+</script>

--- a/crates/vue_oxlint_jsx/src/codegen/mod.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/mod.rs
@@ -99,7 +99,7 @@ impl<'a> VueJsxCodegen<'a> {
       };
     }
 
-    let codegen_ret = Codegen::new().build(&ret.program);
+    let codegen_ret = Codegen::new().with_clean_spans(ret.clean_spans).build(&ret.program);
     let source_text = codegen_ret.code;
     let source_type = ret.program.source_type;
     let comments = ret.program.comments.iter().copied().collect();

--- a/crates/vue_oxlint_jsx/src/codegen/mod.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/mod.rs
@@ -123,4 +123,6 @@ mod tests {
   test_ast!(scripts_codegen_fidelity_vue, "scripts/codegen_fidelity.vue");
 
   test_ast!(scripts_mapping_vue, "scripts/mapping.vue");
+
+  test_ast!(scripts_directive_prologue_vue, "scripts/directive_prologue.vue");
 }

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/gen.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/gen.rs
@@ -22,6 +22,9 @@ pub trait Gen: GetSpan {
   /// Generate code for an AST node. Alias for `gen`.
   #[inline]
   fn print(&self, p: &mut Codegen, ctx: Context) {
+    if p.try_emit_clean(self.span()) {
+      return;
+    }
     p.enter_mapping(self.span());
     self.r#gen(p, ctx);
     p.leave_mapping();
@@ -36,6 +39,9 @@ pub trait GenExpr: GetSpan {
   /// Generate code for an expression, respecting operator precedence. Alias for `gen_expr`.
   #[inline]
   fn print_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+    if p.try_emit_clean(self.span()) {
+      return;
+    }
     p.enter_mapping(self.span());
     self.gen_expr(p, precedence, ctx);
     p.leave_mapping();

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/lib.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/lib.rs
@@ -525,6 +525,7 @@ impl<'a> Codegen<'a> {
     ctx: Context,
   ) {
     for directive in directives {
+      self.print_semicolon_if_needed();
       directive.print(self, ctx);
     }
     self.print_stmts(stmts, ctx);

--- a/crates/vue_oxlint_jsx/src/codegen/oxc/lib.rs
+++ b/crates/vue_oxlint_jsx/src/codegen/oxc/lib.rs
@@ -19,7 +19,7 @@ use oxc_syntax::{
   operator::{BinaryOperator, UnaryOperator, UpdateOperator},
   precedence::Precedence,
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 mod binary_expr_visitor;
 mod context;
@@ -85,6 +85,11 @@ pub struct Codegen<'a> {
   mappings: Vec<Mapping>,
   mapping_stack: Vec<Option<usize>>,
 
+  /// Clean node spans — these map to original source text and can be emitted verbatim.
+  clean_spans: FxHashSet<Span>,
+  /// Original source text, populated at build time from the program.
+  source_text: Option<&'a str>,
+
   // states
   prev_op_end: usize,
   prev_reg_exp_end: usize,
@@ -125,6 +130,8 @@ impl<'a> Codegen<'a> {
       code: CodeBuffer::default(),
       mappings: Vec::new(),
       mapping_stack: Vec::new(),
+      clean_spans: FxHashSet::default(),
+      source_text: None,
       needs_semicolon: false,
       need_space_before_dot: 0,
       binary_expr_stack: Stack::with_capacity(12),
@@ -140,10 +147,18 @@ impl<'a> Codegen<'a> {
     }
   }
 
+  /// Register clean spans so the codegen can copy source text verbatim for unchanged nodes.
+  #[must_use]
+  pub fn with_clean_spans(mut self, clean_spans: FxHashSet<Span>) -> Self {
+    self.clean_spans = clean_spans;
+    self
+  }
+
   /// Print a [`Program`] into a string of source code.
   ///
   #[must_use]
   pub fn build(mut self, program: &Program<'a>) -> CodegenReturn {
+    self.source_text = Some(program.source_text);
     self.code.reserve(program.source_text.len());
     program.print(&mut self, Context::default());
     let code = self.code.into_string();
@@ -293,6 +308,32 @@ impl<'a> Codegen<'a> {
 
   fn code_len(&self) -> usize {
     self.code().len()
+  }
+
+  /// Attempt to emit a clean node by copying source text verbatim.
+  ///
+  /// Returns `true` and emits the original source slice + a single mapping when `span` is in
+  /// the clean set. Returns `false` when the node should be emitted via normal codegen.
+  pub(crate) fn try_emit_clean(&mut self, span: Span) -> bool {
+    if span.start == 0 && span.end == 0 {
+      return false;
+    }
+    let Some(source_text) = self.source_text else {
+      return false;
+    };
+    if !self.clean_spans.contains(&span) {
+      return false;
+    }
+    let text = &source_text[span.start as usize..span.end as usize];
+    let codegen_start = self.code_len() as u32;
+    self.print_str(text);
+    let codegen_end = self.code_len() as u32;
+    self.mappings.push(Mapping::new(Span::new(codegen_start, codegen_end), span));
+    // If the clean text already ends with `;` no extra separator is needed.
+    // In all other cases (including `}`) signal that a `;` should precede the next statement.
+    // Function/class declarations that end with `}` will harmlessly get a trailing `;\n`.
+    self.needs_semicolon = self.last_byte() != Some(b';');
+    true
   }
 
   pub(crate) fn enter_mapping(&mut self, span: Span) {

--- a/crates/vue_oxlint_jsx/src/parser/interface.rs
+++ b/crates/vue_oxlint_jsx/src/parser/interface.rs
@@ -99,7 +99,7 @@ impl<'a> VueJsxParser<'a> {
   /// ```
   #[must_use]
   pub fn parse(self) -> VueJsxParserReturn<'a> {
-    let ParserImplReturn { program, errors, fatal, module_record, irregular_whitespaces } =
+    let ParserImplReturn { program, errors, fatal, module_record, irregular_whitespaces, .. } =
       ParserImpl::new(self.allocator, self.source_text, self.options, ParseConfig::default())
         .parse();
 

--- a/crates/vue_oxlint_jsx/src/parser/mod.rs
+++ b/crates/vue_oxlint_jsx/src/parser/mod.rs
@@ -9,6 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::ParseOptions;
 use oxc_span::{SourceType, Span};
 use oxc_syntax::module_record::ModuleRecord;
+use rustc_hash::FxHashSet;
 
 mod codegen;
 mod elements;
@@ -51,6 +52,8 @@ pub struct ParserImpl<'a> {
   global: ScriptBlock<'a>,
   setup: ScriptBlock<'a>,
   sfc_struct_jsx_statement: Option<Statement<'a>>,
+
+  clean_spans: FxHashSet<Span>,
 }
 
 impl<'a> ParserImpl<'a> {
@@ -85,6 +88,8 @@ impl<'a> ParserImpl<'a> {
       global: ScriptBlock { directives: ast.vec(), statements: ast.vec() },
       setup: ScriptBlock { directives: ast.vec(), statements: ast.vec() },
       sfc_struct_jsx_statement: None,
+
+      clean_spans: FxHashSet::default(),
     }
   }
 }
@@ -93,6 +98,7 @@ pub struct ParserImplReturn<'a> {
   pub program: Program<'a>,
   pub module_record: ModuleRecord<'a>,
   pub irregular_whitespaces: Box<[Span]>,
+  pub clean_spans: FxHashSet<Span>,
 
   pub fatal: bool,
   pub errors: Vec<OxcDiagnostic>,

--- a/crates/vue_oxlint_jsx/src/parser/parse.rs
+++ b/crates/vue_oxlint_jsx/src/parser/parse.rs
@@ -49,6 +49,7 @@ impl<'a> ParserImpl<'a> {
           global,
           setup,
           sfc_struct_jsx_statement: sfc_return,
+          clean_spans,
           ..
         } = self;
 
@@ -69,6 +70,7 @@ impl<'a> ParserImpl<'a> {
             ),
           ),
           irregular_whitespaces: collect_irregular_whitespaces(source_text),
+          clean_spans,
           fatal: false,
           errors,
           module_record,
@@ -80,6 +82,7 @@ impl<'a> ParserImpl<'a> {
         errors: self.errors,
         module_record: ModuleRecord::new(self.allocator),
         irregular_whitespaces: Box::new([]),
+        clean_spans: rustc_hash::FxHashSet::default(),
       },
     }
   }

--- a/crates/vue_oxlint_jsx/src/parser/script.rs
+++ b/crates/vue_oxlint_jsx/src/parser/script.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::ast::Statement;
 
-use oxc_span::SourceType;
+use oxc_span::{GetSpan, SourceType};
 use vue_compiler_core::{
   parser::{ElemProp, Element},
   util::{find_prop, prop_finder},
@@ -69,6 +69,13 @@ impl<'a> ParserImpl<'a> {
       else {
         return ResParse::success(());
       };
+
+      for directive in &directives {
+        self.clean_spans.insert(directive.span());
+      }
+      for stmt in &body {
+        self.clean_spans.insert(stmt.span());
+      }
 
       // Deal with modules record there
       if is_setup {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_directive_prologue_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/ast/scripts_directive_prologue_vue.snap
@@ -1,0 +1,634 @@
+---
+source: crates/vue_oxlint_jsx/src/test/mod.rs
+expression: result
+---
+=============== Program ===============
+Program {
+    span: Span {
+        start: 0,
+        end: 133,
+    },
+    node_id: Cell {
+        value: NodeId(0),
+    },
+    scope_id: Cell {
+        value: None,
+    },
+    source_text: "<script>\n\"use strict\"\n\"use asm\"\nsemiFunctionCall();\nexport const x = 1\n</script>\n\n<script setup>\nfunctionCallWithoutSemi()\n</script>\n",
+    comments: Vec(
+        [],
+    ),
+    hashbang: None,
+    directives: Vec(
+        [
+            Directive {
+                span: Span {
+                    start: 9,
+                    end: 21,
+                },
+                node_id: Cell {
+                    value: NodeId(0),
+                },
+                expression: StringLiteral {
+                    span: Span {
+                        start: 9,
+                        end: 21,
+                    },
+                    node_id: Cell {
+                        value: NodeId(0),
+                    },
+                    lone_surrogates: false,
+                    value: "use strict",
+                    raw: Some(
+                        "\"use strict\"",
+                    ),
+                },
+                directive: "use strict",
+            },
+            Directive {
+                span: Span {
+                    start: 22,
+                    end: 31,
+                },
+                node_id: Cell {
+                    value: NodeId(0),
+                },
+                expression: StringLiteral {
+                    span: Span {
+                        start: 22,
+                        end: 31,
+                    },
+                    node_id: Cell {
+                        value: NodeId(0),
+                    },
+                    lone_surrogates: false,
+                    value: "use asm",
+                    raw: Some(
+                        "\"use asm\"",
+                    ),
+                },
+                directive: "use asm",
+            },
+        ],
+    ),
+    body: Vec(
+        [
+            ExpressionStatement(
+                ExpressionStatement {
+                    span: Span {
+                        start: 32,
+                        end: 51,
+                    },
+                    node_id: Cell {
+                        value: NodeId(0),
+                    },
+                    expression: CallExpression(
+                        CallExpression {
+                            span: Span {
+                                start: 32,
+                                end: 50,
+                            },
+                            node_id: Cell {
+                                value: NodeId(0),
+                            },
+                            optional: false,
+                            pure: false,
+                            callee: Identifier(
+                                IdentifierReference {
+                                    span: Span {
+                                        start: 32,
+                                        end: 48,
+                                    },
+                                    node_id: Cell {
+                                        value: NodeId(0),
+                                    },
+                                    reference_id: Cell {
+                                        value: None,
+                                    },
+                                    name: "semiFunctionCall",
+                                },
+                            ),
+                            type_arguments: None,
+                            arguments: Vec(
+                                [],
+                            ),
+                        },
+                    ),
+                },
+            ),
+            ExportNamedDeclaration(
+                ExportNamedDeclaration {
+                    span: Span {
+                        start: 52,
+                        end: 70,
+                    },
+                    node_id: Cell {
+                        value: NodeId(0),
+                    },
+                    export_kind: Value,
+                    declaration: Some(
+                        VariableDeclaration(
+                            VariableDeclaration {
+                                span: Span {
+                                    start: 59,
+                                    end: 70,
+                                },
+                                node_id: Cell {
+                                    value: NodeId(0),
+                                },
+                                kind: Const,
+                                declare: false,
+                                declarations: Vec(
+                                    [
+                                        VariableDeclarator {
+                                            span: Span {
+                                                start: 65,
+                                                end: 70,
+                                            },
+                                            node_id: Cell {
+                                                value: NodeId(0),
+                                            },
+                                            kind: Const,
+                                            definite: false,
+                                            id: BindingIdentifier(
+                                                BindingIdentifier {
+                                                    span: Span {
+                                                        start: 65,
+                                                        end: 66,
+                                                    },
+                                                    node_id: Cell {
+                                                        value: NodeId(0),
+                                                    },
+                                                    symbol_id: Cell {
+                                                        value: None,
+                                                    },
+                                                    name: "x",
+                                                },
+                                            ),
+                                            type_annotation: None,
+                                            init: Some(
+                                                NumericLiteral(
+                                                    NumericLiteral {
+                                                        span: Span {
+                                                            start: 69,
+                                                            end: 70,
+                                                        },
+                                                        node_id: Cell {
+                                                            value: NodeId(0),
+                                                        },
+                                                        base: Decimal,
+                                                        raw: Some(
+                                                            "1",
+                                                        ),
+                                                        value: 1.0,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ],
+                                ),
+                            },
+                        ),
+                    ),
+                    specifiers: Vec(
+                        [],
+                    ),
+                    source: None,
+                    with_clause: None,
+                },
+            ),
+            ExpressionStatement(
+                ExpressionStatement {
+                    span: Span {
+                        start: 0,
+                        end: 0,
+                    },
+                    node_id: Cell {
+                        value: NodeId(0),
+                    },
+                    expression: ArrowFunctionExpression(
+                        ArrowFunctionExpression {
+                            span: Span {
+                                start: 0,
+                                end: 0,
+                            },
+                            node_id: Cell {
+                                value: NodeId(0),
+                            },
+                            scope_id: Cell {
+                                value: None,
+                            },
+                            type_parameters: None,
+                            params: FormalParameters {
+                                span: Span {
+                                    start: 0,
+                                    end: 0,
+                                },
+                                node_id: Cell {
+                                    value: NodeId(0),
+                                },
+                                kind: ArrowFormalParameters,
+                                items: Vec(
+                                    [],
+                                ),
+                                rest: None,
+                            },
+                            return_type: None,
+                            body: FunctionBody {
+                                span: Span {
+                                    start: 0,
+                                    end: 0,
+                                },
+                                node_id: Cell {
+                                    value: NodeId(0),
+                                },
+                                directives: Vec(
+                                    [],
+                                ),
+                                statements: Vec(
+                                    [
+                                        ExpressionStatement(
+                                            ExpressionStatement {
+                                                span: Span {
+                                                    start: 97,
+                                                    end: 122,
+                                                },
+                                                node_id: Cell {
+                                                    value: NodeId(0),
+                                                },
+                                                expression: CallExpression(
+                                                    CallExpression {
+                                                        span: Span {
+                                                            start: 97,
+                                                            end: 122,
+                                                        },
+                                                        node_id: Cell {
+                                                            value: NodeId(0),
+                                                        },
+                                                        optional: false,
+                                                        pure: false,
+                                                        callee: Identifier(
+                                                            IdentifierReference {
+                                                                span: Span {
+                                                                    start: 97,
+                                                                    end: 120,
+                                                                },
+                                                                node_id: Cell {
+                                                                    value: NodeId(0),
+                                                                },
+                                                                reference_id: Cell {
+                                                                    value: None,
+                                                                },
+                                                                name: "functionCallWithoutSemi",
+                                                            },
+                                                        ),
+                                                        type_arguments: None,
+                                                        arguments: Vec(
+                                                            [],
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ExpressionStatement(
+                                            ExpressionStatement {
+                                                span: Span {
+                                                    start: 0,
+                                                    end: 0,
+                                                },
+                                                node_id: Cell {
+                                                    value: NodeId(0),
+                                                },
+                                                expression: JSXFragment(
+                                                    JSXFragment {
+                                                        span: Span {
+                                                            start: 0,
+                                                            end: 0,
+                                                        },
+                                                        node_id: Cell {
+                                                            value: NodeId(0),
+                                                        },
+                                                        opening_fragment: JSXOpeningFragment {
+                                                            span: Span {
+                                                                start: 0,
+                                                                end: 0,
+                                                            },
+                                                            node_id: Cell {
+                                                                value: NodeId(0),
+                                                            },
+                                                        },
+                                                        children: Vec(
+                                                            [
+                                                                Element(
+                                                                    JSXElement {
+                                                                        span: Span {
+                                                                            start: 0,
+                                                                            end: 80,
+                                                                        },
+                                                                        node_id: Cell {
+                                                                            value: NodeId(0),
+                                                                        },
+                                                                        opening_element: JSXOpeningElement {
+                                                                            span: Span {
+                                                                                start: 0,
+                                                                                end: 8,
+                                                                            },
+                                                                            node_id: Cell {
+                                                                                value: NodeId(0),
+                                                                            },
+                                                                            name: Identifier(
+                                                                                JSXIdentifier {
+                                                                                    span: Span {
+                                                                                        start: 1,
+                                                                                        end: 7,
+                                                                                    },
+                                                                                    node_id: Cell {
+                                                                                        value: NodeId(0),
+                                                                                    },
+                                                                                    name: "script",
+                                                                                },
+                                                                            ),
+                                                                            type_arguments: None,
+                                                                            attributes: Vec(
+                                                                                [],
+                                                                            ),
+                                                                        },
+                                                                        children: Vec(
+                                                                            [],
+                                                                        ),
+                                                                        closing_element: Some(
+                                                                            JSXClosingElement {
+                                                                                span: Span {
+                                                                                    start: 71,
+                                                                                    end: 80,
+                                                                                },
+                                                                                node_id: Cell {
+                                                                                    value: NodeId(0),
+                                                                                },
+                                                                                name: Identifier(
+                                                                                    JSXIdentifier {
+                                                                                        span: Span {
+                                                                                            start: 73,
+                                                                                            end: 79,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        name: "script",
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                Element(
+                                                                    JSXElement {
+                                                                        span: Span {
+                                                                            start: 82,
+                                                                            end: 132,
+                                                                        },
+                                                                        node_id: Cell {
+                                                                            value: NodeId(0),
+                                                                        },
+                                                                        opening_element: JSXOpeningElement {
+                                                                            span: Span {
+                                                                                start: 82,
+                                                                                end: 96,
+                                                                            },
+                                                                            node_id: Cell {
+                                                                                value: NodeId(0),
+                                                                            },
+                                                                            name: Identifier(
+                                                                                JSXIdentifier {
+                                                                                    span: Span {
+                                                                                        start: 83,
+                                                                                        end: 89,
+                                                                                    },
+                                                                                    node_id: Cell {
+                                                                                        value: NodeId(0),
+                                                                                    },
+                                                                                    name: "script",
+                                                                                },
+                                                                            ),
+                                                                            type_arguments: None,
+                                                                            attributes: Vec(
+                                                                                [
+                                                                                    Attribute(
+                                                                                        JSXAttribute {
+                                                                                            span: Span {
+                                                                                                start: 90,
+                                                                                                end: 95,
+                                                                                            },
+                                                                                            node_id: Cell {
+                                                                                                value: NodeId(0),
+                                                                                            },
+                                                                                            name: Identifier(
+                                                                                                JSXIdentifier {
+                                                                                                    span: Span {
+                                                                                                        start: 90,
+                                                                                                        end: 95,
+                                                                                                    },
+                                                                                                    node_id: Cell {
+                                                                                                        value: NodeId(0),
+                                                                                                    },
+                                                                                                    name: "setup",
+                                                                                                },
+                                                                                            ),
+                                                                                            value: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                            ),
+                                                                        },
+                                                                        children: Vec(
+                                                                            [],
+                                                                        ),
+                                                                        closing_element: Some(
+                                                                            JSXClosingElement {
+                                                                                span: Span {
+                                                                                    start: 123,
+                                                                                    end: 132,
+                                                                                },
+                                                                                node_id: Cell {
+                                                                                    value: NodeId(0),
+                                                                                },
+                                                                                name: Identifier(
+                                                                                    JSXIdentifier {
+                                                                                        span: Span {
+                                                                                            start: 125,
+                                                                                            end: 131,
+                                                                                        },
+                                                                                        node_id: Cell {
+                                                                                            value: NodeId(0),
+                                                                                        },
+                                                                                        name: "script",
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        ),
+                                                        closing_fragment: JSXClosingFragment {
+                                                            span: Span {
+                                                                start: 0,
+                                                                end: 0,
+                                                            },
+                                                            node_id: Cell {
+                                                                value: NodeId(0),
+                                                            },
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                ),
+                            },
+                            expression: false,
+                            async: true,
+                            pure: false,
+                            pife: false,
+                        },
+                    ),
+                },
+            ),
+        ],
+    ),
+    source_type: SourceType {
+        language: JavaScript,
+        module_kind: Unambiguous,
+        variant: Jsx,
+        extension: Some(
+            Js,
+        ),
+    },
+}
+
+===============  Error  ===============
+[]
+
+=============== Codegen ===============
+"use strict";
+"use asm";
+semiFunctionCall();
+export const x = 1;
+async () => {
+	functionCallWithoutSemi();
+	<><script></script><script setup></script></>;
+};
+
+
+===============  Spans  ===============
+Slice: "<script>\n\"use strict\"\n\"use asm\"\nsemiFunc..[OMIT]..up>\nfunctionCallWithoutSemi()\n</script>\n"; 
+Span: (0, 133); 
+Type: Program; 
+
+Slice: "\"use strict\""; 
+Span: (9, 21); 
+Type: Directive; 
+
+Slice: "\"use strict\""; 
+Span: (9, 21); 
+Type: StringLiteral; 
+
+Slice: "\"use asm\""; 
+Span: (22, 31); 
+Type: Directive; 
+
+Slice: "\"use asm\""; 
+Span: (22, 31); 
+Type: StringLiteral; 
+
+Slice: "semiFunctionCall();"; 
+Span: (32, 51); 
+Type: ExpressionStatement; 
+
+Slice: "semiFunctionCall()"; 
+Span: (32, 50); 
+Type: CallExpression; 
+
+Slice: "semiFunctionCall"; 
+Span: (32, 48); 
+Type: IdentifierReference; 
+
+Slice: "export const x = 1"; 
+Span: (52, 70); 
+Type: ExportNamedDeclaration; 
+
+Slice: "const x = 1"; 
+Span: (59, 70); 
+Type: VariableDeclaration; 
+
+Slice: "x = 1"; 
+Span: (65, 70); 
+Type: VariableDeclarator; 
+
+Slice: "x"; 
+Span: (65, 66); 
+Type: BindingIdentifier; 
+
+Slice: "1"; 
+Span: (69, 70); 
+Type: NumericLiteral; 
+
+Slice: "functionCallWithoutSemi()"; 
+Span: (97, 122); 
+Type: ExpressionStatement; 
+
+Slice: "functionCallWithoutSemi()"; 
+Span: (97, 122); 
+Type: CallExpression; 
+
+Slice: "functionCallWithoutSemi"; 
+Span: (97, 120); 
+Type: IdentifierReference; 
+
+Slice: "<script>\n\"use strict\"\n\"use asm\"\nsemiFunctionCall();\nexport const x = 1\n</script>"; 
+Span: (0, 80); 
+Type: JSXElement; 
+
+Slice: "<script>"; 
+Span: (0, 8); 
+Type: JSXOpeningElement; 
+
+Slice: "script"; 
+Span: (1, 7); 
+Type: JSXIdentifier; 
+
+Slice: "</script>"; 
+Span: (71, 80); 
+Type: JSXClosingElement; 
+
+Slice: "script"; 
+Span: (73, 79); 
+Type: JSXIdentifier; 
+
+Slice: "<script setup>\nfunctionCallWithoutSemi()\n</script>"; 
+Span: (82, 132); 
+Type: JSXElement; 
+
+Slice: "<script setup>"; 
+Span: (82, 96); 
+Type: JSXOpeningElement; 
+
+Slice: "script"; 
+Span: (83, 89); 
+Type: JSXIdentifier; 
+
+Slice: "setup"; 
+Span: (90, 95); 
+Type: JSXAttribute; 
+
+Slice: "setup"; 
+Span: (90, 95); 
+Type: JSXIdentifier; 
+
+Slice: "</script>"; 
+Span: (123, 132); 
+Type: JSXClosingElement; 
+
+Slice: "script"; 
+Span: (125, 131); 
+Type: JSXIdentifier;

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/basic_vue.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
-assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
 
-async()=>{const count=1;<><template><div>{count}</div></template><script lang="js" setup></script><style></style></>};
+async()=>{const count = 1;<><template><div>{count}</div></template><script lang="js" setup></script><style></style></>};
 
 =============== Mappings ===============
 
@@ -13,7 +12,7 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 118,
+            end: 120,
         },
         original_span: Span {
             start: 0,
@@ -23,7 +22,7 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     Mapping {
         codegen_span: Span {
             start: 10,
-            end: 23,
+            end: 26,
         },
         original_span: Span {
             start: 82,
@@ -32,38 +31,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 15,
-            end: 23,
-        },
-        original_span: Span {
-            start: 88,
-            end: 97,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 15,
-            end: 21,
-        },
-        original_span: Span {
-            start: 88,
-            end: 93,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 22,
-            end: 23,
-        },
-        original_span: Span {
-            start: 96,
-            end: 97,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 26,
-            end: 65,
+            start: 28,
+            end: 67,
         },
         original_span: Span {
             start: 0,
@@ -72,8 +41,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 26,
-            end: 36,
+            start: 28,
+            end: 38,
         },
         original_span: Span {
             start: 0,
@@ -82,8 +51,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 27,
-            end: 35,
+            start: 29,
+            end: 37,
         },
         original_span: Span {
             start: 1,
@@ -92,8 +61,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 36,
-            end: 54,
+            start: 38,
+            end: 56,
         },
         original_span: Span {
             start: 13,
@@ -102,8 +71,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 36,
-            end: 41,
+            start: 38,
+            end: 43,
         },
         original_span: Span {
             start: 13,
@@ -112,8 +81,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 37,
-            end: 40,
+            start: 39,
+            end: 42,
         },
         original_span: Span {
             start: 14,
@@ -122,8 +91,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 41,
-            end: 48,
+            start: 43,
+            end: 50,
         },
         original_span: Span {
             start: 23,
@@ -132,8 +101,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 42,
-            end: 47,
+            start: 44,
+            end: 49,
         },
         original_span: Span {
             start: 26,
@@ -142,8 +111,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 48,
-            end: 54,
+            start: 50,
+            end: 56,
         },
         original_span: Span {
             start: 37,
@@ -152,8 +121,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 50,
-            end: 53,
+            start: 52,
+            end: 55,
         },
         original_span: Span {
             start: 39,
@@ -162,8 +131,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 54,
-            end: 65,
+            start: 56,
+            end: 67,
         },
         original_span: Span {
             start: 44,
@@ -172,8 +141,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 56,
-            end: 64,
+            start: 58,
+            end: 66,
         },
         original_span: Span {
             start: 46,
@@ -182,8 +151,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 65,
-            end: 98,
+            start: 67,
+            end: 100,
         },
         original_span: Span {
             start: 57,
@@ -192,8 +161,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 65,
-            end: 89,
+            start: 67,
+            end: 91,
         },
         original_span: Span {
             start: 57,
@@ -202,8 +171,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 66,
-            end: 72,
+            start: 68,
+            end: 74,
         },
         original_span: Span {
             start: 58,
@@ -212,8 +181,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 73,
-            end: 82,
+            start: 75,
+            end: 84,
         },
         original_span: Span {
             start: 65,
@@ -222,8 +191,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 73,
-            end: 77,
+            start: 75,
+            end: 79,
         },
         original_span: Span {
             start: 65,
@@ -232,8 +201,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 78,
-            end: 82,
+            start: 80,
+            end: 84,
         },
         original_span: Span {
             start: 71,
@@ -242,8 +211,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 83,
-            end: 88,
+            start: 85,
+            end: 90,
         },
         original_span: Span {
             start: 75,
@@ -252,8 +221,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 89,
-            end: 98,
+            start: 91,
+            end: 100,
         },
         original_span: Span {
             start: 99,
@@ -262,8 +231,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 91,
-            end: 97,
+            start: 93,
+            end: 99,
         },
         original_span: Span {
             start: 101,
@@ -272,8 +241,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 98,
-            end: 113,
+            start: 100,
+            end: 115,
         },
         original_span: Span {
             start: 110,
@@ -282,8 +251,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 98,
-            end: 105,
+            start: 100,
+            end: 107,
         },
         original_span: Span {
             start: 110,
@@ -292,8 +261,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 99,
-            end: 104,
+            start: 101,
+            end: 106,
         },
         original_span: Span {
             start: 111,
@@ -302,8 +271,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 105,
-            end: 113,
+            start: 107,
+            end: 115,
         },
         original_span: Span {
             start: 140,
@@ -312,8 +281,8 @@ async()=>{const count=1;<><template><div>{count}</div></template><script lang="j
     },
     Mapping {
         codegen_span: Span {
-            start: 107,
-            end: 112,
+            start: 109,
+            end: 114,
         },
         original_span: Span {
             start: 142,

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/components_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/components_vue.snap
@@ -4,7 +4,7 @@ expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n
 ---
 =============== Source Text ===============
 
-import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';async()=>{<><template><SomeComponent></SomeComponent><SomeComponent></SomeComponent><Transition></Transition><Component></Component><motion.div></motion.div></template><script lang="ts" setup></script></>};
+import SomeComponent from './SomeComponent.vue';import { motion } from 'motion-v';async()=>{<><template><SomeComponent></SomeComponent><SomeComponent></SomeComponent><Transition></Transition><Component></Component><motion.div></motion.div></template><script lang="ts" setup></script></>};
 
 =============== Mappings ===============
 
@@ -12,7 +12,7 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 282,
+            end: 288,
         },
         original_span: Span {
             start: 0,
@@ -22,7 +22,7 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 46,
+            end: 48,
         },
         original_span: Span {
             start: 172,
@@ -31,18 +31,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 7,
-            end: 20,
-        },
-        original_span: Span {
-            start: 179,
-            end: 192,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 47,
-            end: 75,
+            start: 48,
+            end: 81,
         },
         original_span: Span {
             start: 221,
@@ -51,18 +41,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 54,
-            end: 60,
-        },
-        original_span: Span {
-            start: 230,
-            end: 236,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 88,
-            end: 244,
+            start: 94,
+            end: 250,
         },
         original_span: Span {
             start: 0,
@@ -71,8 +51,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 88,
-            end: 98,
+            start: 94,
+            end: 104,
         },
         original_span: Span {
             start: 0,
@@ -81,8 +61,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 89,
-            end: 97,
+            start: 95,
+            end: 103,
         },
         original_span: Span {
             start: 1,
@@ -91,8 +71,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 98,
-            end: 129,
+            start: 104,
+            end: 135,
         },
         original_span: Span {
             start: 13,
@@ -101,8 +81,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 98,
-            end: 113,
+            start: 104,
+            end: 119,
         },
         original_span: Span {
             start: 13,
@@ -111,8 +91,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 99,
-            end: 112,
+            start: 105,
+            end: 118,
         },
         original_span: Span {
             start: 14,
@@ -121,8 +101,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 113,
-            end: 129,
+            start: 119,
+            end: 135,
         },
         original_span: Span {
             start: 13,
@@ -131,8 +111,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 115,
-            end: 128,
+            start: 121,
+            end: 134,
         },
         original_span: Span {
             start: 15,
@@ -141,8 +121,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 129,
-            end: 160,
+            start: 135,
+            end: 166,
         },
         original_span: Span {
             start: 33,
@@ -151,8 +131,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 129,
-            end: 144,
+            start: 135,
+            end: 150,
         },
         original_span: Span {
             start: 33,
@@ -161,8 +141,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 130,
-            end: 143,
+            start: 136,
+            end: 149,
         },
         original_span: Span {
             start: 34,
@@ -171,8 +151,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 144,
-            end: 160,
+            start: 150,
+            end: 166,
         },
         original_span: Span {
             start: 33,
@@ -181,8 +161,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 146,
-            end: 159,
+            start: 152,
+            end: 165,
         },
         original_span: Span {
             start: 35,
@@ -191,8 +171,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 160,
-            end: 185,
+            start: 166,
+            end: 191,
         },
         original_span: Span {
             start: 54,
@@ -201,8 +181,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 160,
-            end: 172,
+            start: 166,
+            end: 178,
         },
         original_span: Span {
             start: 54,
@@ -211,8 +191,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 161,
-            end: 171,
+            start: 167,
+            end: 177,
         },
         original_span: Span {
             start: 55,
@@ -221,8 +201,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 172,
-            end: 185,
+            start: 178,
+            end: 191,
         },
         original_span: Span {
             start: 66,
@@ -231,8 +211,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 174,
-            end: 184,
+            start: 180,
+            end: 190,
         },
         original_span: Span {
             start: 68,
@@ -241,8 +221,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 185,
-            end: 208,
+            start: 191,
+            end: 214,
         },
         original_span: Span {
             start: 82,
@@ -251,8 +231,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 185,
-            end: 196,
+            start: 191,
+            end: 202,
         },
         original_span: Span {
             start: 82,
@@ -261,8 +241,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 186,
-            end: 195,
+            start: 192,
+            end: 201,
         },
         original_span: Span {
             start: 83,
@@ -271,8 +251,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 196,
-            end: 208,
+            start: 202,
+            end: 214,
         },
         original_span: Span {
             start: 93,
@@ -281,8 +261,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 198,
-            end: 207,
+            start: 204,
+            end: 213,
         },
         original_span: Span {
             start: 95,
@@ -291,8 +271,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 208,
-            end: 233,
+            start: 214,
+            end: 239,
         },
         original_span: Span {
             start: 108,
@@ -301,8 +281,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 208,
-            end: 220,
+            start: 214,
+            end: 226,
         },
         original_span: Span {
             start: 108,
@@ -311,8 +291,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 209,
-            end: 219,
+            start: 215,
+            end: 225,
         },
         original_span: Span {
             start: 109,
@@ -321,8 +301,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 209,
-            end: 215,
+            start: 215,
+            end: 221,
         },
         original_span: Span {
             start: 109,
@@ -331,8 +311,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 216,
-            end: 219,
+            start: 222,
+            end: 225,
         },
         original_span: Span {
             start: 116,
@@ -341,8 +321,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 220,
-            end: 233,
+            start: 226,
+            end: 239,
         },
         original_span: Span {
             start: 120,
@@ -351,8 +331,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 222,
-            end: 232,
+            start: 228,
+            end: 238,
         },
         original_span: Span {
             start: 122,
@@ -361,8 +341,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 222,
-            end: 228,
+            start: 228,
+            end: 234,
         },
         original_span: Span {
             start: 109,
@@ -371,8 +351,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 229,
-            end: 232,
+            start: 235,
+            end: 238,
         },
         original_span: Span {
             start: 116,
@@ -381,8 +361,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 233,
-            end: 244,
+            start: 239,
+            end: 250,
         },
         original_span: Span {
             start: 134,
@@ -391,8 +371,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 235,
-            end: 243,
+            start: 241,
+            end: 249,
         },
         original_span: Span {
             start: 136,
@@ -401,8 +381,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 244,
-            end: 277,
+            start: 250,
+            end: 283,
         },
         original_span: Span {
             start: 147,
@@ -411,8 +391,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 244,
-            end: 268,
+            start: 250,
+            end: 274,
         },
         original_span: Span {
             start: 147,
@@ -421,8 +401,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 245,
-            end: 251,
+            start: 251,
+            end: 257,
         },
         original_span: Span {
             start: 148,
@@ -431,8 +411,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 252,
-            end: 261,
+            start: 258,
+            end: 267,
         },
         original_span: Span {
             start: 155,
@@ -441,8 +421,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 252,
-            end: 256,
+            start: 258,
+            end: 262,
         },
         original_span: Span {
             start: 155,
@@ -451,8 +431,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 257,
-            end: 261,
+            start: 263,
+            end: 267,
         },
         original_span: Span {
             start: 161,
@@ -461,8 +441,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 262,
-            end: 267,
+            start: 268,
+            end: 273,
         },
         original_span: Span {
             start: 165,
@@ -471,8 +451,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 268,
-            end: 277,
+            start: 274,
+            end: 283,
         },
         original_span: Span {
             start: 255,
@@ -481,8 +461,8 @@ import SomeComponent from'./SomeComponent.vue';import{motion}from'motion-v';asyn
     },
     Mapping {
         codegen_span: Span {
-            start: 270,
-            end: 276,
+            start: 276,
+            end: 282,
         },
         original_span: Span {
             start: 257,

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/error_empty_multiple_scripts_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/error_empty_multiple_scripts_vue.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
-assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
 
-const a=1;async()=>{<><script></script><script></script></>};
+const a = 1;async()=>{<><script></script><script></script></>};
 
 =============== Mappings ===============
 
@@ -13,7 +12,7 @@ const a=1;async()=>{<><script></script><script></script></>};
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 61,
+            end: 63,
         },
         original_span: Span {
             start: 0,
@@ -23,7 +22,7 @@ const a=1;async()=>{<><script></script><script></script></>};
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 9,
+            end: 12,
         },
         original_span: Span {
             start: 9,
@@ -32,38 +31,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 5,
-            end: 9,
-        },
-        original_span: Span {
-            start: 15,
-            end: 20,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 5,
-            end: 7,
-        },
-        original_span: Span {
-            start: 15,
-            end: 16,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 8,
-            end: 9,
-        },
-        original_span: Span {
-            start: 19,
-            end: 20,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 22,
-            end: 39,
+            start: 24,
+            end: 41,
         },
         original_span: Span {
             start: 0,
@@ -72,8 +41,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 22,
-            end: 30,
+            start: 24,
+            end: 32,
         },
         original_span: Span {
             start: 0,
@@ -82,8 +51,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 23,
-            end: 29,
+            start: 25,
+            end: 31,
         },
         original_span: Span {
             start: 1,
@@ -92,8 +61,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 30,
-            end: 39,
+            start: 32,
+            end: 41,
         },
         original_span: Span {
             start: 22,
@@ -102,8 +71,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 32,
-            end: 38,
+            start: 34,
+            end: 40,
         },
         original_span: Span {
             start: 24,
@@ -112,8 +81,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 39,
-            end: 56,
+            start: 41,
+            end: 58,
         },
         original_span: Span {
             start: 33,
@@ -122,8 +91,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 39,
-            end: 47,
+            start: 41,
+            end: 49,
         },
         original_span: Span {
             start: 33,
@@ -132,8 +101,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 40,
-            end: 46,
+            start: 42,
+            end: 48,
         },
         original_span: Span {
             start: 34,
@@ -142,8 +111,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 47,
-            end: 56,
+            start: 49,
+            end: 58,
         },
         original_span: Span {
             start: 43,
@@ -152,8 +121,8 @@ const a=1;async()=>{<><script></script><script></script></>};
     },
     Mapping {
         codegen_span: Span {
-            start: 49,
-            end: 55,
+            start: 51,
+            end: 57,
         },
         original_span: Span {
             start: 45,

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_basic_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_basic_vue.snap
@@ -1,11 +1,16 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
-assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
 
-const count=0;export default {data(){return{count}}};async()=>{<><template><div></div></template><script></script></>};
+const count = 0;export default {
+  data() {
+    return {
+      count
+    }
+  }
+};async()=>{<><template><div></div></template><script></script></>};
 
 =============== Mappings ===============
 
@@ -13,7 +18,7 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 119,
+            end: 147,
         },
         original_span: Span {
             start: 0,
@@ -23,7 +28,7 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 13,
+            end: 15,
         },
         original_span: Span {
             start: 55,
@@ -32,38 +37,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 5,
-            end: 13,
-        },
-        original_span: Span {
-            start: 61,
-            end: 70,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 5,
-            end: 11,
-        },
-        original_span: Span {
-            start: 61,
-            end: 66,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 12,
-            end: 13,
-        },
-        original_span: Span {
-            start: 69,
-            end: 70,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 14,
-            end: 52,
+            start: 16,
+            end: 80,
         },
         original_span: Span {
             start: 72,
@@ -72,88 +47,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 29,
-            end: 52,
-        },
-        original_span: Span {
-            start: 87,
-            end: 136,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 30,
-            end: 51,
-        },
-        original_span: Span {
-            start: 91,
-            end: 134,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 30,
-            end: 34,
-        },
-        original_span: Span {
-            start: 91,
-            end: 95,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 35,
-            end: 35,
-        },
-        original_span: Span {
-            start: 95,
-            end: 97,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 36,
-            end: 51,
-        },
-        original_span: Span {
-            start: 98,
-            end: 134,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 37,
-            end: 50,
-        },
-        original_span: Span {
-            start: 104,
-            end: 130,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 43,
-            end: 50,
-        },
-        original_span: Span {
-            start: 111,
-            end: 130,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 44,
-            end: 49,
-        },
-        original_span: Span {
-            start: 119,
-            end: 124,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 65,
-            end: 97,
+            start: 93,
+            end: 125,
         },
         original_span: Span {
             start: 0,
@@ -162,8 +57,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 65,
-            end: 75,
+            start: 93,
+            end: 103,
         },
         original_span: Span {
             start: 0,
@@ -172,8 +67,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 66,
-            end: 74,
+            start: 94,
+            end: 102,
         },
         original_span: Span {
             start: 1,
@@ -182,8 +77,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 75,
-            end: 86,
+            start: 103,
+            end: 114,
         },
         original_span: Span {
             start: 13,
@@ -192,8 +87,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 75,
-            end: 80,
+            start: 103,
+            end: 108,
         },
         original_span: Span {
             start: 13,
@@ -202,8 +97,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 76,
-            end: 79,
+            start: 104,
+            end: 107,
         },
         original_span: Span {
             start: 14,
@@ -212,8 +107,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 80,
-            end: 86,
+            start: 108,
+            end: 114,
         },
         original_span: Span {
             start: 26,
@@ -222,8 +117,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 82,
-            end: 85,
+            start: 110,
+            end: 113,
         },
         original_span: Span {
             start: 28,
@@ -232,8 +127,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 86,
-            end: 97,
+            start: 114,
+            end: 125,
         },
         original_span: Span {
             start: 33,
@@ -242,8 +137,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 88,
-            end: 96,
+            start: 116,
+            end: 124,
         },
         original_span: Span {
             start: 35,
@@ -252,8 +147,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 97,
-            end: 114,
+            start: 125,
+            end: 142,
         },
         original_span: Span {
             start: 46,
@@ -262,8 +157,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 97,
-            end: 105,
+            start: 125,
+            end: 133,
         },
         original_span: Span {
             start: 46,
@@ -272,8 +167,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 98,
-            end: 104,
+            start: 126,
+            end: 132,
         },
         original_span: Span {
             start: 47,
@@ -282,8 +177,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 105,
-            end: 114,
+            start: 133,
+            end: 142,
         },
         original_span: Span {
             start: 137,
@@ -292,8 +187,8 @@ const count=0;export default {data(){return{count}}};async()=>{<><template><div>
     },
     Mapping {
         codegen_span: Span {
-            start: 107,
-            end: 113,
+            start: 135,
+            end: 141,
         },
         original_span: Span {
             start: 139,

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_both_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_both_vue.snap
@@ -1,11 +1,16 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
-assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
 
-import{ref}from'vue';const count=0;export default {data(){return{count}}};async()=>{const number=ref(-1);<><template><div></div></template><script setup></script><script></script></>};
+import { ref } from 'vue';const count = 0;export default {
+  data() {
+    return {
+      count,
+    }
+  }
+};async()=>{const number = ref(-1);<><template><div></div></template><script setup></script><script></script></>};
 
 =============== Mappings ===============
 
@@ -13,7 +18,7 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 184,
+            end: 220,
         },
         original_span: Span {
             start: 0,
@@ -23,7 +28,7 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 20,
+            end: 26,
         },
         original_span: Span {
             start: 61,
@@ -32,18 +37,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 7,
-            end: 10,
-        },
-        original_span: Span {
-            start: 70,
-            end: 73,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 21,
-            end: 34,
+            start: 26,
+            end: 42,
         },
         original_span: Span {
             start: 133,
@@ -52,38 +47,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 26,
-            end: 34,
-        },
-        original_span: Span {
-            start: 139,
-            end: 148,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 26,
-            end: 32,
-        },
-        original_span: Span {
-            start: 139,
-            end: 144,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 33,
-            end: 34,
-        },
-        original_span: Span {
-            start: 147,
-            end: 148,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 35,
-            end: 73,
+            start: 42,
+            end: 107,
         },
         original_span: Span {
             start: 151,
@@ -92,88 +57,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 50,
-            end: 73,
-        },
-        original_span: Span {
-            start: 166,
-            end: 216,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 72,
-        },
-        original_span: Span {
-            start: 170,
-            end: 214,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 55,
-        },
-        original_span: Span {
-            start: 170,
-            end: 174,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 56,
-            end: 56,
-        },
-        original_span: Span {
-            start: 174,
-            end: 176,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 57,
-            end: 72,
-        },
-        original_span: Span {
-            start: 177,
-            end: 214,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 58,
-            end: 71,
-        },
-        original_span: Span {
-            start: 183,
-            end: 210,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 64,
-            end: 71,
-        },
-        original_span: Span {
-            start: 190,
-            end: 210,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 65,
-            end: 70,
-        },
-        original_span: Span {
-            start: 198,
-            end: 203,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 84,
-            end: 104,
+            start: 118,
+            end: 141,
         },
         original_span: Span {
             start: 89,
@@ -182,68 +67,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 89,
-            end: 104,
-        },
-        original_span: Span {
-            start: 95,
-            end: 111,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 89,
-            end: 96,
-        },
-        original_span: Span {
-            start: 95,
-            end: 101,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 97,
-            end: 104,
-        },
-        original_span: Span {
-            start: 104,
-            end: 111,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 97,
-            end: 100,
-        },
-        original_span: Span {
-            start: 104,
-            end: 107,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 101,
-            end: 103,
-        },
-        original_span: Span {
-            start: 108,
-            end: 110,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 102,
-            end: 103,
-        },
-        original_span: Span {
-            start: 109,
-            end: 110,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 107,
-            end: 139,
+            start: 143,
+            end: 175,
         },
         original_span: Span {
             start: 0,
@@ -252,8 +77,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 107,
-            end: 117,
+            start: 143,
+            end: 153,
         },
         original_span: Span {
             start: 0,
@@ -262,8 +87,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 108,
-            end: 116,
+            start: 144,
+            end: 152,
         },
         original_span: Span {
             start: 1,
@@ -272,8 +97,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 117,
-            end: 128,
+            start: 153,
+            end: 164,
         },
         original_span: Span {
             start: 13,
@@ -282,8 +107,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 117,
-            end: 122,
+            start: 153,
+            end: 158,
         },
         original_span: Span {
             start: 13,
@@ -292,8 +117,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 118,
-            end: 121,
+            start: 154,
+            end: 157,
         },
         original_span: Span {
             start: 14,
@@ -302,8 +127,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 122,
-            end: 128,
+            start: 158,
+            end: 164,
         },
         original_span: Span {
             start: 26,
@@ -312,8 +137,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 124,
-            end: 127,
+            start: 160,
+            end: 163,
         },
         original_span: Span {
             start: 28,
@@ -322,8 +147,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 128,
-            end: 139,
+            start: 164,
+            end: 175,
         },
         original_span: Span {
             start: 33,
@@ -332,8 +157,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 130,
-            end: 138,
+            start: 166,
+            end: 174,
         },
         original_span: Span {
             start: 35,
@@ -342,8 +167,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 139,
-            end: 162,
+            start: 175,
+            end: 198,
         },
         original_span: Span {
             start: 46,
@@ -352,8 +177,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 139,
-            end: 153,
+            start: 175,
+            end: 189,
         },
         original_span: Span {
             start: 46,
@@ -362,8 +187,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 140,
-            end: 146,
+            start: 176,
+            end: 182,
         },
         original_span: Span {
             start: 47,
@@ -372,8 +197,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 147,
-            end: 152,
+            start: 183,
+            end: 188,
         },
         original_span: Span {
             start: 54,
@@ -382,8 +207,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 153,
-            end: 162,
+            start: 189,
+            end: 198,
         },
         original_span: Span {
             start: 113,
@@ -392,8 +217,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 155,
-            end: 161,
+            start: 191,
+            end: 197,
         },
         original_span: Span {
             start: 115,
@@ -402,8 +227,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 162,
-            end: 179,
+            start: 198,
+            end: 215,
         },
         original_span: Span {
             start: 124,
@@ -412,8 +237,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 162,
-            end: 170,
+            start: 198,
+            end: 206,
         },
         original_span: Span {
             start: 124,
@@ -422,8 +247,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 163,
-            end: 169,
+            start: 199,
+            end: 205,
         },
         original_span: Span {
             start: 125,
@@ -432,8 +257,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 170,
-            end: 179,
+            start: 206,
+            end: 215,
         },
         original_span: Span {
             start: 217,
@@ -442,8 +267,8 @@ import{ref}from'vue';const count=0;export default {data(){return{count}}};async(
     },
     Mapping {
         codegen_span: Span {
-            start: 172,
-            end: 178,
+            start: 208,
+            end: 214,
         },
         original_span: Span {
             start: 219,

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_codegen_fidelity_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_codegen_fidelity_vue.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
-assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
 
-import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;const separated=1_000_000;const hex=0x10;const binary=0b1010;const bigint=0x10n;const escaped='\x41';const attrs=<div label={'\x42'} raw="\x43"/>;const grouped=(a+b)+c;const object={foo:foo,wrapped:(foo)};const{foo:foo,bar:bar=1}=source;const arrow=(x)=>x;const instance=new Foo();async()=>{<><script lang="tsx"></script></>};
+import { foo as foo, bar as baz } from './dep';export { foo as foo };const decimal = 1.0;const separated = 1_000_000;const hex = 0x10;const binary = 0b1010;const bigint = 0x10n;const escaped = '\x41';const attrs = <div label={'\x42'} raw="\x43" />;const grouped = (a + b) + c;const object = { foo: foo, wrapped: (foo) };const { foo: foo, bar: bar = 1 } = source;const arrow = (x) => x;const instance = new Foo();async()=>{<><script lang="tsx"></script></>};
 
 =============== Mappings ===============
 
@@ -13,7 +12,7 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 404,
+            end: 457,
         },
         original_span: Span {
             start: 0,
@@ -23,7 +22,7 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 40,
+            end: 46,
         },
         original_span: Span {
             start: 20,
@@ -32,48 +31,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 7,
-            end: 10,
-        },
-        original_span: Span {
-            start: 29,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 14,
-            end: 17,
-        },
-        original_span: Span {
-            start: 36,
-            end: 39,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 18,
-            end: 21,
-        },
-        original_span: Span {
-            start: 41,
-            end: 44,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 25,
-            end: 28,
-        },
-        original_span: Span {
-            start: 48,
-            end: 51,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 41,
-            end: 59,
+            start: 47,
+            end: 68,
         },
         original_span: Span {
             start: 67,
@@ -82,38 +41,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 48,
-            end: 58,
-        },
-        original_span: Span {
-            start: 76,
-            end: 86,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 48,
-            end: 51,
-        },
-        original_span: Span {
-            start: 76,
-            end: 79,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 55,
-            end: 58,
-        },
-        original_span: Span {
-            start: 83,
-            end: 86,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 60,
-            end: 77,
+            start: 69,
+            end: 88,
         },
         original_span: Span {
             start: 90,
@@ -122,38 +51,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 65,
-            end: 77,
-        },
-        original_span: Span {
-            start: 96,
-            end: 109,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 65,
-            end: 73,
-        },
-        original_span: Span {
-            start: 96,
-            end: 103,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 74,
-            end: 77,
-        },
-        original_span: Span {
-            start: 106,
-            end: 109,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 78,
-            end: 103,
+            start: 89,
+            end: 116,
         },
         original_span: Span {
             start: 110,
@@ -162,38 +61,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 83,
-            end: 103,
-        },
-        original_span: Span {
-            start: 116,
-            end: 137,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 83,
-            end: 93,
-        },
-        original_span: Span {
-            start: 116,
-            end: 125,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 94,
-            end: 103,
-        },
-        original_span: Span {
-            start: 128,
-            end: 137,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 104,
-            end: 118,
+            start: 117,
+            end: 133,
         },
         original_span: Span {
             start: 138,
@@ -202,38 +71,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 109,
-            end: 118,
-        },
-        original_span: Span {
-            start: 144,
-            end: 154,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 109,
-            end: 113,
-        },
-        original_span: Span {
-            start: 144,
-            end: 147,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 114,
-            end: 118,
-        },
-        original_span: Span {
-            start: 150,
-            end: 154,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 119,
-            end: 138,
+            start: 134,
+            end: 155,
         },
         original_span: Span {
             start: 155,
@@ -242,38 +81,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 124,
-            end: 138,
-        },
-        original_span: Span {
-            start: 161,
+            start: 156,
             end: 176,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 124,
-            end: 131,
-        },
-        original_span: Span {
-            start: 161,
-            end: 167,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 132,
-            end: 138,
-        },
-        original_span: Span {
-            start: 170,
-            end: 176,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 139,
-            end: 157,
         },
         original_span: Span {
             start: 177,
@@ -282,38 +91,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 144,
-            end: 157,
-        },
-        original_span: Span {
-            start: 183,
-            end: 197,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 144,
-            end: 151,
-        },
-        original_span: Span {
-            start: 183,
-            end: 189,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 152,
-            end: 157,
-        },
-        original_span: Span {
-            start: 192,
-            end: 197,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 158,
-            end: 178,
+            start: 177,
+            end: 199,
         },
         original_span: Span {
             start: 198,
@@ -322,38 +101,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 163,
-            end: 178,
-        },
-        original_span: Span {
-            start: 204,
-            end: 220,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 163,
-            end: 171,
-        },
-        original_span: Span {
-            start: 204,
-            end: 211,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 172,
-            end: 178,
-        },
-        original_span: Span {
-            start: 214,
-            end: 220,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 179,
-            end: 223,
+            start: 200,
+            end: 247,
         },
         original_span: Span {
             start: 221,
@@ -362,118 +111,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 184,
-            end: 223,
-        },
-        original_span: Span {
-            start: 227,
-            end: 268,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 184,
-            end: 190,
-        },
-        original_span: Span {
-            start: 227,
-            end: 232,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 191,
-            end: 223,
-        },
-        original_span: Span {
-            start: 235,
-            end: 268,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 192,
-            end: 195,
-        },
-        original_span: Span {
-            start: 236,
-            end: 239,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 196,
-            end: 210,
-        },
-        original_span: Span {
-            start: 240,
-            end: 254,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 196,
-            end: 201,
-        },
-        original_span: Span {
-            start: 240,
-            end: 245,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 202,
-            end: 210,
-        },
-        original_span: Span {
-            start: 246,
-            end: 254,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 203,
-            end: 209,
-        },
-        original_span: Span {
-            start: 247,
-            end: 253,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 211,
-            end: 221,
-        },
-        original_span: Span {
-            start: 255,
-            end: 265,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 211,
-            end: 214,
-        },
-        original_span: Span {
-            start: 255,
-            end: 258,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 215,
-            end: 221,
-        },
-        original_span: Span {
-            start: 259,
-            end: 265,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 224,
-            end: 245,
+            start: 248,
+            end: 275,
         },
         original_span: Span {
             start: 269,
@@ -482,88 +121,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 229,
-            end: 245,
-        },
-        original_span: Span {
-            start: 275,
-            end: 296,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 229,
-            end: 237,
-        },
-        original_span: Span {
-            start: 275,
-            end: 282,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 238,
-            end: 245,
-        },
-        original_span: Span {
-            start: 285,
-            end: 296,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 238,
-            end: 243,
-        },
-        original_span: Span {
-            start: 285,
-            end: 292,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 239,
-            end: 242,
-        },
-        original_span: Span {
-            start: 286,
-            end: 291,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 239,
-            end: 240,
-        },
-        original_span: Span {
-            start: 286,
-            end: 287,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 241,
-            end: 242,
-        },
-        original_span: Span {
-            start: 290,
-            end: 291,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 244,
-            end: 245,
-        },
-        original_span: Span {
-            start: 295,
-            end: 296,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 246,
-            end: 282,
+            start: 276,
+            end: 319,
         },
         original_span: Span {
             start: 297,
@@ -572,108 +131,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 251,
-            end: 282,
-        },
-        original_span: Span {
-            start: 303,
-            end: 340,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 251,
-            end: 258,
-        },
-        original_span: Span {
-            start: 303,
-            end: 309,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 259,
-            end: 282,
-        },
-        original_span: Span {
-            start: 312,
-            end: 340,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 260,
-            end: 267,
-        },
-        original_span: Span {
-            start: 314,
-            end: 322,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 260,
-            end: 263,
-        },
-        original_span: Span {
-            start: 314,
-            end: 317,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 264,
-            end: 267,
-        },
-        original_span: Span {
-            start: 319,
-            end: 322,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 268,
-            end: 281,
-        },
-        original_span: Span {
-            start: 324,
-            end: 338,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 268,
-            end: 275,
-        },
-        original_span: Span {
-            start: 324,
-            end: 331,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 276,
-            end: 281,
-        },
-        original_span: Span {
-            start: 333,
-            end: 338,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 277,
-            end: 280,
-        },
-        original_span: Span {
-            start: 334,
-            end: 337,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 283,
-            end: 314,
+            start: 320,
+            end: 361,
         },
         original_span: Span {
             start: 341,
@@ -682,118 +141,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 288,
-            end: 314,
-        },
-        original_span: Span {
-            start: 347,
-            end: 382,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 288,
-            end: 307,
-        },
-        original_span: Span {
-            start: 347,
-            end: 373,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 289,
-            end: 296,
-        },
-        original_span: Span {
-            start: 349,
-            end: 357,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 289,
-            end: 292,
-        },
-        original_span: Span {
-            start: 349,
-            end: 352,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 293,
-            end: 296,
-        },
-        original_span: Span {
-            start: 354,
-            end: 357,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 297,
-            end: 306,
-        },
-        original_span: Span {
-            start: 359,
-            end: 371,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 297,
-            end: 300,
-        },
-        original_span: Span {
-            start: 359,
-            end: 362,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 301,
-            end: 306,
-        },
-        original_span: Span {
-            start: 364,
-            end: 371,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 301,
-            end: 304,
-        },
-        original_span: Span {
-            start: 364,
-            end: 367,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 305,
-            end: 306,
-        },
-        original_span: Span {
-            start: 370,
-            end: 371,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 308,
-            end: 314,
-        },
-        original_span: Span {
-            start: 376,
-            end: 382,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 315,
-            end: 333,
+            start: 362,
+            end: 384,
         },
         original_span: Span {
             start: 383,
@@ -802,68 +151,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 320,
-            end: 333,
-        },
-        original_span: Span {
-            start: 389,
-            end: 405,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 320,
-            end: 326,
-        },
-        original_span: Span {
-            start: 389,
-            end: 394,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 327,
-            end: 333,
-        },
-        original_span: Span {
-            start: 397,
-            end: 405,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 328,
-            end: 329,
-        },
-        original_span: Span {
-            start: 397,
-            end: 400,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 328,
-            end: 329,
-        },
-        original_span: Span {
-            start: 398,
-            end: 399,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 332,
-            end: 333,
-        },
-        original_span: Span {
-            start: 404,
-            end: 405,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 334,
-            end: 358,
+            start: 385,
+            end: 411,
         },
         original_span: Span {
             start: 406,
@@ -872,48 +161,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 339,
-            end: 358,
-        },
-        original_span: Span {
-            start: 412,
-            end: 432,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 339,
-            end: 348,
-        },
-        original_span: Span {
-            start: 412,
-            end: 420,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 349,
-            end: 358,
-        },
-        original_span: Span {
-            start: 423,
-            end: 432,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 352,
-            end: 356,
-        },
-        original_span: Span {
-            start: 427,
-            end: 430,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 371,
-            end: 399,
+            start: 424,
+            end: 452,
         },
         original_span: Span {
             start: 0,
@@ -922,8 +171,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 371,
-            end: 390,
+            start: 424,
+            end: 443,
         },
         original_span: Span {
             start: 0,
@@ -932,8 +181,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 372,
-            end: 378,
+            start: 425,
+            end: 431,
         },
         original_span: Span {
             start: 1,
@@ -942,8 +191,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 379,
-            end: 389,
+            start: 432,
+            end: 442,
         },
         original_span: Span {
             start: 8,
@@ -952,8 +201,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 379,
-            end: 383,
+            start: 432,
+            end: 436,
         },
         original_span: Span {
             start: 8,
@@ -962,8 +211,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 384,
-            end: 389,
+            start: 437,
+            end: 442,
         },
         original_span: Span {
             start: 14,
@@ -972,8 +221,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 390,
-            end: 399,
+            start: 443,
+            end: 452,
         },
         original_span: Span {
             start: 433,
@@ -982,8 +231,8 @@ import{foo as foo,bar as baz}from'./dep';export{foo as foo};const decimal=1.0;co
     },
     Mapping {
         codegen_span: Span {
-            start: 392,
-            end: 398,
+            start: 445,
+            end: 451,
         },
         original_span: Span {
             start: 435,

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_directive_prologue_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_directive_prologue_vue.snap
@@ -1,0 +1,182 @@
+---
+source: crates/vue_oxlint_jsx/src/test/codegen.rs
+expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
+---
+=============== Source Text ===============
+
+"use strict";"use asm";semiFunctionCall();export const x = 1;async()=>{functionCallWithoutSemi();<><script></script><script setup></script></>};
+
+=============== Mappings ===============
+
+[
+    Mapping {
+        codegen_span: Span {
+            start: 0,
+            end: 144,
+        },
+        original_span: Span {
+            start: 0,
+            end: 133,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 0,
+            end: 12,
+        },
+        original_span: Span {
+            start: 9,
+            end: 21,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 13,
+            end: 22,
+        },
+        original_span: Span {
+            start: 22,
+            end: 31,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 23,
+            end: 42,
+        },
+        original_span: Span {
+            start: 32,
+            end: 51,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 42,
+            end: 60,
+        },
+        original_span: Span {
+            start: 52,
+            end: 70,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 71,
+            end: 96,
+        },
+        original_span: Span {
+            start: 97,
+            end: 122,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 99,
+            end: 116,
+        },
+        original_span: Span {
+            start: 0,
+            end: 80,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 99,
+            end: 107,
+        },
+        original_span: Span {
+            start: 0,
+            end: 8,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 100,
+            end: 106,
+        },
+        original_span: Span {
+            start: 1,
+            end: 7,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 107,
+            end: 116,
+        },
+        original_span: Span {
+            start: 71,
+            end: 80,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 109,
+            end: 115,
+        },
+        original_span: Span {
+            start: 73,
+            end: 79,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 116,
+            end: 139,
+        },
+        original_span: Span {
+            start: 82,
+            end: 132,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 116,
+            end: 130,
+        },
+        original_span: Span {
+            start: 82,
+            end: 96,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 117,
+            end: 123,
+        },
+        original_span: Span {
+            start: 83,
+            end: 89,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 124,
+            end: 129,
+        },
+        original_span: Span {
+            start: 90,
+            end: 95,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 130,
+            end: 139,
+        },
+        original_span: Span {
+            start: 123,
+            end: 132,
+        },
+    },
+    Mapping {
+        codegen_span: Span {
+            start: 132,
+            end: 138,
+        },
+        original_span: Span {
+            start: 125,
+            end: 131,
+        },
+    },
+]

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_directives_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_directives_vue.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
-assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
 
-'use client';async()=>{'use server';<><script></script><script setup></script></>};
+"use client";async()=>{"use server";<><script></script><script setup></script></>};
 
 =============== Mappings ===============
 

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_mapping_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_mapping_vue.snap
@@ -22,11 +22,11 @@ expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 1,
+            end: 2,
         },
         original_span: Span {
             start: 9,
-            end: 10,
+            end: 11,
         },
     },
     Mapping {

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_setup_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/scripts_setup_vue.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
-assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
 
-import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></template><script setup></script></>};
+import { ref } from 'vue';async()=>{const count = ref(0);<><template><div></div></template><script setup></script></>};
 
 =============== Mappings ===============
 
@@ -13,7 +12,7 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 112,
+            end: 119,
         },
         original_span: Span {
             start: 0,
@@ -23,7 +22,7 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 20,
+            end: 25,
         },
         original_span: Span {
             start: 61,
@@ -32,18 +31,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 7,
-            end: 10,
-        },
-        original_span: Span {
-            start: 70,
-            end: 73,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 31,
-            end: 49,
+            start: 36,
+            end: 56,
         },
         original_span: Span {
             start: 88,
@@ -52,58 +41,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 36,
-            end: 49,
-        },
-        original_span: Span {
-            start: 94,
-            end: 108,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 36,
-            end: 42,
-        },
-        original_span: Span {
-            start: 94,
-            end: 99,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 43,
-            end: 49,
-        },
-        original_span: Span {
-            start: 102,
-            end: 108,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 43,
-            end: 46,
-        },
-        original_span: Span {
-            start: 102,
-            end: 105,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 47,
-            end: 48,
-        },
-        original_span: Span {
-            start: 106,
-            end: 107,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 52,
-            end: 84,
+            start: 59,
+            end: 91,
         },
         original_span: Span {
             start: 0,
@@ -112,8 +51,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 52,
-            end: 62,
+            start: 59,
+            end: 69,
         },
         original_span: Span {
             start: 0,
@@ -122,8 +61,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 53,
-            end: 61,
+            start: 60,
+            end: 68,
         },
         original_span: Span {
             start: 1,
@@ -132,8 +71,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 62,
-            end: 73,
+            start: 69,
+            end: 80,
         },
         original_span: Span {
             start: 13,
@@ -142,8 +81,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 62,
-            end: 67,
+            start: 69,
+            end: 74,
         },
         original_span: Span {
             start: 13,
@@ -152,8 +91,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 63,
-            end: 66,
+            start: 70,
+            end: 73,
         },
         original_span: Span {
             start: 14,
@@ -162,8 +101,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 67,
-            end: 73,
+            start: 74,
+            end: 80,
         },
         original_span: Span {
             start: 26,
@@ -172,8 +111,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 69,
-            end: 72,
+            start: 76,
+            end: 79,
         },
         original_span: Span {
             start: 28,
@@ -182,8 +121,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 73,
-            end: 84,
+            start: 80,
+            end: 91,
         },
         original_span: Span {
             start: 33,
@@ -192,8 +131,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 75,
-            end: 83,
+            start: 82,
+            end: 90,
         },
         original_span: Span {
             start: 35,
@@ -202,8 +141,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 84,
-            end: 107,
+            start: 91,
+            end: 114,
         },
         original_span: Span {
             start: 46,
@@ -212,8 +151,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 84,
-            end: 98,
+            start: 91,
+            end: 105,
         },
         original_span: Span {
             start: 46,
@@ -222,8 +161,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 85,
-            end: 91,
+            start: 92,
+            end: 98,
         },
         original_span: Span {
             start: 47,
@@ -232,8 +171,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 92,
-            end: 97,
+            start: 99,
+            end: 104,
         },
         original_span: Span {
             start: 54,
@@ -242,8 +181,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 98,
-            end: 107,
+            start: 105,
+            end: 114,
         },
         original_span: Span {
             start: 109,
@@ -252,8 +191,8 @@ import{ref}from'vue';async()=>{const count=ref(0);<><template><div></div></templ
     },
     Mapping {
         codegen_span: Span {
-            start: 100,
-            end: 106,
+            start: 107,
+            end: 113,
         },
         original_span: Span {
             start: 111,

--- a/crates/vue_oxlint_jsx/src/test/snapshots/codegen/typescript_vue.snap
+++ b/crates/vue_oxlint_jsx/src/test/snapshots/codegen/typescript_vue.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/vue_oxlint_jsx/src/test/codegen.rs
-assertion_line: 29
 expression: "format!(\"=============== Source Text ===============\\n\\n{}\\n\\n=============== Mappings ===============\\n\\n{:#?}\",\nret.source_text, ret.mappings)"
 ---
 =============== Source Text ===============
 
-async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><script lang="ts" setup></script><template><div>{a.msg}</div><div></div></template></>};
+async()=>{const a = someFunction<{ msg: 1 }>();const b = someFunction<SomeType>();<><script lang="ts" setup></script><template><div>{a.msg}</div><div></div></template></>};
 
 =============== Mappings ===============
 
@@ -13,7 +12,7 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     Mapping {
         codegen_span: Span {
             start: 0,
-            end: 166,
+            end: 172,
         },
         original_span: Span {
             start: 0,
@@ -23,7 +22,7 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     Mapping {
         codegen_span: Span {
             start: 10,
-            end: 42,
+            end: 46,
         },
         original_span: Span {
             start: 25,
@@ -32,108 +31,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 15,
-            end: 42,
-        },
-        original_span: Span {
-            start: 31,
-            end: 61,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 15,
-            end: 17,
-        },
-        original_span: Span {
-            start: 31,
-            end: 32,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 18,
-            end: 42,
-        },
-        original_span: Span {
-            start: 35,
-            end: 61,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 18,
-            end: 30,
-        },
-        original_span: Span {
-            start: 35,
-            end: 47,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 30,
-            end: 40,
-        },
-        original_span: Span {
             start: 47,
-            end: 59,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 31,
-            end: 39,
-        },
-        original_span: Span {
-            start: 48,
-            end: 58,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 32,
-            end: 37,
-        },
-        original_span: Span {
-            start: 50,
-            end: 56,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 32,
-            end: 35,
-        },
-        original_span: Span {
-            start: 50,
-            end: 53,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 36,
-            end: 37,
-        },
-        original_span: Span {
-            start: 53,
-            end: 56,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 36,
-            end: 37,
-        },
-        original_span: Span {
-            start: 55,
-            end: 56,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 43,
-            end: 75,
+            end: 81,
         },
         original_span: Span {
             start: 62,
@@ -142,68 +41,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 48,
-            end: 75,
-        },
-        original_span: Span {
-            start: 68,
-            end: 96,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 48,
-            end: 50,
-        },
-        original_span: Span {
-            start: 68,
-            end: 69,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 75,
-        },
-        original_span: Span {
-            start: 72,
-            end: 96,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 51,
-            end: 63,
-        },
-        original_span: Span {
-            start: 72,
-            end: 84,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 63,
-            end: 73,
-        },
-        original_span: Span {
             start: 84,
-            end: 94,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 64,
-            end: 72,
-        },
-        original_span: Span {
-            start: 85,
-            end: 93,
-        },
-    },
-    Mapping {
-        codegen_span: Span {
-            start: 78,
-            end: 111,
+            end: 117,
         },
         original_span: Span {
             start: 0,
@@ -212,8 +51,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 78,
-            end: 102,
+            start: 84,
+            end: 108,
         },
         original_span: Span {
             start: 0,
@@ -222,8 +61,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 79,
-            end: 85,
+            start: 85,
+            end: 91,
         },
         original_span: Span {
             start: 1,
@@ -232,8 +71,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 86,
-            end: 95,
+            start: 92,
+            end: 101,
         },
         original_span: Span {
             start: 8,
@@ -242,8 +81,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 86,
-            end: 90,
+            start: 92,
+            end: 96,
         },
         original_span: Span {
             start: 8,
@@ -252,8 +91,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 91,
-            end: 95,
+            start: 97,
+            end: 101,
         },
         original_span: Span {
             start: 14,
@@ -262,8 +101,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 96,
-            end: 101,
+            start: 102,
+            end: 107,
         },
         original_span: Span {
             start: 18,
@@ -272,8 +111,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 102,
-            end: 111,
+            start: 108,
+            end: 117,
         },
         original_span: Span {
             start: 115,
@@ -282,8 +121,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 104,
-            end: 110,
+            start: 110,
+            end: 116,
         },
         original_span: Span {
             start: 117,
@@ -292,8 +131,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 111,
-            end: 161,
+            start: 117,
+            end: 167,
         },
         original_span: Span {
             start: 126,
@@ -302,8 +141,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 111,
-            end: 121,
+            start: 117,
+            end: 127,
         },
         original_span: Span {
             start: 126,
@@ -312,8 +151,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 112,
-            end: 120,
+            start: 118,
+            end: 126,
         },
         original_span: Span {
             start: 127,
@@ -322,8 +161,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 121,
-            end: 139,
+            start: 127,
+            end: 145,
         },
         original_span: Span {
             start: 139,
@@ -332,8 +171,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 121,
-            end: 126,
+            start: 127,
+            end: 132,
         },
         original_span: Span {
             start: 139,
@@ -342,8 +181,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 122,
-            end: 125,
+            start: 128,
+            end: 131,
         },
         original_span: Span {
             start: 140,
@@ -352,8 +191,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 126,
-            end: 133,
+            start: 132,
+            end: 139,
         },
         original_span: Span {
             start: 144,
@@ -362,8 +201,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 127,
-            end: 132,
+            start: 133,
+            end: 138,
         },
         original_span: Span {
             start: 147,
@@ -372,8 +211,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 127,
-            end: 128,
+            start: 133,
+            end: 134,
         },
         original_span: Span {
             start: 147,
@@ -382,8 +221,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 129,
-            end: 132,
+            start: 135,
+            end: 138,
         },
         original_span: Span {
             start: 149,
@@ -392,8 +231,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 133,
-            end: 139,
+            start: 139,
+            end: 145,
         },
         original_span: Span {
             start: 155,
@@ -402,8 +241,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 135,
-            end: 138,
+            start: 141,
+            end: 144,
         },
         original_span: Span {
             start: 157,
@@ -412,8 +251,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 139,
-            end: 150,
+            start: 145,
+            end: 156,
         },
         original_span: Span {
             start: 164,
@@ -422,8 +261,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 139,
-            end: 144,
+            start: 145,
+            end: 150,
         },
         original_span: Span {
             start: 164,
@@ -432,8 +271,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 140,
-            end: 143,
+            start: 146,
+            end: 149,
         },
         original_span: Span {
             start: 165,
@@ -442,8 +281,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 144,
-            end: 150,
+            start: 150,
+            end: 156,
         },
         original_span: Span {
             start: 195,
@@ -452,8 +291,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 146,
-            end: 149,
+            start: 152,
+            end: 155,
         },
         original_span: Span {
             start: 197,
@@ -462,8 +301,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 150,
-            end: 161,
+            start: 156,
+            end: 167,
         },
         original_span: Span {
             start: 202,
@@ -472,8 +311,8 @@ async()=>{const a=someFunction<{msg:1;}>();const b=someFunction<SomeType>();<><s
     },
     Mapping {
         codegen_span: Span {
-            start: 152,
-            end: 160,
+            start: 158,
+            end: 166,
         },
         original_span: Span {
             start: 204,

--- a/packages/vue-oxlint-toolkit/tests/index.test.ts
+++ b/packages/vue-oxlint-toolkit/tests/index.test.ts
@@ -12,7 +12,7 @@ const msg: string = 'hello'
   const result = transformJsx(source)
 
   expect(result.scriptKind).toBe('tsx')
-  expect(result.sourceText).toContain("const msg:string='hello';")
+  expect(result.sourceText).toContain("const msg: string = 'hello'")
   expect(result.sourceText).toContain('<div>{msg}</div>')
 
   const originalStart = source.indexOf('msg }}</')


### PR DESCRIPTION
## Summary

Implements the RFC at `rfcs/clean-codegen-mapping.md`.

- Adds a `clean_spans: FxHashSet<Span>` field to `ParserImpl` — populated with the spans of every top-level statement and directive produced by each `<script>` / `<script setup>` `oxc_parse` call.
- `ParserImplReturn` now carries `clean_spans` through to `VueJsxCodegen::build`.
- `Codegen` gains `with_clean_spans()` and, before printing any node, calls `try_emit_clean`:
  - **Clean node**: emit `source_text[span]` verbatim + push a single `Mapping` → skip all child traversal.
  - **Dirty node**: normal recursive codegen as before.
- `needs_semicolon` is updated so the `;` separator between statements is still emitted correctly even when source doesn't have explicit semicolons.

### Effect on output

Script-level nodes now preserve original whitespace/formatting instead of being minified, and produce **one** mapping entry per top-level statement instead of deeply-nested per-child entries. Template codegen is unchanged.

## Test plan

- [x] All 48 Rust unit/snapshot tests pass (`cargo test -p vue_oxlint_jsx`)
- [x] Updated 10 codegen snapshots that changed due to cleaner mappings + preserved formatting
- [x] 5 JS integration tests pass (`vp test`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)