### PR TITLE
feat(parser): copy metadata and script parsing utils from jsx crate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,12 @@ Cargo workspace members live in `crates/*`, `packages/*`, and `benchmark/`.
   - `test/` — `test_ast!` and `test_module_record!` macros driving snapshot tests in `test/snapshots/`. `test_ast!` runs both AST and codegen checks on each fixture.
   - Public API is intentionally narrow: `VueJsxParser`/`VueJsxParserReturn` + `VueJsxCodegen`/`VueJsxCodegenReturn` (re-exported from `lib.rs`).
 
-- **`crates/vue_oxlint_parser`** — placeholder crate intended as a Rust port of `vue-eslint-parser`. Currently only contains a `parse_vue()` stub (`todo!()`). Plan to implement it to replace the internal parser of `vue_oxlint_jsx` and provide custom AST apis for napi bindings so that other existing Vue js plugins will be compatible with it.
+- **`crates/vue_oxlint_parser`** — in-progress Rust port of `vue-eslint-parser`.
+  - `ast.rs` — canonical V-tree surface (`VueSingleFileComponent`, `VElement`, directive/value nodes, embedded-JS attachment points).
+  - `lexer/` — first-party HTML/Vue template tokenizer, including raw-text/RCDATA/foreign-content/v-pre modes and vue-eslint-parser-compatible token kinds.
+  - `parser/mod.rs` — two-allocator `VueParser` scaffold and parse return surface.
+  - `parser/script.rs` — phase-3 script-side utilities: wrapped `oxc_parser` calls, script lang/source-type resolution, duplicate-script guards, module-record aggregation, comment/token collection, and clean-span tracking.
+  - `parser/template.rs` — reserved for the recursive-descent V-tree builder in phase 4.
 
 - **`packages/vue-oxlint-toolkit`** — published npm package `vue-oxlint-toolkit`.
   - `src/lib.rs` — napi-rs cdylib exposing `transformJsx(source)` which calls `VueJsxCodegen::build` and converts results to N-API types (`NativeTransformResult`).

--- a/crates/vue_oxlint_parser/src/parser/mod.rs
+++ b/crates/vue_oxlint_parser/src/parser/mod.rs
@@ -8,9 +8,10 @@ mod template;
 
 use std::ptr;
 
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_ast::Comment;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_parser::ParseOptions;
+use oxc_parser::{ParseOptions, Token};
 use oxc_span::{SourceType, Span};
 use oxc_syntax::module_record::ModuleRecord;
 use rustc_hash::FxHashSet;
@@ -59,10 +60,7 @@ pub struct VueParseConfig {
 /// Two-allocator design is documented in the RFC; phase 1 wires the lifetime
 /// plumbing without committing to its correctness — the open question is
 /// flagged in the RFC.
-#[expect(
-  dead_code,
-  reason = "phases 3-4 will read these fields; kept on the struct so the public surface is stable from phase 1"
-)]
+#[allow(dead_code, reason = "phase 4 parser integration will consume the stored script-side state")]
 pub struct VueParser<'a, 'b>
 where
   'b: 'a,
@@ -74,18 +72,27 @@ where
   options: ParseOptions,
   config: VueParseConfig,
 
-  /// Mirror of [`crate::lexer::Lexer`]'s mutable buffer trick from the JSX
-  /// crate — wrap bytes are written here, parsed via `oxc_parser`, then the
-  /// buffer is reset to match `origin_source_text`.
+  /// Template-side source used by the lexer and recursive-descent parser.
+  source_text: &'a str,
+
+  /// Mirror of the JSX crate's mutable buffer trick for `oxc_parser` calls:
+  /// wrap bytes are written here, parsed, then reset to match
+  /// `origin_source_text`.
   ///
   /// Spans on the resulting AST refer to original SFC offsets, not the
   /// rewritten buffer.
-  source_text: &'a str,
-  mut_ptr_source_text: *mut [u8],
+  oxc_source_text: &'b str,
+  mut_ptr_oxc_source_text: *mut [u8],
 
   source_type: SourceType,
   errors: Vec<OxcDiagnostic>,
   clean_spans: FxHashSet<Span>,
+  script_comments: ArenaVec<'a, Comment>,
+  script_tokens: ArenaVec<'b, Token>,
+  module_record: ModuleRecord<'b>,
+  script_lang: Option<&'a str>,
+  script_set: bool,
+  script_setup_set: bool,
 }
 
 impl<'a, 'b> VueParser<'a, 'b>
@@ -99,7 +106,8 @@ where
     options: ParseOptions,
     config: VueParseConfig,
   ) -> Self {
-    let alloced_str = allocator_a.alloc_slice_copy(source_text.as_bytes());
+    let alloced_str_a = allocator_a.alloc_slice_copy(source_text.as_bytes());
+    let alloced_str_b = allocator_b.alloc_slice_copy(source_text.as_bytes());
 
     Self {
       allocator_a,
@@ -108,13 +116,20 @@ where
       options,
       config,
 
-      mut_ptr_source_text: ptr::from_mut(alloced_str),
-      // SAFETY: `alloced_str` was just copied from a `&str`.
-      source_text: unsafe { str::from_utf8_unchecked(alloced_str) },
+      // SAFETY: both slices were copied from a `&str`.
+      source_text: unsafe { str::from_utf8_unchecked(alloced_str_a) },
+      mut_ptr_oxc_source_text: ptr::from_mut(alloced_str_b),
+      oxc_source_text: unsafe { str::from_utf8_unchecked(alloced_str_b) },
 
       source_type: SourceType::mjs().with_unambiguous(true),
       errors: Vec::new(),
       clean_spans: FxHashSet::default(),
+      script_comments: ArenaVec::new_in(allocator_a),
+      script_tokens: ArenaVec::new_in(allocator_b),
+      module_record: ModuleRecord::new(allocator_b),
+      script_lang: None,
+      script_set: false,
+      script_setup_set: false,
     }
   }
 
@@ -130,13 +145,13 @@ where
   /// Called after each in-place wrap-and-parse cycle (see the RFC's
   /// "Reusing the `oxc_parse` mutation trick" section).
   pub const fn sync_source_text(&mut self) {
-    // SAFETY: `self.origin_source_text` and `self.mut_ptr_source_text` have
+    // SAFETY: `self.origin_source_text` and `self.mut_ptr_oxc_source_text` have
     // identical lengths; the former lives on the heap and the latter in the
     // arena, so the regions cannot overlap.
     unsafe {
       ptr::copy_nonoverlapping(
         self.origin_source_text.as_ptr(),
-        self.mut_ptr_source_text.cast(),
+        self.mut_ptr_oxc_source_text.cast(),
         self.origin_source_text.len(),
       );
     }

--- a/crates/vue_oxlint_parser/src/parser/script.rs
+++ b/crates/vue_oxlint_parser/src/parser/script.rs
@@ -1,16 +1,393 @@
 //! `<script>` / `<script setup>` handling.
 //!
-//! Phase 3 will port the relevant utilities from `vue_oxlint_jsx`'s
-//! `parser::script` and `parser::modules`:
+//! Phase 3 ports the parser-side utilities from `vue_oxlint_jsx` that phase 4
+//! will need when the recursive-descent parser starts crossing script and
+//! directive boundaries:
 //!
-//! - resolving `lang="ts"` / `lang="tsx"` into a `SourceType`
-//! - guarding against multiple `<script>` / `<script setup>` blocks with
-//!   conflicting `SourceType`s
-//! - feeding script body slices into `oxc_parser` via the wrap-and-reset
-//!   trick
-//! - merging the resulting [`oxc_syntax::module_record::ModuleRecord`]s
-//! - relocating `oxc_ast::Comment`s onto
-//!   [`crate::ast::VueSingleFileComponent::script_comments`]
-//!
-//! Phase 4 will then call into these helpers as the recursive-descent parser
-//! crosses each `<script>` block.
+//! - source-type resolution from `lang=...`
+//! - duplicate `<script>` / `<script setup>` guards
+//! - in-place wrapped `oxc_parser` calls that preserve original-source spans
+//! - module-record aggregation
+//! - script-comment and token collection
+
+use oxc_allocator::{Allocator, CloneIn, Dummy, TakeIn, Vec as ArenaVec};
+use oxc_ast::{
+  Comment,
+  ast::{Directive, Expression, Program, Statement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_parser::{Parser, ParserReturn, config::RuntimeParserConfig};
+use oxc_span::{GetSpan, SPAN, SourceType, Span};
+use oxc_syntax::module_record::{
+  ExportEntry, ExportExportName, ExportImportName, ExportLocalName, ModuleRecord,
+};
+
+use super::VueParser;
+
+#[allow(dead_code, reason = "phase 4 will call this when it starts parsing <script> tags")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ScriptKind {
+  Script,
+  Setup,
+}
+
+impl ScriptKind {
+  const fn is_setup(self) -> bool {
+    matches!(self, Self::Setup)
+  }
+}
+
+#[allow(
+  dead_code,
+  reason = "phase 4 will use these module-record helpers while aggregating script blocks"
+)]
+pub(super) trait ModuleRecordExt {
+  fn merge_all(&mut self, instance: Self);
+  fn merge_imports(&mut self, instance: Self);
+  fn ensure_default_export(&mut self);
+}
+
+impl ModuleRecordExt for ModuleRecord<'_> {
+  fn merge_all(&mut self, mut instance: Self) {
+    self.has_module_syntax |= instance.has_module_syntax;
+    self.requested_modules.extend(instance.requested_modules);
+    self.import_entries.append(&mut instance.import_entries);
+    self.local_export_entries.append(&mut instance.local_export_entries);
+    self.indirect_export_entries.append(&mut instance.indirect_export_entries);
+    self.star_export_entries.append(&mut instance.star_export_entries);
+    self.exported_bindings.extend(instance.exported_bindings);
+    self.dynamic_imports.append(&mut instance.dynamic_imports);
+    self.import_metas.append(&mut instance.import_metas);
+  }
+
+  fn merge_imports(&mut self, mut instance: Self) {
+    self.has_module_syntax |= instance.has_module_syntax;
+    self.requested_modules.extend(instance.requested_modules);
+    self.import_entries.append(&mut instance.import_entries);
+    self.dynamic_imports.append(&mut instance.dynamic_imports);
+    self.import_metas.append(&mut instance.import_metas);
+  }
+
+  fn ensure_default_export(&mut self) {
+    self.has_module_syntax = true;
+
+    if !self.local_export_entries.iter().any(|entry| entry.export_name.is_default()) {
+      self.local_export_entries.push(ExportEntry {
+        span: SPAN,
+        statement_span: SPAN,
+        module_request: None,
+        import_name: ExportImportName::Null,
+        export_name: ExportExportName::Default(SPAN),
+        local_name: ExportLocalName::Null,
+        is_type: false,
+      });
+    }
+  }
+}
+
+#[allow(
+  dead_code,
+  reason = "phase 4 will call these wrapped oxc_parser helpers from the recursive-descent parser"
+)]
+impl<'a, 'b> VueParser<'a, 'b>
+where
+  'b: 'a,
+{
+  pub(super) fn parse_script_block(
+    &mut self,
+    span: Span,
+    lang: Option<&'a str>,
+    kind: ScriptKind,
+  ) -> Option<Program<'b>> {
+    self.resolve_script_lang(lang)?;
+
+    if span.source_text(self.source_text).trim().is_empty() {
+      return Some(Program::dummy(self.allocator_b));
+    }
+
+    self.register_script_block(kind, span)?;
+
+    let mut ret = self.parse_program_region(span, &[], &[], self.allocator_b)?;
+    self.collect_script_comments(&ret.program.comments);
+    self.script_tokens.append(&mut ret.tokens);
+    self.record_clean_spans(&ret.program.directives, &ret.program.body);
+
+    if kind.is_setup() {
+      self.module_record.merge_imports(ret.module_record);
+    } else {
+      self.module_record.merge_all(ret.module_record);
+    }
+
+    Some(ret.program)
+  }
+
+  pub(super) fn parse_pure_expression(
+    &mut self,
+    span: Span,
+    allocator: &'b Allocator,
+  ) -> Option<Expression<'b>> {
+    self.parse_expression_region(span, b"(", b")", allocator)
+  }
+
+  pub(super) fn parse_expression_region(
+    &mut self,
+    span: Span,
+    start_wrap: &[u8],
+    end_wrap: &[u8],
+    allocator: &'b Allocator,
+  ) -> Option<Expression<'b>> {
+    let mut ret = self.parse_program_region(span, start_wrap, end_wrap, allocator)?;
+    self.collect_script_comments(&ret.program.comments);
+
+    let stmt = ret.program.body.get_mut(0)?;
+    let Statement::ExpressionStatement(stmt) = stmt else {
+      unreachable!("wrapped expression regions always parse as an expression statement");
+    };
+    let Expression::ParenthesizedExpression(expr) = &mut stmt.expression else {
+      unreachable!("wrapped expression regions always retain their outer parentheses");
+    };
+    Some(expr.expression.take_in(allocator))
+  }
+
+  pub(super) fn resolve_script_lang(&mut self, lang: Option<&'a str>) -> Option<SourceType> {
+    let lang = lang.unwrap_or("js");
+
+    if let Some(prev) = self.script_lang {
+      if prev != lang {
+        self.errors.push(OxcDiagnostic::error(
+          "<script> and <script setup> must have the same language type.",
+        ));
+        return None;
+      }
+    } else {
+      self.script_lang = Some(lang);
+    }
+
+    let Ok(source_type) = SourceType::from_extension(lang) else {
+      self
+        .errors
+        .push(OxcDiagnostic::error(format!("Unsupported lang {lang} in <script> blocks.")));
+      return None;
+    };
+
+    self.source_type = source_type;
+    Some(source_type)
+  }
+
+  pub(super) fn register_script_block(&mut self, kind: ScriptKind, span: Span) -> Option<()> {
+    let already_set = match kind {
+      ScriptKind::Script => &mut self.script_set,
+      ScriptKind::Setup => &mut self.script_setup_set,
+    };
+
+    if *already_set {
+      let message = match kind {
+        ScriptKind::Script => "Single file component can contain only one <script> element.",
+        ScriptKind::Setup => "Single file component can contain only one <script setup> element.",
+      };
+      self.errors.push(OxcDiagnostic::error(message).with_label(span));
+      return None;
+    }
+
+    *already_set = true;
+    Some(())
+  }
+
+  pub(super) fn parse_program_region(
+    &mut self,
+    span: Span,
+    start_wrap: &[u8],
+    end_wrap: &[u8],
+    allocator: &'b Allocator,
+  ) -> Option<ParserReturn<'b>> {
+    let start = span.start as usize;
+    let end = span.end as usize;
+    let source_len = self.oxc_source_text.len();
+
+    if start < start_wrap.len() || end + end_wrap.len() > source_len {
+      self.errors.push(
+        OxcDiagnostic::error("wrapped parser region does not fit inside the SFC source")
+          .with_label(span),
+      );
+      return None;
+    }
+
+    // SAFETY: the parser only mutates bytes outside `span`, and resets the
+    // scratch buffer before returning.
+    unsafe {
+      let real_start = start - start_wrap.len();
+      let first_byte_ptr = self.mut_ptr_oxc_source_text.cast::<u8>();
+
+      std::ptr::copy_nonoverlapping(
+        start_wrap.as_ptr(),
+        first_byte_ptr.add(real_start),
+        start_wrap.len(),
+      );
+      std::ptr::copy_nonoverlapping(end_wrap.as_ptr(), first_byte_ptr.add(end), end_wrap.len());
+
+      for i in 0..real_start {
+        first_byte_ptr.add(i).write(b' ');
+      }
+    }
+
+    // SAFETY: the scratch buffer was copied from a valid UTF-8 source and the
+    // wrapper bytes are ASCII.
+    let result = self.call_oxc_parse(
+      unsafe { str::from_utf8_unchecked(&self.oxc_source_text.as_bytes()[..end + end_wrap.len()]) },
+      allocator,
+    );
+
+    self.sync_source_text();
+    result
+  }
+
+  fn call_oxc_parse(
+    &mut self,
+    source: &'b str,
+    allocator: &'b Allocator,
+  ) -> Option<ParserReturn<'b>> {
+    let mut ret = Parser::new(allocator, source, self.source_type)
+      .with_options(self.options)
+      .with_config(RuntimeParserConfig::new(true))
+      .parse();
+
+    self.errors.append(&mut ret.errors);
+    if ret.panicked { None } else { Some(ret) }
+  }
+
+  fn collect_script_comments(&mut self, comments: &ArenaVec<'b, Comment>) {
+    let mut comments = comments.clone_in(self.allocator_a);
+    self.script_comments.append(&mut comments);
+  }
+
+  fn record_clean_spans(
+    &mut self,
+    directives: &ArenaVec<'b, Directive<'b>>,
+    statements: &ArenaVec<'b, Statement<'b>>,
+  ) {
+    if !self.config.track_clean_spans {
+      return;
+    }
+
+    for directive in directives {
+      self.clean_spans.insert(directive.span());
+    }
+    for statement in statements {
+      self.clean_spans.insert(statement.span());
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use oxc_allocator::Allocator;
+  use oxc_ast::ast::Expression;
+  use oxc_parser::ParseOptions;
+  use oxc_span::{GetSpan, Span};
+
+  use super::{ModuleRecordExt, ScriptKind, VueParser};
+  use crate::parser::VueParseConfig;
+
+  fn make_parser<'a>(
+    allocator_a: &'a Allocator,
+    allocator_b: &'a Allocator,
+    source: &'a str,
+  ) -> VueParser<'a, 'a> {
+    VueParser::new(
+      allocator_a,
+      allocator_b,
+      source,
+      ParseOptions::default(),
+      VueParseConfig { track_clean_spans: true },
+    )
+  }
+
+  #[test]
+  fn parse_script_block_collects_side_channels() {
+    let allocator_a = Allocator::new();
+    let allocator_b = Allocator::new();
+    let source = "/* before */ import foo from 'foo';\nconst answer = 42;";
+    let span = Span::new(0, source.len() as u32);
+    let mut parser = make_parser(&allocator_a, &allocator_b, source);
+
+    let program = parser
+      .parse_script_block(span, Some("ts"), ScriptKind::Script)
+      .expect("script block should parse");
+
+    assert_eq!(program.body.len(), 2);
+    assert!(parser.source_type.is_typescript());
+    assert!(program.source_type.is_typescript());
+    assert!(program.source_type.is_module());
+    assert_eq!(parser.script_comments.len(), 1);
+    assert!(!parser.script_tokens.is_empty());
+    assert_eq!(parser.module_record.import_entries.len(), 1);
+    assert_eq!(parser.clean_spans.len(), 2);
+    assert!(parser.errors.is_empty());
+  }
+
+  #[test]
+  fn parse_setup_script_only_merges_import_side_effects() {
+    let allocator_a = Allocator::new();
+    let allocator_b = Allocator::new();
+    let source = "import foo from 'foo'; export const answer = 42; import.meta; import('bar');";
+    let span = Span::new(0, source.len() as u32);
+    let mut parser = make_parser(&allocator_a, &allocator_b, source);
+
+    let _ =
+      parser.parse_script_block(span, None, ScriptKind::Setup).expect("setup script should parse");
+
+    assert_eq!(parser.module_record.import_entries.len(), 1);
+    assert_eq!(parser.module_record.dynamic_imports.len(), 1);
+    assert_eq!(parser.module_record.import_metas.len(), 1);
+    assert!(parser.module_record.local_export_entries.is_empty());
+  }
+
+  #[test]
+  fn parse_expression_region_preserves_original_span() {
+    let allocator_a = Allocator::new();
+    let allocator_b = Allocator::new();
+    let source = "{{ foo + bar }}";
+    let span = Span::new(3, 12);
+    let mut parser = make_parser(&allocator_a, &allocator_b, source);
+
+    let expr = parser.parse_pure_expression(span, &allocator_b).expect("expression should parse");
+
+    assert!(matches!(expr, Expression::BinaryExpression(_)));
+    assert_eq!(expr.span(), span);
+  }
+
+  #[test]
+  fn conflicting_script_langs_report_an_error() {
+    let allocator_a = Allocator::new();
+    let allocator_b = Allocator::new();
+    let mut parser = make_parser(&allocator_a, &allocator_b, "");
+
+    assert!(parser.resolve_script_lang(Some("ts")).is_some());
+    assert!(parser.resolve_script_lang(None).is_none());
+    assert_eq!(parser.errors.len(), 1);
+  }
+
+  #[test]
+  fn duplicate_script_kinds_report_an_error() {
+    let allocator_a = Allocator::new();
+    let allocator_b = Allocator::new();
+    let mut parser = make_parser(&allocator_a, &allocator_b, "");
+    let span = Span::new(1, 2);
+
+    assert!(parser.register_script_block(ScriptKind::Script, span).is_some());
+    assert!(parser.register_script_block(ScriptKind::Script, span).is_none());
+    assert_eq!(parser.errors.len(), 1);
+  }
+
+  #[test]
+  fn ensure_default_export_adds_only_one_entry() {
+    let allocator = Allocator::new();
+    let mut module_record = oxc_syntax::module_record::ModuleRecord::new(&allocator);
+
+    module_record.ensure_default_export();
+    module_record.ensure_default_export();
+
+    assert_eq!(module_record.local_export_entries.len(), 1);
+    assert!(module_record.local_export_entries[0].export_name.is_default());
+  }
+}


### PR DESCRIPTION
## What changed

This implements phase 3 of `rfcs/vue-oxlint-parser.md` inside `crates/vue_oxlint_parser`.

The parser crate now has script-side helpers for:
- resolving and validating `<script>` / `<script setup>` `lang` handling into `SourceType`
- guarding duplicate script block kinds
- running wrapped `oxc_parser` parses against a dedicated `'b`-lifetime source buffer
- collecting script comments and tokens
- aggregating module records, including setup-only import merging
- recording `clean_spans` for script directives and statements

It also adds focused unit coverage around those helpers and updates `AGENTS.md` to reflect the parser crate's current structure.

## Why

Phase 4 needs these utilities in place before the recursive-descent template parser can attach embedded JS regions and script blocks without reintroducing the ad-hoc logic that currently lives in `vue_oxlint_jsx`.

The key design point here is moving the wrap-and-reset `oxc_parser` path into the new parser crate while preserving original SFC spans and the two-allocator model described in the RFC.

## Impact

`vue_oxlint_parser` now owns the parser-side script infrastructure that later phases will call directly.

No public parsing behavior changes yet: `VueParser::parse()` is still the phase-4 stub, but the supporting internals and tests for script/embedded-JS parsing are now in place.

## Validation

- `just lint`
- `just test`
- `just ready`