### PR TITLE
feat(parser): scaffold V-tree AST and parser/lexer skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,8 +1730,10 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_diagnostics",
+ "oxc_parser",
  "oxc_span",
- "vue-compiler-core",
+ "oxc_syntax",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]

--- a/crates/vue_oxlint_parser/Cargo.toml
+++ b/crates/vue_oxlint_parser/Cargo.toml
@@ -14,10 +14,12 @@ description = "Rust port of vue-eslint-parser: AST types and SFC parser for Vue 
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_diagnostics = { workspace = true }
+oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
 
 memchr = { workspace = true }
-vue-compiler-core = { workspace = true }
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/vue_oxlint_parser/src/ast.rs
+++ b/crates/vue_oxlint_parser/src/ast.rs
@@ -1,0 +1,232 @@
+//! V-tree AST for Vue single-file components.
+//!
+//! See `rfcs/vue-oxlint-parser.md` for the design rationale.
+//!
+//! ## Lifetimes
+//!
+//! - `'a` — owns all `V*` nodes (the V-tree itself).
+//! - `'b` — owns nodes produced by [`oxc_parser`] (script `Program`s, embedded
+//!   `Expression`s, `Statement`s, `BindingPattern`s, etc.) referenced from the
+//!   V-tree.
+//!
+//! Constraint: `'b: 'a`. Nodes in `'a` may reference nodes in `'b`; nodes in
+//! `'b` never reference nodes in `'a`; the two arenas are never mixed in a
+//! single `Vec`.
+
+use oxc_allocator::Vec as ArenaVec;
+use oxc_ast::ast::{Expression, FormalParameter, Statement};
+use oxc_span::Span;
+
+/// Root of a parsed Vue SFC.
+///
+/// `children` is a flat list of top-level SFC nodes (e.g. `<template>`,
+/// `<script>`, `<style>`, plus any whitespace / comments between them).
+pub struct VueSingleFileComponent<'a, 'b> {
+  pub children: ArenaVec<'a, VNode<'a, 'b>>,
+  /// Comments collected from `<script>` / `<script setup>` bodies.
+  ///
+  /// HTML `<!-- -->` comments live as [`VComment`] nodes in the tree and are
+  /// **not** flattened here.
+  pub script_comments: ArenaVec<'a, oxc_ast::Comment>,
+  pub source_type: oxc_span::SourceType,
+}
+
+/// A node in the V-tree.
+pub enum VNode<'a, 'b> {
+  Element(VElement<'a, 'b>),
+  Text(VText<'a>),
+  Comment(VComment<'a>),
+  Interpolation(VInterpolation<'b>),
+  CData(VCData<'a>),
+}
+
+impl VNode<'_, '_> {
+  #[must_use]
+  pub const fn span(&self) -> Span {
+    match self {
+      Self::Element(e) => e.span,
+      Self::Text(t) => t.span,
+      Self::Comment(c) => c.span,
+      Self::Interpolation(i) => i.span,
+      Self::CData(c) => c.span,
+    }
+  }
+}
+
+/// `<tag ...> ... </tag>` (or self-closing).
+pub struct VElement<'a, 'b> {
+  pub start_tag: VStartTag<'a, 'b>,
+  /// `None` for self-closing or void elements.
+  pub end_tag: Option<VEndTag>,
+  pub children: ArenaVec<'a, VNode<'a, 'b>>,
+  pub span: Span,
+}
+
+pub struct VStartTag<'a, 'b> {
+  /// Span of the tag name only (`div` in `<div ...>`).
+  pub name_span: Span,
+  pub attributes: ArenaVec<'a, VAttributeOrDirective<'a, 'b>>,
+  pub self_closing: bool,
+  /// Span of the entire start tag, including `<` and `>`.
+  pub span: Span,
+}
+
+pub struct VEndTag {
+  /// Span of the tag name only (`div` in `</div>`).
+  pub name_span: Span,
+  /// Span of the entire end tag, including `</` and `>`.
+  pub span: Span,
+}
+
+pub enum VAttributeOrDirective<'a, 'b> {
+  Attribute(VAttribute<'a>),
+  Directive(VDirective<'a, 'b>),
+}
+
+impl VAttributeOrDirective<'_, '_> {
+  #[must_use]
+  pub const fn span(&self) -> Span {
+    match self {
+      Self::Attribute(a) => a.span,
+      Self::Directive(d) => d.span,
+    }
+  }
+}
+
+/// A plain (non-directive) HTML attribute, e.g. `id="foo"`.
+pub struct VAttribute<'a> {
+  pub key: VAttributeKey<'a>,
+  pub value: Option<VAttributeValue<'a>>,
+  pub span: Span,
+}
+
+pub struct VAttributeKey<'a> {
+  pub name: &'a str,
+  pub span: Span,
+}
+
+/// An HTML attribute value, with both raw and decoded forms.
+pub struct VAttributeValue<'a> {
+  /// Raw text between the quotes (or unquoted), as it appears in source.
+  pub raw: &'a str,
+  /// Decoded value (HTML entities resolved). Allocated in `'a` if decoding
+  /// produced a different string from `raw`.
+  pub value: &'a str,
+  /// Span covering the value, including surrounding quotes if any.
+  pub span: Span,
+  pub quote: VQuote,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VQuote {
+  Double,
+  Single,
+  Unquoted,
+}
+
+/// A Vue directive: `v-name:arg.mod1.mod2="expr"`, or its shorthand forms
+/// (`:`, `@`, `#`, `.`).
+pub struct VDirective<'a, 'b> {
+  pub key: VDirectiveKey<'a>,
+  pub value: Option<VDirectiveValue<'a, 'b>>,
+  pub span: Span,
+}
+
+pub struct VDirectiveKey<'a> {
+  /// Directive name without `v-` prefix (e.g. `bind`, `on`, `for`, `slot`).
+  pub name: VDirectiveName<'a>,
+  /// `:arg` part. May be a static identifier or a dynamic `[expr]` argument.
+  pub argument: Option<VDirectiveArgument<'a>>,
+  /// `.mod` parts.
+  pub modifiers: ArenaVec<'a, VDirectiveModifier<'a>>,
+  /// Span covering the entire key (name + argument + modifiers), excluding
+  /// `=` and the value.
+  pub span: Span,
+}
+
+pub struct VDirectiveName<'a> {
+  pub name: &'a str,
+  pub span: Span,
+}
+
+pub struct VDirectiveArgument<'a> {
+  pub raw: &'a str,
+  pub kind: VDirectiveArgumentKind,
+  pub span: Span,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VDirectiveArgumentKind {
+  /// `v-bind:foo`
+  Static,
+  /// `v-bind:[foo]`
+  Dynamic,
+}
+
+pub struct VDirectiveModifier<'a> {
+  pub name: &'a str,
+  pub span: Span,
+}
+
+/// Directive value, with its parsed JavaScript form attached.
+///
+/// The exact JS shape depends on the directive kind — see the table in the
+/// RFC. Spans on the embedded JS nodes refer to original SFC byte offsets.
+pub struct VDirectiveValue<'a, 'b> {
+  pub raw: &'a str,
+  pub span: Span,
+  pub quote: VQuote,
+  pub expression: VDirectiveExpression<'a, 'b>,
+}
+
+pub enum VDirectiveExpression<'a, 'b> {
+  /// Generic expression (`v-bind`, `v-if`, `v-show`, `v-model`, `:foo`, …).
+  Expression(&'b Expression<'b>),
+  /// `v-for="(item, index) in items"`.
+  VFor(VForDirective<'b>),
+  /// `v-slot:name="(props)"`.
+  VSlot(VSlotDirective<'b>),
+  /// `v-on:evt="…"` / `@evt="…"`. Body is parsed as a statement list.
+  VOn(VOnExpression<'a, 'b>),
+}
+
+pub struct VForDirective<'b> {
+  pub left: &'b FormalParameter<'b>,
+  pub right: &'b Expression<'b>,
+}
+
+pub struct VSlotDirective<'b> {
+  pub params: &'b FormalParameter<'b>,
+}
+
+pub struct VOnExpression<'a, 'b> {
+  pub statements: ArenaVec<'a, Statement<'b>>,
+}
+
+/// `{{ expression }}`.
+pub struct VInterpolation<'b> {
+  pub expression: &'b Expression<'b>,
+  pub span: Span,
+}
+
+/// Plain text node.
+pub struct VText<'a> {
+  /// Raw text as it appears in source (including HTML entities).
+  pub raw: &'a str,
+  /// HTML-entity-decoded text.
+  pub value: &'a str,
+  pub span: Span,
+}
+
+/// `<!-- comment -->`.
+pub struct VComment<'a> {
+  /// Comment body, excluding `<!--` and `-->`.
+  pub value: &'a str,
+  pub span: Span,
+}
+
+/// `<![CDATA[ ... ]]>` — only valid in foreign content (`<svg>`, `<math>`).
+pub struct VCData<'a> {
+  pub value: &'a str,
+  pub span: Span,
+}

--- a/crates/vue_oxlint_parser/src/lexer/mod.rs
+++ b/crates/vue_oxlint_parser/src/lexer/mod.rs
@@ -1,0 +1,95 @@
+//! Vue template lexer.
+//!
+//! Phase 2 of the RFC will implement this. For now the module exposes only
+//! the [`VToken`] / [`VTokenKind`] shapes and a [`Lexer`] skeleton whose
+//! methods are all `todo!()`.
+//!
+//! The lexer will be HTML5-aware (raw-text for `<script>`, `<style>`,
+//! `<textarea>`, `<title>`; foreign content for `<svg>`, `<math>`) and will
+//! honour `v-pre`, mirroring `vue-eslint-parser`.
+
+mod tokens;
+
+pub use tokens::{VToken, VTokenKind};
+
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+
+/// HTML5 tokenizer modes.
+///
+/// The lexer switches between these as it crosses element boundaries (e.g.
+/// entering `<script>` switches to [`LexerMode::RawText`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LexerMode {
+  /// Default mode — recognises tags, comments, character references, etc.
+  Data,
+  /// `<script>`, `<style>`, `<xmp>`, etc. — only the closing tag terminates.
+  RawText,
+  /// `<textarea>`, `<title>` — character references resolved, but no tags.
+  RcData,
+  /// `<svg>`, `<math>` — foreign content rules (CDATA allowed, etc.).
+  Foreign,
+  /// Inside a `v-pre` subtree — directives are not recognised, but tags are.
+  VPre,
+}
+
+/// Vue template lexer.
+///
+/// The lexer produces [`VToken`]s in source order, with spans in the original
+/// SFC byte-offset space.
+pub struct Lexer<'a> {
+  allocator: &'a Allocator,
+  #[expect(dead_code, reason = "phase 2 will scan this")]
+  source_text: &'a str,
+  mode: LexerMode,
+  tokens: ArenaVec<'a, VToken>,
+  errors: Vec<OxcDiagnostic>,
+}
+
+impl<'a> Lexer<'a> {
+  #[must_use]
+  pub fn new(allocator: &'a Allocator, source_text: &'a str) -> Self {
+    Self {
+      allocator,
+      source_text,
+      mode: LexerMode::Data,
+      tokens: ArenaVec::new_in(allocator),
+      errors: Vec::new(),
+    }
+  }
+
+  #[must_use]
+  pub const fn mode(&self) -> LexerMode {
+    self.mode
+  }
+
+  pub const fn set_mode(&mut self, mode: LexerMode) {
+    self.mode = mode;
+  }
+
+  /// Advance the lexer by one token, pushing it into the internal buffer.
+  ///
+  /// Returns the token kind for the parser's lookahead, or `None` at EOF.
+  pub fn next_token(&mut self) -> Option<VToken> {
+    todo!("phase 2: implement template tokenization")
+  }
+
+  /// Lex a contiguous run of raw text terminated by `</{tag}>` (case-insensitive).
+  ///
+  /// Used for `<script>` / `<style>` bodies, where the parser will hand off
+  /// the resulting span to `oxc_parser` rather than tokenising the contents.
+  pub fn lex_raw_text_until(&mut self, _close_tag: &str) -> Span {
+    todo!("phase 2: implement raw-text scanning")
+  }
+
+  /// Consume and return all tokens collected so far, leaving the lexer empty.
+  pub fn take_tokens(&mut self) -> ArenaVec<'a, VToken> {
+    std::mem::replace(&mut self.tokens, ArenaVec::new_in(self.allocator))
+  }
+
+  /// Drain all errors collected so far.
+  pub fn take_errors(&mut self) -> Vec<OxcDiagnostic> {
+    std::mem::take(&mut self.errors)
+  }
+}

--- a/crates/vue_oxlint_parser/src/lexer/tokens.rs
+++ b/crates/vue_oxlint_parser/src/lexer/tokens.rs
@@ -1,0 +1,34 @@
+//! Tokens emitted by the Vue template lexer.
+//!
+//! The intent is to be compatible with `vue-eslint-parser`'s token output, so
+//! that the toolkit's `ESTree` adapter can include them in `Program.tokens`.
+//!
+//! Phase 2 of the RFC will flesh this out and implement the lexer that
+//! produces it.
+
+use oxc_span::Span;
+
+/// A single template-side token.
+///
+/// Spans are in original SFC byte-offset space.
+//
+// NOTE: This is a placeholder shape. Phase 2 will:
+//   - finalise the variant set against `vue-eslint-parser`'s token kinds
+//   - decide whether to pack into `u128` like `oxc_parser::Token` for parity
+//     with the script-side tokens
+#[derive(Debug, Clone, Copy)]
+pub struct VToken {
+  pub kind: VTokenKind,
+  pub span: Span,
+}
+
+/// Template-side token kinds.
+///
+/// This enum is intentionally not yet exhaustive — phase 2 will expand it to
+/// match `vue-eslint-parser`'s token kinds (the `HTML*` family, plus
+/// `VExpressionStart` / `VExpressionEnd`, `Punctuator`, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VTokenKind {
+  /// Placeholder for the not-yet-defined variants.
+  Placeholder,
+}

--- a/crates/vue_oxlint_parser/src/lib.rs
+++ b/crates/vue_oxlint_parser/src/lib.rs
@@ -1,6 +1,17 @@
-// Goal: A Rust port of vue-eslint-parser.
-#[must_use]
-pub fn parse_vue() -> String {
-  // It is now a placeholder.
-  todo!()
-}
+//! `vue_oxlint_parser` — first-party Vue SFC parser for the toolkit.
+//!
+//! See `rfcs/vue-oxlint-parser.md` for the design. This crate is being built
+//! out in phases:
+//!
+//! - **Phase 1 (this commit)**: V-tree AST, parser/lexer module skeleton,
+//!   public surface. Parsing logic is `todo!()`.
+//! - Phase 2: high-compatibility template lexer + tokens.
+//! - Phase 3: `<script>` / `<script setup>` utilities ported from
+//!   `vue_oxlint_jsx`.
+//! - Phase 4: recursive-descent parser implementation.
+
+pub mod ast;
+pub mod lexer;
+pub mod parser;
+
+pub use parser::{VueParseConfig, VueParser, VueParserReturn};

--- a/crates/vue_oxlint_parser/src/parser/mod.rs
+++ b/crates/vue_oxlint_parser/src/parser/mod.rs
@@ -1,0 +1,144 @@
+//! Vue SFC recursive-descent parser.
+//!
+//! Phase 1 sets up the public surface and module structure; phases 3 and 4
+//! fill in the actual parsing logic.
+
+mod script;
+mod template;
+
+use std::ptr;
+
+use oxc_allocator::Allocator;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_parser::ParseOptions;
+use oxc_span::{SourceType, Span};
+use oxc_syntax::module_record::ModuleRecord;
+use rustc_hash::FxHashSet;
+
+use crate::ast::VueSingleFileComponent;
+use crate::lexer::Lexer;
+
+/// Result of a Vue SFC parse.
+///
+/// Mirrors `oxc_parser::ParserReturn` in spirit: a single struct with the
+/// parsed root, side-channel metadata, and a recoverable-vs-fatal split via
+/// `errors` + `panicked`.
+pub struct VueParserReturn<'a, 'b> {
+  pub sfc: VueSingleFileComponent<'a, 'b>,
+  pub irregular_whitespaces: Box<[Span]>,
+  /// Spans coming directly from a single `oxc_parser` call — see the
+  /// clean-codegen-mapping RFC for how the codegen side consumes this.
+  pub clean_spans: FxHashSet<Span>,
+  pub module_record: ModuleRecord<'b>,
+  /// Tokens from the script side, produced by `oxc_parser` with
+  /// [`oxc_parser::config::RuntimeParserConfig::new(true)`].
+  pub script_tokens: oxc_allocator::Vec<'b, oxc_parser::Token>,
+  /// Tokens from our first-party template lexer.
+  pub template_tokens: oxc_allocator::Vec<'a, crate::lexer::VToken>,
+  pub errors: Vec<OxcDiagnostic>,
+  /// Set on unrecoverable structural errors (e.g. unclosed `<template>`).
+  pub panicked: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VueParseConfig {
+  /// Whether the consumer needs the parser to record `clean_spans`. The JSX
+  /// crate sets this; the toolkit side doesn't need it.
+  pub track_clean_spans: bool,
+}
+
+/// Vue SFC parser.
+///
+/// ## Lifetimes
+///
+/// - `'a` owns V-tree nodes (allocated in `allocator_a`).
+/// - `'b` owns nodes produced by `oxc_parser` (allocated in `allocator_b`).
+/// - `'b: 'a` — V-tree nodes may borrow from `oxc_parser` output, never the
+///   reverse.
+///
+/// Two-allocator design is documented in the RFC; phase 1 wires the lifetime
+/// plumbing without committing to its correctness — the open question is
+/// flagged in the RFC.
+#[expect(
+  dead_code,
+  reason = "phases 3-4 will read these fields; kept on the struct so the public surface is stable from phase 1"
+)]
+pub struct VueParser<'a, 'b>
+where
+  'b: 'a,
+{
+  allocator_a: &'a Allocator,
+  allocator_b: &'b Allocator,
+  origin_source_text: &'a str,
+
+  options: ParseOptions,
+  config: VueParseConfig,
+
+  /// Mirror of [`crate::lexer::Lexer`]'s mutable buffer trick from the JSX
+  /// crate — wrap bytes are written here, parsed via `oxc_parser`, then the
+  /// buffer is reset to match `origin_source_text`.
+  ///
+  /// Spans on the resulting AST refer to original SFC offsets, not the
+  /// rewritten buffer.
+  source_text: &'a str,
+  mut_ptr_source_text: *mut [u8],
+
+  source_type: SourceType,
+  errors: Vec<OxcDiagnostic>,
+  clean_spans: FxHashSet<Span>,
+}
+
+impl<'a, 'b> VueParser<'a, 'b>
+where
+  'b: 'a,
+{
+  pub fn new(
+    allocator_a: &'a Allocator,
+    allocator_b: &'b Allocator,
+    source_text: &'a str,
+    options: ParseOptions,
+    config: VueParseConfig,
+  ) -> Self {
+    let alloced_str = allocator_a.alloc_slice_copy(source_text.as_bytes());
+
+    Self {
+      allocator_a,
+      allocator_b,
+      origin_source_text: source_text,
+      options,
+      config,
+
+      mut_ptr_source_text: ptr::from_mut(alloced_str),
+      // SAFETY: `alloced_str` was just copied from a `&str`.
+      source_text: unsafe { str::from_utf8_unchecked(alloced_str) },
+
+      source_type: SourceType::mjs().with_unambiguous(true),
+      errors: Vec::new(),
+      clean_spans: FxHashSet::default(),
+    }
+  }
+
+  /// Parse the SFC. Phase 4 will implement this.
+  #[must_use]
+  pub fn parse(self) -> VueParserReturn<'a, 'b> {
+    let _lexer = Lexer::new(self.allocator_a, self.source_text);
+    todo!("phase 4: drive the lexer and recursive-descent parser")
+  }
+
+  /// Reset the mutable source buffer to match the original source.
+  ///
+  /// Called after each in-place wrap-and-parse cycle (see the RFC's
+  /// "Reusing the `oxc_parse` mutation trick" section).
+  pub const fn sync_source_text(&mut self) {
+    // SAFETY: `self.origin_source_text` and `self.mut_ptr_source_text` have
+    // identical lengths; the former lives on the heap and the latter in the
+    // arena, so the regions cannot overlap.
+    unsafe {
+      ptr::copy_nonoverlapping(
+        self.origin_source_text.as_ptr(),
+        self.mut_ptr_source_text.cast(),
+        self.origin_source_text.len(),
+      );
+    }
+  }
+}

--- a/crates/vue_oxlint_parser/src/parser/script.rs
+++ b/crates/vue_oxlint_parser/src/parser/script.rs
@@ -1,0 +1,16 @@
+//! `<script>` / `<script setup>` handling.
+//!
+//! Phase 3 will port the relevant utilities from `vue_oxlint_jsx`'s
+//! `parser::script` and `parser::modules`:
+//!
+//! - resolving `lang="ts"` / `lang="tsx"` into a `SourceType`
+//! - guarding against multiple `<script>` / `<script setup>` blocks with
+//!   conflicting `SourceType`s
+//! - feeding script body slices into `oxc_parser` via the wrap-and-reset
+//!   trick
+//! - merging the resulting [`oxc_syntax::module_record::ModuleRecord`]s
+//! - relocating `oxc_ast::Comment`s onto
+//!   [`crate::ast::VueSingleFileComponent::script_comments`]
+//!
+//! Phase 4 will then call into these helpers as the recursive-descent parser
+//! crosses each `<script>` block.

--- a/crates/vue_oxlint_parser/src/parser/template.rs
+++ b/crates/vue_oxlint_parser/src/parser/template.rs
@@ -1,0 +1,15 @@
+//! `<template>` body handling.
+//!
+//! Phase 4 will implement the recursive-descent parser that turns lexer
+//! tokens into the V-tree (`VElement`, `VText`, `VComment`, `VInterpolation`,
+//! `VCData`), including:
+//!
+//! - HTML5 open/close-tag matching with implied closes (e.g. `<p>` autoclose)
+//! - void / self-closing element handling
+//! - mode switches for `<script>` / `<style>` / `<textarea>` / `<title>` and
+//!   foreign content (`<svg>`, `<math>`)
+//! - `v-pre` subtree skipping for directive parsing
+//! - attribute / directive parsing, including dispatching embedded JS
+//!   regions (`v-bind`, `v-if`, `v-for`, `v-slot`, `v-on`, `{{ … }}`) to
+//!   `oxc_parser` via the wrap-and-reset trick on the `'b` arena
+//! - non-HTML preprocessor diagnostics for `<template lang="pug">` etc.


### PR DESCRIPTION
## Summary

Implements **phase 1** of `rfcs/vue-oxlint-parser.md` — the public surface and module skeleton for the first-party Vue SFC parser. No actual parsing logic; all parse / lex / metadata sites are `todo!()`.

- **V-tree AST** (`src/ast.rs`): `VueSingleFileComponent`, `VNode` (`VElement` / `VText` / `VComment` / `VInterpolation` / `VCData`), `VStartTag` / `VEndTag`, `VAttribute`, `VDirective` family (`VDirectiveKey`, `VDirectiveArgument`, `VDirectiveModifier`, `VDirectiveValue`, `VDirectiveExpression`), `VForDirective`, `VSlotDirective`, `VOnExpression`. Every node carries a `Span`; raw + decoded values are kept separately on `VText` and attribute values per the RFC.
- **Two-allocator lifetimes** (`'b: 'a`): V-tree in `'a`, `oxc_parser` output in `'b`. The lifetime plumbing is wired through `VueParser` and `VueParserReturn`; the open question about its soundness is preserved.
- **`VueParserReturn`** (`src/parser/mod.rs`): `sfc`, `irregular_whitespaces`, `clean_spans`, `module_record`, `script_tokens` (`oxc_parser::Token`), `template_tokens` (first-party `VToken`), `errors`, `panicked`.
- **Lexer skeleton** (`src/lexer/`): `Lexer`, `LexerMode` (Data / RawText / RcData / Foreign / VPre), `VToken` / `VTokenKind` placeholder for phase 2.
- **Parser skeleton** (`src/parser/`): `VueParser::new` allocates the mutable source buffer mirroring the JSX crate's `oxc_parse` mutation trick; `parse()` is `todo!()`. `script.rs` and `template.rs` are doc-only stubs describing what phases 3 and 4 will land there.

The legacy `parse_vue()` placeholder in `lib.rs` is replaced by the new public surface.

## Test plan

- [x] `cargo build -p vue_oxlint_parser`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --all-features --workspace`
- [ ] Phases 2-4 will land in follow-up PRs; this one intentionally only ships scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)